### PR TITLE
3D "Ride the Route" mode (Three.js + MapLibre)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,8 @@ env/
 # Logs
 *.log
 
+# Crash dumps (e.g. Cygwin/MSYS bash on Windows)
+*.stackdump
+
 # Local development settings
 instance/

--- a/app.py
+++ b/app.py
@@ -1,5 +1,13 @@
-from flask import Flask, render_template, send_from_directory, json
+from flask import Flask, render_template, send_from_directory, jsonify, json
 import os
+import xml.etree.ElementTree as ET
+
+# Prefer defusedxml to guard against XXE / entity-expansion attacks; fall back
+# to the stdlib parser (our KML files are trusted, shipped-in-repo assets).
+try:
+    from defusedxml.ElementTree import parse as _xml_parse
+except ImportError:
+    _xml_parse = ET.parse
 
 app = Flask(
     __name__,
@@ -8,9 +16,107 @@ app = Flask(
 )
 
 
+def _find_kml(filename):
+    """Locate a KML file: static/data/kml first, then top-level data/kml."""
+    # Reject path traversal / absolute paths — only serve plain KML filenames.
+    if os.path.isabs(filename) or ".." in filename.replace("\\", "/").split("/"):
+        return None
+
+    static_kml = os.path.join(app.static_folder, "data", "kml", filename)
+    if os.path.exists(static_kml):
+        return static_kml
+
+    data_kml = os.path.join("data", "kml", filename)
+    if os.path.exists(data_kml):
+        return data_kml
+
+    return None
+
+
+def _localname(tag):
+    """Strip the XML namespace from a tag, e.g. '{ns}LineString' -> 'LineString'."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _parse_coords(text):
+    """Parse a KML <coordinates> blob ('lon,lat[,alt] lon,lat[,alt] ...')."""
+    points = []
+    for token in text.split():
+        parts = token.split(",")
+        if len(parts) < 2:
+            continue
+        try:
+            lon = float(parts[0])
+            lat = float(parts[1])
+        except ValueError:
+            continue
+        points.append([lon, lat])
+    return points
+
+
+def parse_route_geometry(path):
+    """Extract drive-path LineStrings and named stop Points from a KML file."""
+    root = _xml_parse(path).getroot()
+    segments = []
+    stops = []
+
+    for elem in root.iter():
+        name = _localname(elem.tag)
+
+        if name == "LineString":
+            for child in elem:
+                if _localname(child.tag) == "coordinates" and child.text:
+                    pts = _parse_coords(child.text)
+                    if len(pts) >= 2:
+                        segments.append(pts)
+
+        elif name == "Placemark":
+            stop_name = None
+            point = None
+            for child in elem.iter():
+                cname = _localname(child.tag)
+                if cname == "name" and child.text and stop_name is None:
+                    stop_name = child.text.strip()
+                elif cname == "Point":
+                    for pc in child:
+                        if _localname(pc.tag) == "coordinates" and pc.text:
+                            coords = _parse_coords(pc.text)
+                            if coords:
+                                point = coords[0]
+            if point:
+                stops.append({"name": stop_name or "", "lon": point[0], "lat": point[1]})
+
+    # Bounds across all path vertices (fall back to stops if no segments).
+    all_points = [pt for seg in segments for pt in seg]
+    if not all_points:
+        all_points = [[s["lon"], s["lat"]] for s in stops]
+    bounds = None
+    if all_points:
+        lons = [p[0] for p in all_points]
+        lats = [p[1] for p in all_points]
+        bounds = {
+            "minLon": min(lons),
+            "minLat": min(lats),
+            "maxLon": max(lons),
+            "maxLat": max(lats),
+        }
+
+    return {"segments": segments, "stops": stops, "bounds": bounds}
+
+
 @app.route("/")
 def index():
     return render_template("index.html")
+
+
+@app.route("/ride/three")
+def ride_three():
+    return render_template("ride_three.html")
+
+
+@app.route("/ride/maplibre")
+def ride_maplibre():
+    return render_template("ride_maplibre.html")
 
 
 @app.route("/data/routes.json")
@@ -21,18 +127,25 @@ def get_routes():
         return json.load(f)
 
 
+@app.route("/data/route-geometry/<path:filename>")
+def route_geometry(filename):
+    # Parse a route's KML into JSON (drive segments, named stops, bounds).
+    path = _find_kml(filename)
+    if not path:
+        return jsonify({"error": "Route not found"}), 404
+    try:
+        data = parse_route_geometry(path)
+    except ET.ParseError as e:
+        return jsonify({"error": f"Failed to parse KML: {e}"}), 500
+    data["name"] = os.path.splitext(os.path.basename(filename))[0]
+    return jsonify(data)
+
+
 @app.route("/data/kml/<path:filename>")
 def serve_kml(filename):
-    # First try the static folder
-    static_kml_path = os.path.join(app.static_folder, "data", "kml")
-    if os.path.exists(os.path.join(static_kml_path, filename)):
-        return send_from_directory(static_kml_path, filename)
-
-    # If not found in static, try the data folder
-    data_kml_path = os.path.join("data", "kml")
-    if os.path.exists(os.path.join(data_kml_path, filename)):
-        return send_from_directory(data_kml_path, filename)
-
+    path = _find_kml(filename)
+    if path:
+        return send_from_directory(os.path.dirname(path), os.path.basename(path))
     return "KML file not found", 404
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask==3.1.3
+defusedxml==0.7.1

--- a/static/css/ride.css
+++ b/static/css/ride.css
@@ -1,0 +1,191 @@
+/* Shared HUD / overlay styling for the 3D ride-along pages. */
+html,
+body {
+  margin: 0;
+  height: 100%;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #87ceeb;
+}
+
+#scene,
+#map {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* Top bar: route name + engine badge + exit */
+#ride-topbar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  color: #fff;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), rgba(0, 0, 0, 0));
+  z-index: 10;
+  pointer-events: none;
+}
+
+#ride-topbar .route-title {
+  font-size: 18px;
+  font-weight: 600;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+
+#ride-topbar .engine-badge {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 3px 8px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+#ride-topbar .spacer {
+  flex: 1 1 auto;
+}
+
+#exit {
+  pointer-events: auto;
+  text-decoration: none;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+}
+#exit:hover {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+/* Minimap overlay (top-right) */
+#minimap {
+  position: absolute;
+  top: 56px;
+  right: 12px;
+  width: 180px;
+  height: 180px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 10px;
+  box-shadow: 0 3px 14px rgba(0, 0, 0, 0.32);
+  z-index: 10;
+  overflow: hidden;
+}
+#minimap svg {
+  display: block;
+}
+@media (max-width: 600px) {
+  #minimap {
+    width: 120px;
+    height: 120px;
+  }
+}
+
+/* Approaching-stop banner */
+#stop-banner {
+  position: absolute;
+  top: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 6px 16px;
+  border-radius: 16px;
+  font-size: 14px;
+  z-index: 10;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+  white-space: nowrap;
+}
+#stop-banner.show {
+  opacity: 1;
+}
+
+/* Bottom control bar */
+#ride-controls {
+  position: absolute;
+  left: 50%;
+  bottom: 18px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 16px;
+  background: rgba(20, 20, 24, 0.78);
+  border-radius: 12px;
+  color: #fff;
+  z-index: 10;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+  max-width: 92vw;
+}
+
+#ride-controls button {
+  background: #fff;
+  color: #111;
+  border: none;
+  border-radius: 8px;
+  width: 44px;
+  height: 36px;
+  font-size: 16px;
+  cursor: pointer;
+}
+#ride-controls button:active {
+  transform: scale(0.96);
+}
+
+#ride-controls .speed {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+#progress-wrap {
+  width: 34vw;
+  min-width: 120px;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 3px;
+  overflow: hidden;
+}
+#progress-bar {
+  height: 100%;
+  width: 0;
+  background: #4ade80;
+}
+
+/* Loading / error splash */
+#ride-status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 10px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 20;
+  text-align: center;
+  padding: 20px;
+}
+#ride-status.hidden {
+  display: none;
+}
+#ride-status .sub {
+  font-size: 13px;
+  opacity: 0.8;
+}
+#ride-status a {
+  color: #93c5fd;
+}

--- a/static/css/ride.css
+++ b/static/css/ride.css
@@ -65,10 +65,10 @@ body {
   background: rgba(0, 0, 0, 0.7);
 }
 
-/* Minimap overlay (top-right) */
+/* Minimap overlay (bottom-right, above the control bar) */
 #minimap {
   position: absolute;
-  top: 56px;
+  bottom: 72px;
   right: 12px;
   width: 180px;
   height: 180px;
@@ -79,8 +79,41 @@ body {
   z-index: 10;
   overflow: hidden;
 }
+#minimap.hidden {
+  display: none;
+}
 #minimap svg {
   display: block;
+}
+
+/* Minimap zoom buttons (top-left of the minimap) */
+.minimap-zoom {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  z-index: 2;
+}
+.minimap-zoom button {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #111;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+}
+.minimap-zoom button:active {
+  transform: scale(0.94);
+}
+.minimap-zoom-reset.hidden {
+  display: none;
 }
 @media (max-width: 600px) {
   #minimap {
@@ -142,6 +175,20 @@ body {
   transform: scale(0.96);
 }
 
+/* Labeled toggles (auto width) with a dimmed "off" state */
+#ride-controls .toggle-btn {
+  width: auto;
+  padding: 0 12px;
+  font-size: 13px;
+  white-space: nowrap;
+  background: rgba(255, 255, 255, 0.28);
+  color: #fff;
+}
+#ride-controls .toggle-btn.active {
+  background: #ffd166;
+  color: #111;
+}
+
 #ride-controls .speed {
   display: flex;
   align-items: center;
@@ -151,17 +198,35 @@ body {
 }
 
 #progress-wrap {
+  position: relative;
   width: 34vw;
   min-width: 120px;
-  height: 6px;
+  height: 8px;
   background: rgba(255, 255, 255, 0.25);
-  border-radius: 3px;
-  overflow: hidden;
+  border-radius: 4px;
+  cursor: pointer;
+  touch-action: none; /* let us handle drag without the browser scrolling */
 }
 #progress-bar {
   height: 100%;
   width: 0;
   background: #4ade80;
+  border-radius: 4px;
+  position: relative;
+  pointer-events: none; /* clicks/drag go to the wrap, not the fill */
+}
+/* Draggable thumb at the playhead */
+#progress-bar::after {
+  content: "";
+  position: absolute;
+  right: -6px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
 }
 
 /* Loading / error splash */

--- a/static/js/ride/launcher.js
+++ b/static/js/ride/launcher.js
@@ -1,0 +1,32 @@
+// Launcher for the 3D ride-along modes. Populates the route chooser (numbered
+// routes only for v1) and opens the selected route in either engine.
+window.APP = window.APP || {};
+
+$(document).ready(function () {
+  const select = $("#rideRouteSelect");
+
+  fetch("/data/routes.json")
+    .then((r) => r.json())
+    .then((routes) => {
+      routes
+        .filter((f) => /^\d/.test(f)) // numbered routes have clean single paths
+        .forEach((f) => {
+          select.append(
+            $("<option></option>").val(f).text(f.replace(".kml", ""))
+          );
+        });
+    })
+    .catch((error) => APP.MapUtils.handleError(error, "Loading ride routes"));
+
+  function launch(engine) {
+    const route = select.val();
+    if (!route) return;
+    window.open(
+      `/ride/${engine}?route=${encodeURIComponent(route)}`,
+      "_blank"
+    );
+  }
+
+  $("#rideThreeBtn").click(() => launch("three"));
+  $("#rideMaplibreBtn").click(() => launch("maplibre"));
+});

--- a/static/js/ride/launcher.js
+++ b/static/js/ride/launcher.js
@@ -21,10 +21,8 @@ $(document).ready(function () {
   function launch(engine) {
     const route = select.val();
     if (!route) return;
-    window.open(
-      `/ride/${engine}?route=${encodeURIComponent(route)}`,
-      "_blank"
-    );
+    // Navigate in the same tab; each ride page has an "✕ Exit" link back to "/".
+    window.location.href = `/ride/${engine}?route=${encodeURIComponent(route)}`;
   }
 
   $("#rideThreeBtn").click(() => launch("three"));

--- a/static/js/ride/maplibre-ride.js
+++ b/static/js/ride/maplibre-ride.js
@@ -13,6 +13,10 @@
     speed: document.getElementById("speed"),
     speedVal: document.getElementById("speed-val"),
     progress: document.getElementById("progress-bar"),
+    progressWrap: document.getElementById("progress-wrap"),
+    toggleStops: document.getElementById("toggle-stops"),
+    toggleMinimap: document.getElementById("toggle-minimap"),
+    minimap: document.getElementById("minimap"),
   };
 
   function showError(msg) {
@@ -108,9 +112,21 @@
     const baseSpeed = total / TARGET_DURATION; // km/s
     let traveled = 0;
     let playing = true;
-    let speedMul = 1;
+    let speedMul = 0.1;
     let lastStop = null;
     let lastTs = null;
+    let scrubbing = false;
+    let stopsVisible = true;
+
+    // Stop markers as a GeoJSON point layer (matches the Three.js yellow pucks).
+    const stopsFC = {
+      type: "FeatureCollection",
+      features: geo.stops.map((s) => ({
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [s.lon, s.lat] },
+        properties: { name: s.name || "" },
+      })),
+    };
 
     function sampleHeading(dist) {
       const back = turf.along(line, Math.max(dist - 0.012, 0));
@@ -119,6 +135,7 @@
     }
 
     function updateStopBanner(busCoord) {
+      if (!stopsVisible) return;
       let nearest = null;
       let best = 0.07; // km (~70 m)
       for (const s of geo.stops) {
@@ -156,6 +173,19 @@
         paint: { "line-color": color, "line-width": 5 },
         layout: { "line-cap": "round", "line-join": "round" },
       });
+      map.addSource("stops", { type: "geojson", data: stopsFC });
+      map.addLayer({
+        id: "stops",
+        type: "circle",
+        source: "stops",
+        layout: { visibility: stopsVisible ? "visible" : "none" },
+        paint: {
+          "circle-radius": 5,
+          "circle-color": "#ffd166",
+          "circle-stroke-color": "#7a5b00",
+          "circle-stroke-width": 1.5,
+        },
+      });
     }
 
     function frame(ts) {
@@ -163,7 +193,7 @@
       const dt = lastTs == null ? 0 : Math.min((ts - lastTs) / 1000, 0.1);
       lastTs = ts;
 
-      if (playing && traveled < total) {
+      if (playing && !scrubbing && traveled < total) {
         traveled = Math.min(traveled + baseSpeed * speedMul * dt, total);
         if (traveled >= total) {
           playing = false;
@@ -226,6 +256,59 @@
       speedMul = parseFloat(els.speed.value);
       els.speedVal.textContent = `${speedMul}×`;
     });
+    els.toggleStops.addEventListener("click", () => {
+      stopsVisible = !stopsVisible;
+      if (map.getLayer("stops")) {
+        map.setLayoutProperty(
+          "stops",
+          "visibility",
+          stopsVisible ? "visible" : "none"
+        );
+      }
+      els.toggleStops.classList.toggle("active", stopsVisible);
+      els.toggleStops.setAttribute("aria-pressed", String(stopsVisible));
+      if (!stopsVisible) {
+        lastStop = null;
+        els.banner.classList.remove("show");
+      }
+    });
+    els.toggleMinimap.addEventListener("click", () => {
+      const visible = els.minimap.classList.toggle("hidden") === false;
+      els.toggleMinimap.classList.toggle("active", visible);
+      els.toggleMinimap.setAttribute("aria-pressed", String(visible));
+    });
+
+    // Scrub: click or drag along the progress bar to jump anywhere in the ride.
+    // The frame loop reads `traveled` every tick, so the bus/camera/minimap
+    // follow the new position on the next frame.
+    function scrubTo(clientX) {
+      const rect = els.progressWrap.getBoundingClientRect();
+      const f = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width));
+      traveled = f * total;
+      els.progress.style.width = `${(f * 100).toFixed(1)}%`;
+      if (traveled < total) {
+        els.playpause.textContent = playing ? "⏸" : "▶";
+      }
+    }
+    els.progressWrap.addEventListener("pointerdown", (e) => {
+      scrubbing = true;
+      els.progressWrap.setPointerCapture(e.pointerId);
+      scrubTo(e.clientX);
+    });
+    els.progressWrap.addEventListener("pointermove", (e) => {
+      if (scrubbing) scrubTo(e.clientX);
+    });
+    const endScrub = (e) => {
+      if (!scrubbing) return;
+      scrubbing = false;
+      try {
+        els.progressWrap.releasePointerCapture(e.pointerId);
+      } catch (_) {
+        /* pointer already released */
+      }
+    };
+    els.progressWrap.addEventListener("pointerup", endScrub);
+    els.progressWrap.addEventListener("pointercancel", endScrub);
   }
 
   main();

--- a/static/js/ride/maplibre-ride.js
+++ b/static/js/ride/maplibre-ride.js
@@ -1,0 +1,232 @@
+// MapLibre "ride the route" — a real OSM map laid on the ground, tilted, with
+// the camera chasing a bus marker along the route. Companion to three-ride.js
+// for an apples-to-apples comparison of the two engines.
+(function () {
+  const RP = APP.RidePath;
+
+  const els = {
+    title: document.getElementById("route-title"),
+    status: document.getElementById("ride-status"),
+    statusSub: document.getElementById("ride-status-sub"),
+    banner: document.getElementById("stop-banner"),
+    playpause: document.getElementById("playpause"),
+    speed: document.getElementById("speed"),
+    speedVal: document.getElementById("speed-val"),
+    progress: document.getElementById("progress-bar"),
+  };
+
+  function showError(msg) {
+    els.status.classList.remove("hidden");
+    els.status.innerHTML =
+      `<div>${msg}</div><div class="sub"><a href="/">← Back to the map</a></div>`;
+  }
+
+  // Keyless raster style: OpenStreetMap tiles ARE the ground.
+  const OSM_STYLE = {
+    version: 8,
+    sources: {
+      osm: {
+        type: "raster",
+        tiles: [
+          "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+          "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+          "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        ],
+        tileSize: 256,
+        attribution: "© OpenStreetMap contributors",
+      },
+    },
+    layers: [{ id: "osm", type: "raster", source: "osm" }],
+  };
+
+  async function main() {
+    const routeFile = RP.routeFromQuery();
+    if (!routeFile) {
+      showError("No route selected.");
+      return;
+    }
+
+    let geo;
+    try {
+      geo = await RP.fetchGeometry(routeFile);
+    } catch (e) {
+      showError("Could not load this route.");
+      return;
+    }
+    const drivePath = RP.pickDrivePath(geo.segments);
+    if (drivePath.length < 2) {
+      showError("This route has no drivable path yet.");
+      return;
+    }
+
+    const routeName = geo.name || routeFile.replace(".kml", "");
+    els.title.textContent = routeName;
+    document.title = `3D Ride · ${routeName}`;
+    const color = RP.colorFor(routeFile);
+
+    const line = turf.lineString(drivePath);
+    const total = turf.length(line); // km
+    const start = drivePath[0];
+
+    const bounds =
+      geo.bounds ||
+      drivePath.reduce(
+        (b, [lon, lat]) => ({
+          minLon: Math.min(b.minLon, lon),
+          maxLon: Math.max(b.maxLon, lon),
+          minLat: Math.min(b.minLat, lat),
+          maxLat: Math.max(b.maxLat, lat),
+        }),
+        { minLon: 180, maxLon: -180, minLat: 90, maxLat: -90 }
+      );
+    const minimap = new APP.Minimap(
+      document.getElementById("minimap"),
+      drivePath,
+      bounds,
+      color
+    );
+
+    const map = new maplibregl.Map({
+      container: "map",
+      style: OSM_STYLE,
+      center: start,
+      zoom: 17,
+      pitch: 68,
+      bearing: 0,
+      interactive: false, // on-rails: the user doesn't control the view
+      attributionControl: { compact: true },
+    });
+
+    // Bus marker (top-down; map rotates so travel direction points up)
+    const busEl = document.createElement("div");
+    busEl.className = "bus-marker";
+    busEl.style.background = color;
+    const busMarker = new maplibregl.Marker({ element: busEl }).setLngLat(start);
+
+    // Ride state
+    const TARGET_DURATION = 80; // seconds at 1x
+    const baseSpeed = total / TARGET_DURATION; // km/s
+    let traveled = 0;
+    let playing = true;
+    let speedMul = 1;
+    let lastStop = null;
+    let lastTs = null;
+
+    function sampleHeading(dist) {
+      const back = turf.along(line, Math.max(dist - 0.012, 0));
+      const fwd = turf.along(line, Math.min(dist + 0.012, total));
+      return turf.bearing(back, fwd);
+    }
+
+    function updateStopBanner(busCoord) {
+      let nearest = null;
+      let best = 0.07; // km (~70 m)
+      for (const s of geo.stops) {
+        if (!s.name) continue;
+        const d = turf.distance(busCoord, [s.lon, s.lat]);
+        if (d < best) {
+          best = d;
+          nearest = s;
+        }
+      }
+      if (nearest && nearest !== lastStop) {
+        lastStop = nearest;
+        els.banner.textContent = `🚏 ${nearest.name}`;
+        els.banner.classList.add("show");
+      } else if (!nearest) {
+        lastStop = null;
+        els.banner.classList.remove("show");
+      }
+    }
+
+    function addRouteLayers() {
+      if (map.getSource("route")) return;
+      map.addSource("route", { type: "geojson", data: line });
+      map.addLayer({
+        id: "route-casing",
+        type: "line",
+        source: "route",
+        paint: { "line-color": "#ffffff", "line-width": 9, "line-opacity": 0.7 },
+        layout: { "line-cap": "round", "line-join": "round" },
+      });
+      map.addLayer({
+        id: "route-line",
+        type: "line",
+        source: "route",
+        paint: { "line-color": color, "line-width": 5 },
+        layout: { "line-cap": "round", "line-join": "round" },
+      });
+    }
+
+    function frame(ts) {
+      requestAnimationFrame(frame);
+      const dt = lastTs == null ? 0 : Math.min((ts - lastTs) / 1000, 0.1);
+      lastTs = ts;
+
+      if (playing && traveled < total) {
+        traveled = Math.min(traveled + baseSpeed * speedMul * dt, total);
+        if (traveled >= total) {
+          playing = false;
+          els.playpause.textContent = "↻";
+        }
+      }
+
+      const busPt = turf.along(line, Math.min(traveled, total));
+      const camPt = turf.along(line, Math.min(traveled + 0.04, total));
+      const heading = sampleHeading(traveled);
+      const busCoord = busPt.geometry.coordinates;
+
+      busMarker.setLngLat(busCoord);
+      map.jumpTo({
+        center: camPt.geometry.coordinates,
+        bearing: heading,
+        pitch: 68,
+        zoom: 17,
+      });
+
+      updateStopBanner(busCoord);
+      minimap.update(busCoord);
+      els.progress.style.width = `${((traveled / total) * 100).toFixed(1)}%`;
+    }
+
+    // Start the ride on style-load, or after a short fallback so slow tiles
+    // never leave the user stuck on "Preparing…".
+    let started = false;
+    function startRide() {
+      if (started) return;
+      started = true;
+      busMarker.addTo(map);
+      els.status.classList.add("hidden");
+      requestAnimationFrame(frame);
+    }
+    map.on("load", () => {
+      addRouteLayers();
+      startRide();
+    });
+    setTimeout(startRide, 6000);
+
+    map.on("error", (e) => {
+      // tile errors are non-fatal; only surface a hard style failure
+      if (e && e.error && /style/i.test(e.error.message || "")) {
+        showError("Map failed to load.");
+      }
+    });
+
+    // Controls
+    els.playpause.addEventListener("click", () => {
+      if (traveled >= total) {
+        traveled = 0;
+        playing = true;
+      } else {
+        playing = !playing;
+      }
+      els.playpause.textContent = playing ? "⏸" : "▶";
+    });
+    els.speed.addEventListener("input", () => {
+      speedMul = parseFloat(els.speed.value);
+      els.speedVal.textContent = `${speedMul}×`;
+    });
+  }
+
+  main();
+})();

--- a/static/js/ride/minimap.js
+++ b/static/js/ride/minimap.js
@@ -1,0 +1,110 @@
+// Shared minimap overlay for both ride modes: a small north-up SVG map of the
+// full route with a heading arrow marking the bus. No mapping library — pure
+// SVG so it works identically in the Three.js and MapLibre rides.
+window.APP = window.APP || {};
+
+APP.Minimap = class {
+  /**
+   * @param {HTMLElement} container - element to render into
+   * @param {number[][]} drivePath - [[lon,lat], ...]
+   * @param {object} bounds - {minLon, minLat, maxLon, maxLat}
+   * @param {string} color - route color
+   */
+  constructor(container, drivePath, bounds, color) {
+    const W = 180;
+    const H = 180;
+    const pad = 12;
+    const centerLat = (bounds.minLat + bounds.maxLat) / 2;
+    const cosLat = Math.cos((centerLat * Math.PI) / 180);
+    const lonRange = bounds.maxLon - bounds.minLon || 1e-6;
+    const latRange = bounds.maxLat - bounds.minLat || 1e-6;
+    const scale = Math.min(
+      (W - 2 * pad) / (lonRange * cosLat),
+      (H - 2 * pad) / latRange
+    );
+    const offX = (W - lonRange * cosLat * scale) / 2;
+    const offY = (H - latRange * scale) / 2;
+
+    this.cosLat = cosLat;
+    this.heading = 0;
+    this.lastLonLat = null;
+    this.project = (lon, lat) => ({
+      x: offX + (lon - bounds.minLon) * cosLat * scale,
+      y: offY + (bounds.maxLat - lat) * scale, // north up
+    });
+
+    const NS = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(NS, "svg");
+    svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
+    svg.setAttribute("width", "100%");
+    svg.setAttribute("height", "100%");
+
+    const route = document.createElementNS(NS, "polyline");
+    route.setAttribute(
+      "points",
+      drivePath
+        .map(([lon, lat]) => {
+          const p = this.project(lon, lat);
+          return `${p.x.toFixed(1)},${p.y.toFixed(1)}`;
+        })
+        .join(" ")
+    );
+    route.setAttribute("fill", "none");
+    route.setAttribute("stroke", color);
+    route.setAttribute("stroke-width", "2.5");
+    route.setAttribute("stroke-linejoin", "round");
+    route.setAttribute("stroke-linecap", "round");
+    svg.appendChild(route);
+
+    const startP = this.project(drivePath[0][0], drivePath[0][1]);
+    const startDot = document.createElementNS(NS, "circle");
+    startDot.setAttribute("cx", startP.x);
+    startDot.setAttribute("cy", startP.y);
+    startDot.setAttribute("r", "3");
+    startDot.setAttribute("fill", "#fff");
+    startDot.setAttribute("stroke", color);
+    startDot.setAttribute("stroke-width", "1.5");
+    svg.appendChild(startDot);
+
+    // Bus heading arrow (points "up" = north at rotation 0).
+    this.busGroup = document.createElementNS(NS, "g");
+    const arrow = document.createElementNS(NS, "path");
+    arrow.setAttribute("d", "M 0 -7 L 5 6 L 0 3 L -5 6 Z");
+    arrow.setAttribute("fill", "#111");
+    arrow.setAttribute("stroke", "#fff");
+    arrow.setAttribute("stroke-width", "1");
+    this.busGroup.appendChild(arrow);
+    svg.appendChild(this.busGroup);
+
+    container.innerHTML = "";
+    container.appendChild(svg);
+
+    this.update(drivePath[0]);
+  }
+
+  /**
+   * Move the bus marker. Heading is derived from movement unless provided.
+   * @param {number[]} lonLat - [lon, lat]
+   * @param {number} [headingDeg] - optional bearing override
+   */
+  update(lonLat, headingDeg) {
+    if (!lonLat) return;
+    const p = this.project(lonLat[0], lonLat[1]);
+
+    if (headingDeg != null) {
+      this.heading = headingDeg;
+    } else if (this.lastLonLat) {
+      const east = (lonLat[0] - this.lastLonLat[0]) * this.cosLat;
+      const north = lonLat[1] - this.lastLonLat[1];
+      if (Math.abs(east) > 1e-9 || Math.abs(north) > 1e-9) {
+        this.heading = (Math.atan2(east, north) * 180) / Math.PI;
+      }
+    }
+
+    this.busGroup.setAttribute(
+      "transform",
+      `translate(${p.x.toFixed(1)},${p.y.toFixed(1)}) rotate(${this.heading.toFixed(1)})`
+    );
+    this.lastLonLat = lonLat;
+  }
+};

--- a/static/js/ride/minimap.js
+++ b/static/js/ride/minimap.js
@@ -1,6 +1,7 @@
-// Shared minimap overlay for both ride modes: a small north-up SVG map of the
-// full route with a heading arrow marking the bus. No mapping library — pure
-// SVG so it works identically in the Three.js and MapLibre rides.
+// Shared minimap overlay for both ride modes: a small north-up OSM map of the
+// route area with the route line and a live bus heading arrow on top. Uses
+// web-mercator projection so the route overlays the tiles exactly. Pure
+// canvas + SVG — no mapping library, identical in the Three.js and MapLibre rides.
 window.APP = window.APP || {};
 
 APP.Minimap = class {
@@ -13,42 +14,90 @@ APP.Minimap = class {
   constructor(container, drivePath, bounds, color) {
     const W = 180;
     const H = 180;
-    const pad = 12;
-    const centerLat = (bounds.minLat + bounds.maxLat) / 2;
-    const cosLat = Math.cos((centerLat * Math.PI) / 180);
-    const lonRange = bounds.maxLon - bounds.minLon || 1e-6;
-    const latRange = bounds.maxLat - bounds.minLat || 1e-6;
-    const scale = Math.min(
-      (W - 2 * pad) / (lonRange * cosLat),
-      (H - 2 * pad) / latRange
-    );
-    const offX = (W - lonRange * cosLat * scale) / 2;
-    const offY = (H - latRange * scale) / 2;
-
-    this.cosLat = cosLat;
+    const margin = 8;
     this.heading = 0;
     this.lastLonLat = null;
-    this.project = (lon, lat) => ({
-      x: offX + (lon - bounds.minLon) * cosLat * scale,
-      y: offY + (bounds.maxLat - lat) * scale, // north up
-    });
+    this.cosLat = Math.cos(
+      (((bounds.minLat + bounds.maxLat) / 2) * Math.PI) / 180
+    );
 
+    // Pad the route bbox so we see some surroundings.
+    const padLon = (bounds.maxLon - bounds.minLon) * 0.14 + 0.001;
+    const padLat = (bounds.maxLat - bounds.minLat) * 0.14 + 0.001;
+    const b = {
+      minLon: bounds.minLon - padLon,
+      maxLon: bounds.maxLon + padLon,
+      minLat: bounds.minLat - padLat,
+      maxLat: bounds.maxLat + padLat,
+    };
+
+    // Highest zoom where the area fits in a small tile grid (≤3 per side).
+    const z = this._chooseZoom(b, 3);
+    const x0 = this._lon2tx(b.minLon, z);
+    const x1 = this._lon2tx(b.maxLon, z);
+    const y0 = this._lat2ty(b.maxLat, z); // north
+    const y1 = this._lat2ty(b.minLat, z); // south
+
+    // Fit the tile-grid pixel rect into the box, preserving aspect.
+    const pxMinX = x0 * 256;
+    const pxMinY = y0 * 256;
+    const gridW = (x1 - x0 + 1) * 256;
+    const gridH = (y1 - y0 + 1) * 256;
+    const scale = Math.min((W - 2 * margin) / gridW, (H - 2 * margin) / gridH);
+    const offX = (W - gridW * scale) / 2;
+    const offY = (H - gridH * scale) / 2;
+
+    const pow = 2 ** z;
+    this.project = (lon, lat) => {
+      const wx = ((lon + 180) / 360) * pow * 256;
+      const r = (lat * Math.PI) / 180;
+      const wy =
+        ((1 - Math.log(Math.tan(r) + 1 / Math.cos(r)) / Math.PI) / 2) *
+        pow *
+        256;
+      return {
+        x: offX + (wx - pxMinX) * scale,
+        y: offY + (wy - pxMinY) * scale,
+      };
+    };
+
+    container.innerHTML = "";
+
+    // 1) Canvas tile background
+    const canvas = document.createElement("canvas");
+    canvas.width = W;
+    canvas.height = H;
+    canvas.style.cssText =
+      "position:absolute;inset:0;width:100%;height:100%;";
+    container.appendChild(canvas);
+    this._drawTiles(canvas, z, x0, x1, y0, y1, scale, offX, offY, pxMinX, pxMinY);
+
+    // 2) SVG overlay (route + bus), exactly aligned to the tiles
     const NS = "http://www.w3.org/2000/svg";
     const svg = document.createElementNS(NS, "svg");
     svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
-    svg.setAttribute("width", "100%");
-    svg.setAttribute("height", "100%");
+    svg.style.cssText = "position:absolute;inset:0;width:100%;height:100%;";
+
+    const points = drivePath
+      .map(([lon, lat]) => {
+        const p = this.project(lon, lat);
+        return `${p.x.toFixed(1)},${p.y.toFixed(1)}`;
+      })
+      .join(" ");
+
+    // White casing under the colored route for contrast over the map.
+    const casing = document.createElementNS(NS, "polyline");
+    casing.setAttribute("points", points);
+    casing.setAttribute("fill", "none");
+    casing.setAttribute("stroke", "#fff");
+    casing.setAttribute("stroke-width", "4.5");
+    casing.setAttribute("stroke-linejoin", "round");
+    casing.setAttribute("stroke-linecap", "round");
+    casing.setAttribute("opacity", "0.85");
+    svg.appendChild(casing);
 
     const route = document.createElementNS(NS, "polyline");
-    route.setAttribute(
-      "points",
-      drivePath
-        .map(([lon, lat]) => {
-          const p = this.project(lon, lat);
-          return `${p.x.toFixed(1)},${p.y.toFixed(1)}`;
-        })
-        .join(" ")
-    );
+    route.setAttribute("points", points);
     route.setAttribute("fill", "none");
     route.setAttribute("stroke", color);
     route.setAttribute("stroke-width", "2.5");
@@ -66,7 +115,6 @@ APP.Minimap = class {
     startDot.setAttribute("stroke-width", "1.5");
     svg.appendChild(startDot);
 
-    // Bus heading arrow (points "up" = north at rotation 0).
     this.busGroup = document.createElementNS(NS, "g");
     const arrow = document.createElementNS(NS, "path");
     arrow.setAttribute("d", "M 0 -7 L 5 6 L 0 3 L -5 6 Z");
@@ -76,10 +124,55 @@ APP.Minimap = class {
     this.busGroup.appendChild(arrow);
     svg.appendChild(this.busGroup);
 
-    container.innerHTML = "";
     container.appendChild(svg);
 
+    // Tiny OSM attribution.
+    const attr = document.createElement("div");
+    attr.textContent = "© OSM";
+    attr.style.cssText =
+      "position:absolute;right:2px;bottom:1px;font-size:8px;color:#333;" +
+      "background:rgba(255,255,255,0.6);padding:0 2px;border-radius:2px;";
+    container.appendChild(attr);
+
     this.update(drivePath[0]);
+  }
+
+  _lon2tx(lon, z) {
+    return Math.floor(((lon + 180) / 360) * 2 ** z);
+  }
+
+  _lat2ty(lat, z) {
+    const r = (lat * Math.PI) / 180;
+    return Math.floor(
+      ((1 - Math.log(Math.tan(r) + 1 / Math.cos(r)) / Math.PI) / 2) * 2 ** z
+    );
+  }
+
+  _chooseZoom(b, maxPerSide) {
+    for (let z = 18; z >= 8; z--) {
+      const cols = this._lon2tx(b.maxLon, z) - this._lon2tx(b.minLon, z) + 1;
+      const rows = this._lat2ty(b.minLat, z) - this._lat2ty(b.maxLat, z) + 1;
+      if (cols <= maxPerSide && rows <= maxPerSide) return z;
+    }
+    return 11;
+  }
+
+  _drawTiles(canvas, z, x0, x1, y0, y1, scale, offX, offY, pxMinX, pxMinY) {
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "#dfe3e8";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    const size = 256 * scale;
+    const subs = ["a", "b", "c"];
+    for (let x = x0; x <= x1; x++) {
+      for (let y = y0; y <= y1; y++) {
+        const dx = offX + (x * 256 - pxMinX) * scale;
+        const dy = offY + (y * 256 - pxMinY) * scale;
+        const img = new Image();
+        img.crossOrigin = "anonymous";
+        img.onload = () => ctx.drawImage(img, dx, dy, size, size);
+        img.src = `https://${subs[(x + y) % 3]}.tile.openstreetmap.org/${z}/${x}/${y}.png`;
+      }
+    }
   }
 
   /**

--- a/static/js/ride/minimap.js
+++ b/static/js/ride/minimap.js
@@ -1,7 +1,9 @@
-// Shared minimap overlay for both ride modes: a small north-up OSM map of the
-// route area with the route line and a live bus heading arrow on top. Uses
-// web-mercator projection so the route overlays the tiles exactly. Pure
-// canvas + SVG — no mapping library, identical in the Three.js and MapLibre rides.
+// Shared minimap overlay for both ride modes: a small north-up OSM slippy map
+// of the route area with the route line and a live bus heading arrow on top.
+// It fetches real OSM tiles for the currently-visible window (centred on the
+// bus once zoomed in), so zooming in re-fetches higher-zoom tiles and stays
+// sharp at any level instead of upscaling a fixed bitmap. Pure canvas + SVG —
+// no mapping library, identical in the Three.js and MapLibre rides.
 window.APP = window.APP || {};
 
 APP.Minimap = class {
@@ -12,119 +14,136 @@ APP.Minimap = class {
    * @param {string} color - route color
    */
   constructor(container, drivePath, bounds, color) {
-    const W = 180;
-    const H = 180;
-    const margin = 8;
+    this.container = container;
+    this.drivePath = drivePath;
+    this.color = color;
+    this.W = 180;
+    this.H = 180;
     this.heading = 0;
     this.lastLonLat = null;
+    this.tiles = new Map(); // "z/x/y" -> Image (tile cache across frames/zooms)
+    this._rafPending = false;
+    this._routeKey = null;
+
     this.cosLat = Math.cos(
       (((bounds.minLat + bounds.maxLat) / 2) * Math.PI) / 180
     );
+    this.routeCenter = [
+      (bounds.minLon + bounds.maxLon) / 2,
+      (bounds.minLat + bounds.maxLat) / 2,
+    ];
 
-    // Pad the route bbox so we see some surroundings.
-    const padLon = (bounds.maxLon - bounds.minLon) * 0.14 + 0.001;
-    const padLat = (bounds.maxLat - bounds.minLat) * 0.14 + 0.001;
-    const b = {
-      minLon: bounds.minLon - padLon,
-      maxLon: bounds.maxLon + padLon,
-      minLat: bounds.minLat - padLat,
-      maxLat: bounds.maxLat + padLat,
-    };
+    // Fixed zoom range: z7 is the furthest the user can zoom out, z19 is OSM's
+    // max detail, and we open at z15 (street-ish level following the bus).
+    this.minZoom = 7;
+    this.maxZoom = 19;
+    this.defaultZoom = 15;
+    this.zoom = this.defaultZoom;
 
-    // Highest zoom where the area fits in a small tile grid (≤3 per side).
-    const z = this._chooseZoom(b, 3);
-    const x0 = this._lon2tx(b.minLon, z);
-    const x1 = this._lon2tx(b.maxLon, z);
-    const y0 = this._lat2ty(b.maxLat, z); // north
-    const y1 = this._lat2ty(b.minLat, z); // south
+    this._buildDom();
+    this.update(drivePath[0]);
+  }
 
-    // Fit the tile-grid pixel rect into the box, preserving aspect.
-    const pxMinX = x0 * 256;
-    const pxMinY = y0 * 256;
-    const gridW = (x1 - x0 + 1) * 256;
-    const gridH = (y1 - y0 + 1) * 256;
-    const scale = Math.min((W - 2 * margin) / gridW, (H - 2 * margin) / gridH);
-    const offX = (W - gridW * scale) / 2;
-    const offY = (H - gridH * scale) / 2;
+  // --- Web Mercator world-pixel projection (256px tiles) ----------------------
+  _worldX(lon, z) {
+    return ((lon + 180) / 360) * 2 ** z * 256;
+  }
+  _worldY(lat, z) {
+    const r = (lat * Math.PI) / 180;
+    return (
+      ((1 - Math.log(Math.tan(r) + 1 / Math.cos(r)) / Math.PI) / 2) *
+      2 ** z *
+      256
+    );
+  }
 
-    const pow = 2 ** z;
-    this.project = (lon, lat) => {
-      const wx = ((lon + 180) / 360) * pow * 256;
-      const r = (lat * Math.PI) / 180;
-      const wy =
-        ((1 - Math.log(Math.tan(r) + 1 / Math.cos(r)) / Math.PI) / 2) *
-        pow *
-        256;
-      return {
-        x: offX + (wx - pxMinX) * scale,
-        y: offY + (wy - pxMinY) * scale,
-      };
-    };
-
+  _buildDom() {
+    const { container, W, H, color } = this;
     container.innerHTML = "";
 
-    // 1) Canvas tile background
+    // Tile canvas (retina-aware so tiles render crisply).
+    const ratio = Math.min(window.devicePixelRatio || 1, 2);
+    this.ratio = ratio;
     const canvas = document.createElement("canvas");
-    canvas.width = W;
-    canvas.height = H;
-    canvas.style.cssText =
-      "position:absolute;inset:0;width:100%;height:100%;";
+    canvas.width = W * ratio;
+    canvas.height = H * ratio;
+    canvas.style.cssText = "position:absolute;inset:0;width:100%;height:100%;";
     container.appendChild(canvas);
-    this._drawTiles(canvas, z, x0, x1, y0, y1, scale, offX, offY, pxMinX, pxMinY);
+    this.ctx = canvas.getContext("2d");
 
-    // 2) SVG overlay (route + bus), exactly aligned to the tiles
+    // SVG overlay (route + start dot + bus arrow), drawn in box pixel coords.
     const NS = "http://www.w3.org/2000/svg";
     const svg = document.createElementNS(NS, "svg");
     svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
     svg.style.cssText = "position:absolute;inset:0;width:100%;height:100%;";
 
-    const points = drivePath
-      .map(([lon, lat]) => {
-        const p = this.project(lon, lat);
-        return `${p.x.toFixed(1)},${p.y.toFixed(1)}`;
+    const mk = (tag, attrs) => {
+      const el = document.createElementNS(NS, tag);
+      for (const k in attrs) el.setAttribute(k, attrs[k]);
+      return el;
+    };
+
+    this.casing = mk("polyline", {
+      fill: "none",
+      stroke: "#fff",
+      "stroke-width": "4.5",
+      "stroke-linejoin": "round",
+      "stroke-linecap": "round",
+      opacity: "0.85",
+    });
+    svg.appendChild(this.casing);
+
+    this.route = mk("polyline", {
+      fill: "none",
+      stroke: color,
+      "stroke-width": "2.5",
+      "stroke-linejoin": "round",
+      "stroke-linecap": "round",
+    });
+    svg.appendChild(this.route);
+
+    this.startDot = mk("circle", {
+      r: "3",
+      fill: "#fff",
+      stroke: color,
+      "stroke-width": "1.5",
+    });
+    svg.appendChild(this.startDot);
+
+    this.busGroup = mk("g", {});
+    this.busGroup.appendChild(
+      mk("path", {
+        d: "M 0 -7 L 5 6 L 0 3 L -5 6 Z",
+        fill: "#111",
+        stroke: "#fff",
+        "stroke-width": "1",
       })
-      .join(" ");
-
-    // White casing under the colored route for contrast over the map.
-    const casing = document.createElementNS(NS, "polyline");
-    casing.setAttribute("points", points);
-    casing.setAttribute("fill", "none");
-    casing.setAttribute("stroke", "#fff");
-    casing.setAttribute("stroke-width", "4.5");
-    casing.setAttribute("stroke-linejoin", "round");
-    casing.setAttribute("stroke-linecap", "round");
-    casing.setAttribute("opacity", "0.85");
-    svg.appendChild(casing);
-
-    const route = document.createElementNS(NS, "polyline");
-    route.setAttribute("points", points);
-    route.setAttribute("fill", "none");
-    route.setAttribute("stroke", color);
-    route.setAttribute("stroke-width", "2.5");
-    route.setAttribute("stroke-linejoin", "round");
-    route.setAttribute("stroke-linecap", "round");
-    svg.appendChild(route);
-
-    const startP = this.project(drivePath[0][0], drivePath[0][1]);
-    const startDot = document.createElementNS(NS, "circle");
-    startDot.setAttribute("cx", startP.x);
-    startDot.setAttribute("cy", startP.y);
-    startDot.setAttribute("r", "3");
-    startDot.setAttribute("fill", "#fff");
-    startDot.setAttribute("stroke", color);
-    startDot.setAttribute("stroke-width", "1.5");
-    svg.appendChild(startDot);
-
-    this.busGroup = document.createElementNS(NS, "g");
-    const arrow = document.createElementNS(NS, "path");
-    arrow.setAttribute("d", "M 0 -7 L 5 6 L 0 3 L -5 6 Z");
-    arrow.setAttribute("fill", "#111");
-    arrow.setAttribute("stroke", "#fff");
-    arrow.setAttribute("stroke-width", "1");
-    this.busGroup.appendChild(arrow);
+    );
     svg.appendChild(this.busGroup);
-
     container.appendChild(svg);
+
+    // Zoom controls (rendered by the widget so both rides get them for free).
+    const zoomCtl = document.createElement("div");
+    zoomCtl.className = "minimap-zoom";
+    const mkBtn = (label, title, delta) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.textContent = label;
+      btn.title = title;
+      btn.addEventListener("click", () => this._zoomBy(delta));
+      return btn;
+    };
+    zoomCtl.appendChild(mkBtn("+", "Zoom in", 1));
+    // Reset button — only shown once the user has changed the zoom.
+    this.resetBtn = document.createElement("button");
+    this.resetBtn.type = "button";
+    this.resetBtn.className = "minimap-zoom-reset hidden";
+    this.resetBtn.textContent = "⟲";
+    this.resetBtn.title = "Reset zoom";
+    this.resetBtn.addEventListener("click", () => this._resetZoom());
+    zoomCtl.appendChild(this.resetBtn);
+    zoomCtl.appendChild(mkBtn("−", "Zoom out", -1));
+    container.appendChild(zoomCtl);
 
     // Tiny OSM attribution.
     const attr = document.createElement("div");
@@ -133,46 +152,29 @@ APP.Minimap = class {
       "position:absolute;right:2px;bottom:1px;font-size:8px;color:#333;" +
       "background:rgba(255,255,255,0.6);padding:0 2px;border-radius:2px;";
     container.appendChild(attr);
-
-    this.update(drivePath[0]);
   }
 
-  _lon2tx(lon, z) {
-    return Math.floor(((lon + 180) / 360) * 2 ** z);
+  _zoomBy(delta) {
+    const z = Math.max(this.minZoom, Math.min(this.maxZoom, this.zoom + delta));
+    if (z === this.zoom) return;
+    this.zoom = z;
+    this._routeKey = null; // force route re-projection at the new zoom
+    this._updateResetBtn();
+    this._render();
   }
 
-  _lat2ty(lat, z) {
-    const r = (lat * Math.PI) / 180;
-    return Math.floor(
-      ((1 - Math.log(Math.tan(r) + 1 / Math.cos(r)) / Math.PI) / 2) * 2 ** z
-    );
+  _resetZoom() {
+    if (this.zoom === this.defaultZoom) return;
+    this.zoom = this.defaultZoom;
+    this._routeKey = null;
+    this._updateResetBtn();
+    this._render();
   }
 
-  _chooseZoom(b, maxPerSide) {
-    for (let z = 18; z >= 8; z--) {
-      const cols = this._lon2tx(b.maxLon, z) - this._lon2tx(b.minLon, z) + 1;
-      const rows = this._lat2ty(b.minLat, z) - this._lat2ty(b.maxLat, z) + 1;
-      if (cols <= maxPerSide && rows <= maxPerSide) return z;
-    }
-    return 11;
-  }
-
-  _drawTiles(canvas, z, x0, x1, y0, y1, scale, offX, offY, pxMinX, pxMinY) {
-    const ctx = canvas.getContext("2d");
-    ctx.fillStyle = "#dfe3e8";
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    const size = 256 * scale;
-    const subs = ["a", "b", "c"];
-    for (let x = x0; x <= x1; x++) {
-      for (let y = y0; y <= y1; y++) {
-        const dx = offX + (x * 256 - pxMinX) * scale;
-        const dy = offY + (y * 256 - pxMinY) * scale;
-        const img = new Image();
-        img.crossOrigin = "anonymous";
-        img.onload = () => ctx.drawImage(img, dx, dy, size, size);
-        img.src = `https://${subs[(x + y) % 3]}.tile.openstreetmap.org/${z}/${x}/${y}.png`;
-      }
-    }
+  // The reset button only appears once the zoom differs from the default.
+  _updateResetBtn() {
+    if (!this.resetBtn) return;
+    this.resetBtn.classList.toggle("hidden", this.zoom === this.defaultZoom);
   }
 
   /**
@@ -182,8 +184,6 @@ APP.Minimap = class {
    */
   update(lonLat, headingDeg) {
     if (!lonLat) return;
-    const p = this.project(lonLat[0], lonLat[1]);
-
     if (headingDeg != null) {
       this.heading = headingDeg;
     } else if (this.lastLonLat) {
@@ -193,11 +193,104 @@ APP.Minimap = class {
         this.heading = (Math.atan2(east, north) * 180) / Math.PI;
       }
     }
+    this.lastLonLat = lonLat;
+    this._render();
+  }
 
+  // Draw the current view: tiles, route, start dot, bus arrow.
+  _render() {
+    const Z = this.zoom;
+    // Zoomed in → follow the bus; at overview zoom → show the whole route.
+    const center =
+      Z > this.minZoom && this.lastLonLat ? this.lastLonLat : this.routeCenter;
+    this._originX = this._worldX(center[0], Z) - this.W / 2;
+    this._originY = this._worldY(center[1], Z) - this.H / 2;
+
+    this._drawTiles();
+    this._drawRoute();
+    this._drawBus();
+  }
+
+  _drawTiles() {
+    const ctx = this.ctx;
+    const Z = this.zoom;
+    const oX = this._originX;
+    const oY = this._originY;
+    ctx.setTransform(this.ratio, 0, 0, this.ratio, 0, 0);
+    ctx.fillStyle = "#dfe3e8";
+    ctx.fillRect(0, 0, this.W, this.H);
+
+    const tilesPerSide = 2 ** Z;
+    const x0 = Math.floor(oX / 256);
+    const x1 = Math.floor((oX + this.W) / 256);
+    const y0 = Math.floor(oY / 256);
+    const y1 = Math.floor((oY + this.H) / 256);
+    const subs = ["a", "b", "c"];
+
+    for (let x = x0; x <= x1; x++) {
+      for (let y = y0; y <= y1; y++) {
+        if (y < 0 || y >= tilesPerSide) continue;
+        const tx = ((x % tilesPerSide) + tilesPerSide) % tilesPerSide; // wrap lon
+        const dx = x * 256 - oX;
+        const dy = y * 256 - oY;
+        const key = `${Z}/${tx}/${y}`;
+        let img = this.tiles.get(key);
+        if (!img) {
+          img = new Image();
+          img.crossOrigin = "anonymous";
+          // Redraw once it arrives (next frame would also catch it, but this
+          // keeps a paused/overview view from waiting on the ride loop).
+          img.onload = () => this._scheduleDraw();
+          img.src = `https://${subs[(tx + y) % 3]}.tile.openstreetmap.org/${Z}/${tx}/${y}.png`;
+          this.tiles.set(key, img);
+        }
+        if (img.complete && img.naturalWidth) {
+          ctx.drawImage(img, dx, dy, 256, 256);
+        }
+      }
+    }
+  }
+
+  _scheduleDraw() {
+    if (this._rafPending) return;
+    this._rafPending = true;
+    requestAnimationFrame(() => {
+      this._rafPending = false;
+      this._drawTiles();
+    });
+  }
+
+  _drawRoute() {
+    const Z = this.zoom;
+    const oX = this._originX;
+    const oY = this._originY;
+    // Within a zoom level the projection is just a translation, so skip the
+    // re-projection work when neither zoom nor (rounded) origin changed.
+    const key = `${Z}:${Math.round(oX)}:${Math.round(oY)}`;
+    if (key === this._routeKey) return;
+    this._routeKey = key;
+
+    let pts = "";
+    for (const [lon, lat] of this.drivePath) {
+      const x = this._worldX(lon, Z) - oX;
+      const y = this._worldY(lat, Z) - oY;
+      pts += `${x.toFixed(1)},${y.toFixed(1)} `;
+    }
+    this.casing.setAttribute("points", pts);
+    this.route.setAttribute("points", pts);
+
+    const s = this.drivePath[0];
+    this.startDot.setAttribute("cx", (this._worldX(s[0], Z) - oX).toFixed(1));
+    this.startDot.setAttribute("cy", (this._worldY(s[1], Z) - oY).toFixed(1));
+  }
+
+  _drawBus() {
+    if (!this.lastLonLat) return;
+    const x = this._worldX(this.lastLonLat[0], this.zoom) - this._originX;
+    const y = this._worldY(this.lastLonLat[1], this.zoom) - this._originY;
     this.busGroup.setAttribute(
       "transform",
-      `translate(${p.x.toFixed(1)},${p.y.toFixed(1)}) rotate(${this.heading.toFixed(1)})`
+      `translate(${x.toFixed(1)},${y.toFixed(1)}) rotate(${this.heading.toFixed(1)})`
     );
-    this.lastLonLat = lonLat;
   }
 };

--- a/static/js/ride/route-path.js
+++ b/static/js/ride/route-path.js
@@ -1,0 +1,109 @@
+// Shared geometry helpers for the 3D ride-along modes (Three.js + MapLibre).
+// Pure data — no rendering-library dependency — so both engines treat the
+// route identically. Attaches to the existing window.APP namespace.
+window.APP = window.APP || {};
+
+APP.RidePath = {
+  // Meters per degree of latitude (good enough for city-scale local projection).
+  METERS_PER_DEG: 111320,
+
+  /**
+   * Read the chosen route file from the page query string (?route=...).
+   * @returns {string|null}
+   */
+  routeFromQuery() {
+    return new URLSearchParams(window.location.search).get("route");
+  },
+
+  /**
+   * Fetch parsed route geometry from the backend.
+   * @param {string} routeFile - KML filename
+   * @returns {Promise<{segments:number[][][], stops:object[], bounds:object, name:string}>}
+   */
+  async fetchGeometry(routeFile) {
+    const res = await fetch(
+      `/data/route-geometry/${encodeURIComponent(routeFile)}`
+    );
+    if (!res.ok) {
+      throw new Error(`Geometry fetch failed (${res.status})`);
+    }
+    return res.json();
+  },
+
+  /**
+   * The longest segment is the main drive path (numbered routes have one).
+   * @param {number[][][]} segments
+   * @returns {number[][]} array of [lon, lat]
+   */
+  pickDrivePath(segments) {
+    if (!segments || !segments.length) {
+      return [];
+    }
+    return segments.reduce((a, b) => (b.length > a.length ? b : a));
+  },
+
+  /**
+   * Projection origin = center of the route bounds.
+   * @param {object} bounds - {minLon, minLat, maxLon, maxLat}
+   * @returns {{lon:number, lat:number}}
+   */
+  originFromBounds(bounds) {
+    return {
+      lon: (bounds.minLon + bounds.maxLon) / 2,
+      lat: (bounds.minLat + bounds.maxLat) / 2,
+    };
+  },
+
+  /**
+   * Project [lon, lat] to local meters relative to an origin.
+   * East = +x, North = -z (so it maps naturally onto a Three.js XZ ground).
+   * @param {number[]} lonLat - [lon, lat]
+   * @param {{lon:number, lat:number}} origin
+   * @returns {{x:number, z:number}}
+   */
+  lonLatToMeters(lonLat, origin) {
+    const mPerDegLon =
+      this.METERS_PER_DEG * Math.cos((origin.lat * Math.PI) / 180);
+    return {
+      x: (lonLat[0] - origin.lon) * mPerDegLon,
+      z: -(lonLat[1] - origin.lat) * this.METERS_PER_DEG,
+    };
+  },
+
+  /**
+   * Inverse of lonLatToMeters: local meters back to [lon, lat].
+   * @param {{x:number, z:number}} m
+   * @param {{lon:number, lat:number}} origin
+   * @returns {number[]} [lon, lat]
+   */
+  metersToLonLat(m, origin) {
+    const mPerDegLon =
+      this.METERS_PER_DEG * Math.cos((origin.lat * Math.PI) / 180);
+    return [origin.lon + m.x / mPerDegLon, origin.lat - m.z / this.METERS_PER_DEG];
+  },
+
+  /**
+   * Project a whole path of [lon, lat] points to local meters.
+   * @param {number[][]} points
+   * @param {{lon:number, lat:number}} origin
+   * @returns {{x:number, z:number}[]}
+   */
+  pathToMeters(points, origin) {
+    return points.map((p) => this.lonLatToMeters(p, origin));
+  },
+
+  /**
+   * Pick a stable color for a route from the shared palette, keyed by its
+   * leading number so it matches the 2D map's coloring.
+   * @param {string} routeFile
+   * @returns {string} hex color
+   */
+  colorFor(routeFile) {
+    const palette = (APP.ROUTE_COLORS && APP.ROUTE_COLORS.length
+      ? APP.ROUTE_COLORS
+      : ["#e6194b"]);
+    const match = (routeFile || "").match(/(\d+)/);
+    const idx = match ? parseInt(match[1], 10) : 0;
+    return palette[idx % palette.length];
+  },
+};

--- a/static/js/ride/three-ride.js
+++ b/static/js/ride/three-ride.js
@@ -1,0 +1,404 @@
+// Three.js "ride the route" — chase cam following a procedural bus along the
+// real route geometry, over a flat ground textured with stitched OSM tiles.
+import * as THREE from "three";
+
+const RP = APP.RidePath;
+
+const els = {
+  canvas: document.getElementById("scene"),
+  title: document.getElementById("route-title"),
+  status: document.getElementById("ride-status"),
+  statusSub: document.getElementById("ride-status-sub"),
+  banner: document.getElementById("stop-banner"),
+  playpause: document.getElementById("playpause"),
+  speed: document.getElementById("speed"),
+  speedVal: document.getElementById("speed-val"),
+  progress: document.getElementById("progress-bar"),
+};
+
+function showError(msg) {
+  els.status.classList.remove("hidden");
+  els.status.innerHTML =
+    `<div>${msg}</div><div class="sub"><a href="/">← Back to the map</a></div>`;
+}
+
+// --- Web Mercator tile math (for the OSM ground texture) ---------------------
+function lon2tileX(lon, z) {
+  return Math.floor(((lon + 180) / 360) * 2 ** z);
+}
+function lat2tileY(lat, z) {
+  const r = (lat * Math.PI) / 180;
+  return Math.floor(
+    ((1 - Math.log(Math.tan(r) + 1 / Math.cos(r)) / Math.PI) / 2) * 2 ** z
+  );
+}
+function tileX2lon(x, z) {
+  return (x / 2 ** z) * 360 - 180;
+}
+function tileY2lat(y, z) {
+  const n = Math.PI - (2 * Math.PI * y) / 2 ** z;
+  return (180 / Math.PI) * Math.atan(Math.sinh(n));
+}
+function chooseZoom(b, maxPerSide) {
+  for (let z = 17; z >= 10; z--) {
+    const cols = lon2tileX(b.maxLon, z) - lon2tileX(b.minLon, z) + 1;
+    const rows = lat2tileY(b.minLat, z) - lat2tileY(b.maxLat, z) + 1;
+    if (cols <= maxPerSide && rows <= maxPerSide) return z;
+  }
+  return 12;
+}
+
+async function buildGround(bounds, origin) {
+  // Pad the route bbox so we see a bit of surroundings.
+  const padLon = (bounds.maxLon - bounds.minLon) * 0.15 + 0.002;
+  const padLat = (bounds.maxLat - bounds.minLat) * 0.15 + 0.002;
+  const b = {
+    minLon: bounds.minLon - padLon,
+    maxLon: bounds.maxLon + padLon,
+    minLat: bounds.minLat - padLat,
+    maxLat: bounds.maxLat + padLat,
+  };
+  const z = chooseZoom(b, 6);
+  const x0 = lon2tileX(b.minLon, z);
+  const x1 = lon2tileX(b.maxLon, z);
+  const y0 = lat2tileY(b.maxLat, z); // north
+  const y1 = lat2tileY(b.minLat, z); // south
+  const cols = x1 - x0 + 1;
+  const rows = y1 - y0 + 1;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = cols * 256;
+  canvas.height = rows * 256;
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = "#e2e5e9";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  const subs = ["a", "b", "c"];
+  const loads = [];
+  for (let x = x0; x <= x1; x++) {
+    for (let y = y0; y <= y1; y++) {
+      const dx = (x - x0) * 256;
+      const dy = (y - y0) * 256;
+      const url = `https://${subs[(x + y) % 3]}.tile.openstreetmap.org/${z}/${x}/${y}.png`;
+      loads.push(
+        new Promise((resolve) => {
+          const img = new Image();
+          let done = false;
+          const finish = () => {
+            if (!done) {
+              done = true;
+              resolve();
+            }
+          };
+          img.crossOrigin = "anonymous";
+          img.onload = () => {
+            try {
+              ctx.drawImage(img, dx, dy);
+            } catch (e) {
+              /* ignore draw errors */
+            }
+            finish();
+          };
+          img.onerror = finish;
+          // Don't let a slow/unreachable tile hang the whole ride.
+          setTimeout(finish, 4000);
+          img.src = url;
+        })
+      );
+    }
+  }
+  await Promise.all(loads);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+
+  // World extent matches the tile-grid geographic boundaries.
+  const nw = RP.lonLatToMeters([tileX2lon(x0, z), tileY2lat(y0, z)], origin);
+  const se = RP.lonLatToMeters(
+    [tileX2lon(x1 + 1, z), tileY2lat(y1 + 1, z)],
+    origin
+  );
+  const width = se.x - nw.x;
+  const depth = se.z - nw.z;
+
+  const mesh = new THREE.Mesh(
+    new THREE.PlaneGeometry(width, depth),
+    new THREE.MeshBasicMaterial({ map: texture })
+  );
+  mesh.rotation.x = -Math.PI / 2;
+  mesh.position.set((nw.x + se.x) / 2, 0, (nw.z + se.z) / 2);
+  return mesh;
+}
+
+// --- Road ribbon + route line ------------------------------------------------
+function buildRoad(pts, color) {
+  const half = 4.5;
+  const edges = [];
+  for (let i = 0; i < pts.length; i++) {
+    const prev = pts[Math.max(0, i - 1)];
+    const next = pts[Math.min(pts.length - 1, i + 1)];
+    let dx = next.x - prev.x;
+    let dz = next.z - prev.z;
+    const len = Math.hypot(dx, dz) || 1;
+    dx /= len;
+    dz /= len;
+    edges.push([
+      [pts[i].x - dz * half, pts[i].z + dx * half],
+      [pts[i].x + dz * half, pts[i].z - dx * half],
+    ]);
+  }
+  const verts = [];
+  const y = 0.25;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const [a, b] = edges[i];
+    const [c, d] = edges[i + 1];
+    verts.push(a[0], y, a[1], b[0], y, b[1], c[0], y, c[1]);
+    verts.push(b[0], y, b[1], d[0], y, d[1], c[0], y, c[1]);
+  }
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute("position", new THREE.Float32BufferAttribute(verts, 3));
+  const group = new THREE.Group();
+  group.add(
+    new THREE.Mesh(
+      geo,
+      new THREE.MeshBasicMaterial({
+        color: 0x2b2b2b,
+        transparent: true,
+        opacity: 0.55,
+        side: THREE.DoubleSide,
+      })
+    )
+  );
+  // bright centerline in the route color
+  const linePts = pts.map((p) => new THREE.Vector3(p.x, 0.4, p.z));
+  group.add(
+    new THREE.Line(
+      new THREE.BufferGeometry().setFromPoints(linePts),
+      new THREE.LineBasicMaterial({ color })
+    )
+  );
+  return group;
+}
+
+function buildBus(color) {
+  const bus = new THREE.Group();
+  const body = new THREE.Mesh(
+    new THREE.BoxGeometry(2.6, 3, 10),
+    new THREE.MeshLambertMaterial({ color })
+  );
+  body.position.y = 2;
+  bus.add(body);
+  const windows = new THREE.Mesh(
+    new THREE.BoxGeometry(2.64, 1.1, 8),
+    new THREE.MeshLambertMaterial({ color: 0x1c2733 })
+  );
+  windows.position.y = 2.75;
+  bus.add(windows);
+  const wheelGeo = new THREE.CylinderGeometry(0.7, 0.7, 0.6, 16);
+  const wheelMat = new THREE.MeshLambertMaterial({ color: 0x0a0a0a });
+  [
+    [-1.35, -3.2],
+    [1.35, -3.2],
+    [-1.35, 3.2],
+    [1.35, 3.2],
+  ].forEach(([x, z]) => {
+    const w = new THREE.Mesh(wheelGeo, wheelMat);
+    w.rotation.z = Math.PI / 2;
+    w.position.set(x, 0.7, z);
+    bus.add(w);
+  });
+  return bus;
+}
+
+function buildStops(stops, origin) {
+  const group = new THREE.Group();
+  const positions = [];
+  const markerGeo = new THREE.CylinderGeometry(1.2, 1.2, 0.4, 12);
+  const markerMat = new THREE.MeshLambertMaterial({ color: 0xffd166 });
+  stops.forEach((s) => {
+    const m = RP.lonLatToMeters([s.lon, s.lat], origin);
+    const marker = new THREE.Mesh(markerGeo, markerMat);
+    marker.position.set(m.x, 0.5, m.z);
+    group.add(marker);
+    positions.push({ name: s.name, pos: new THREE.Vector3(m.x, 0, m.z) });
+  });
+  return { group, positions };
+}
+
+// --- Main --------------------------------------------------------------------
+async function main() {
+  const routeFile = RP.routeFromQuery();
+  if (!routeFile) {
+    showError("No route selected.");
+    return;
+  }
+
+  let geo;
+  try {
+    geo = await RP.fetchGeometry(routeFile);
+  } catch (e) {
+    showError("Could not load this route.");
+    return;
+  }
+  const drivePath = RP.pickDrivePath(geo.segments);
+  if (drivePath.length < 2 || !geo.bounds) {
+    showError("This route has no drivable path yet.");
+    return;
+  }
+
+  const routeName = geo.name || routeFile.replace(".kml", "");
+  els.title.textContent = routeName;
+  document.title = `3D Ride · ${routeName}`;
+  const color = RP.colorFor(routeFile);
+  const origin = RP.originFromBounds(geo.bounds);
+  const pts = RP.pathToMeters(drivePath, origin);
+
+  // Minimap overlay (shared widget) — built early so it shows while tiles load.
+  const minimap = new APP.Minimap(
+    document.getElementById("minimap"),
+    drivePath,
+    geo.bounds,
+    color
+  );
+
+  // Scene
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color(0x87ceeb);
+  scene.fog = new THREE.Fog(0x87ceeb, 400, 1600);
+  scene.add(new THREE.AmbientLight(0xffffff, 0.85));
+  const sun = new THREE.DirectionalLight(0xffffff, 0.7);
+  sun.position.set(200, 400, 100);
+  scene.add(sun);
+
+  const renderer = new THREE.WebGLRenderer({
+    canvas: els.canvas,
+    antialias: true,
+  });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.setSize(window.innerWidth, window.innerHeight);
+
+  const camera = new THREE.PerspectiveCamera(
+    60,
+    window.innerWidth / window.innerHeight,
+    0.5,
+    4000
+  );
+
+  els.statusSub.textContent = "Loading map tiles…";
+  const ground = await buildGround(geo.bounds, origin);
+  scene.add(ground);
+  scene.add(buildRoad(pts, color));
+  const bus = buildBus(color);
+  scene.add(bus);
+  const { group: stopGroup, positions: stopPositions } = buildStops(
+    geo.stops,
+    origin
+  );
+  scene.add(stopGroup);
+
+  // Smooth, arc-length-parameterized path
+  const curve = new THREE.CatmullRomCurve3(
+    pts.map((p) => new THREE.Vector3(p.x, 0, p.z))
+  );
+  curve.curveType = "catmullrom";
+  curve.arcLengthDivisions = Math.max(400, pts.length * 2);
+  const totalLength = curve.getLength();
+
+  // Ride state
+  const TARGET_DURATION = 80; // seconds at 1x for a full route
+  const baseSpeed = totalLength / TARGET_DURATION; // m/s
+  let traveled = 0;
+  let playing = true;
+  let speedMul = 1;
+  let lastStop = null;
+
+  function placeAt(u) {
+    const clamped = Math.min(Math.max(u, 0), 1);
+    const p = curve.getPointAt(clamped);
+    const tan = curve.getTangentAt(clamped).normalize();
+    bus.position.set(p.x, 0, p.z);
+    bus.rotation.y = Math.atan2(tan.x, tan.z);
+    const desired = new THREE.Vector3(
+      p.x - tan.x * 17,
+      9,
+      p.z - tan.z * 17
+    );
+    camera.position.lerp(desired, 0.1);
+    camera.lookAt(p.x + tan.x * 8, 2.5, p.z + tan.z * 8);
+    return p;
+  }
+
+  function updateStopBanner(busPos) {
+    let nearest = null;
+    let best = 70; // metres
+    for (const s of stopPositions) {
+      if (!s.name) continue;
+      const d = busPos.distanceTo(s.pos);
+      if (d < best) {
+        best = d;
+        nearest = s;
+      }
+    }
+    if (nearest && nearest !== lastStop) {
+      lastStop = nearest;
+      els.banner.textContent = `🚏 ${nearest.name}`;
+      els.banner.classList.add("show");
+    } else if (!nearest) {
+      lastStop = null;
+      els.banner.classList.remove("show");
+    }
+  }
+
+  // Position camera instantly before first frame so we don't fly in from origin
+  camera.position.set(pts[0].x, 9, pts[0].z + 20);
+  placeAt(0);
+  camera.position.set(
+    pts[0].x - curve.getTangentAt(0).x * 17,
+    9,
+    pts[0].z - curve.getTangentAt(0).z * 17
+  );
+
+  els.status.classList.add("hidden");
+
+  // Controls
+  els.playpause.addEventListener("click", () => {
+    if (traveled >= totalLength) {
+      traveled = 0; // replay
+      playing = true;
+    } else {
+      playing = !playing;
+    }
+    els.playpause.textContent = playing ? "⏸" : "▶";
+  });
+  els.speed.addEventListener("input", () => {
+    speedMul = parseFloat(els.speed.value);
+    els.speedVal.textContent = `${speedMul}×`;
+  });
+  window.addEventListener("resize", () => {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+  });
+
+  const clock = new THREE.Clock();
+  function animate() {
+    requestAnimationFrame(animate);
+    const dt = Math.min(clock.getDelta(), 0.1);
+    if (playing && traveled < totalLength) {
+      traveled = Math.min(traveled + baseSpeed * speedMul * dt, totalLength);
+      if (traveled >= totalLength) {
+        playing = false;
+        els.playpause.textContent = "↻";
+      }
+    }
+    const u = totalLength > 0 ? traveled / totalLength : 0;
+    const busPos = placeAt(u);
+    updateStopBanner(busPos);
+    minimap.update(RP.metersToLonLat({ x: busPos.x, z: busPos.z }, origin));
+    els.progress.style.width = `${(u * 100).toFixed(1)}%`;
+    renderer.render(scene, camera);
+  }
+  animate();
+}
+
+main();

--- a/static/js/ride/three-ride.js
+++ b/static/js/ride/three-ride.js
@@ -14,6 +14,10 @@ const els = {
   speed: document.getElementById("speed"),
   speedVal: document.getElementById("speed-val"),
   progress: document.getElementById("progress-bar"),
+  progressWrap: document.getElementById("progress-wrap"),
+  toggleStops: document.getElementById("toggle-stops"),
+  toggleMinimap: document.getElementById("toggle-minimap"),
+  minimap: document.getElementById("minimap"),
 };
 
 function showError(msg) {
@@ -309,8 +313,10 @@ async function main() {
   const baseSpeed = totalLength / TARGET_DURATION; // m/s
   let traveled = 0;
   let playing = true;
-  let speedMul = 1;
+  let speedMul = 0.1;
   let lastStop = null;
+  let stopsVisible = true;
+  let scrubbing = false;
 
   function placeAt(u) {
     const clamped = Math.min(Math.max(u, 0), 1);
@@ -329,6 +335,7 @@ async function main() {
   }
 
   function updateStopBanner(busPos) {
+    if (!stopsVisible) return;
     let nearest = null;
     let best = 70; // metres
     for (const s of stopPositions) {
@@ -374,6 +381,56 @@ async function main() {
     speedMul = parseFloat(els.speed.value);
     els.speedVal.textContent = `${speedMul}×`;
   });
+  els.toggleStops.addEventListener("click", () => {
+    stopsVisible = !stopsVisible;
+    stopGroup.visible = stopsVisible;
+    els.toggleStops.classList.toggle("active", stopsVisible);
+    els.toggleStops.setAttribute("aria-pressed", String(stopsVisible));
+    if (!stopsVisible) {
+      lastStop = null;
+      els.banner.classList.remove("show");
+    }
+  });
+  els.toggleMinimap.addEventListener("click", () => {
+    const visible = els.minimap.classList.toggle("hidden") === false;
+    els.toggleMinimap.classList.toggle("active", visible);
+    els.toggleMinimap.setAttribute("aria-pressed", String(visible));
+  });
+
+  // Scrub: click or drag along the progress bar to jump anywhere in the ride.
+  function scrubTo(clientX) {
+    const rect = els.progressWrap.getBoundingClientRect();
+    const f = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width));
+    traveled = f * totalLength;
+    els.progress.style.width = `${(f * 100).toFixed(1)}%`;
+    // Leaving the end clears the "replay" state so the icon reflects play/pause.
+    if (traveled < totalLength) {
+      els.playpause.textContent = playing ? "⏸" : "▶";
+    }
+    const busPos = placeAt(f);
+    updateStopBanner(busPos);
+    minimap.update(RP.metersToLonLat({ x: busPos.x, z: busPos.z }, origin));
+  }
+  els.progressWrap.addEventListener("pointerdown", (e) => {
+    scrubbing = true;
+    els.progressWrap.setPointerCapture(e.pointerId);
+    scrubTo(e.clientX);
+  });
+  els.progressWrap.addEventListener("pointermove", (e) => {
+    if (scrubbing) scrubTo(e.clientX);
+  });
+  const endScrub = (e) => {
+    if (!scrubbing) return;
+    scrubbing = false;
+    try {
+      els.progressWrap.releasePointerCapture(e.pointerId);
+    } catch (_) {
+      /* pointer already released */
+    }
+  };
+  els.progressWrap.addEventListener("pointerup", endScrub);
+  els.progressWrap.addEventListener("pointercancel", endScrub);
+
   window.addEventListener("resize", () => {
     camera.aspect = window.innerWidth / window.innerHeight;
     camera.updateProjectionMatrix();
@@ -384,7 +441,7 @@ async function main() {
   function animate() {
     requestAnimationFrame(animate);
     const dt = Math.min(clock.getDelta(), 0.1);
-    if (playing && traveled < totalLength) {
+    if (playing && !scrubbing && traveled < totalLength) {
       traveled = Math.min(traveled + baseSpeed * speedMul * dt, totalLength);
       if (traveled >= totalLength) {
         playing = false;

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,6 +56,9 @@
               <option value="dark">Dark</option>
             </select>
           </li>
+          <li>
+            <a href="#" data-toggle="modal" data-target="#rideModal">🚌 3D Ride</a>
+          </li>
         </ul>
       </div>
     </nav>
@@ -94,6 +97,39 @@
       </footer>
     </div>
 
+    <!-- 3D Ride-Along route chooser -->
+    <div class="modal fade" id="rideModal" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">
+              &times;
+            </button>
+            <h4 class="modal-title">🚌 3D Ride-Along</h4>
+          </div>
+          <div class="modal-body">
+            <p>
+              Pick a route and ride it in 3D — sit back as the bus drives the
+              real route. Two engines to compare:
+            </p>
+            <select id="rideRouteSelect" class="form-control"></select>
+            <p style="margin-top: 10px; color: #888; font-size: 12px">
+              Three.js = game-style 3D bus &amp; chase cam · MapLibre = real map
+              tilted on the ground. Numbered routes only for now.
+            </p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" id="rideThreeBtn">
+              Ride · Three.js
+            </button>
+            <button type="button" class="btn btn-info" id="rideMaplibreBtn">
+              Ride · MapLibre
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/offcanvas.js') }}"></script>
     <script src="{{ url_for('static', filename='js/config.js') }}"></script>
@@ -102,5 +138,6 @@
     <script src="{{ url_for('static', filename='js/route-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/info-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/launcher.js') }}"></script>
   </body>
 </html>

--- a/templates/ride_maplibre.html
+++ b/templates/ride_maplibre.html
@@ -50,10 +50,12 @@
 
     <div id="ride-controls">
       <button id="playpause" title="Play/Pause">⏸</button>
+      <button id="toggle-stops" class="toggle-btn active" title="Show/hide stops" aria-pressed="true">🚏 Stops</button>
+      <button id="toggle-minimap" class="toggle-btn active" title="Show/hide minimap" aria-pressed="true">🗺 Map</button>
       <div class="speed">
         <span>Speed</span>
-        <input id="speed" type="range" min="0.25" max="4" step="0.25" value="1" />
-        <span id="speed-val">1×</span>
+        <input id="speed" type="range" min="0.1" max="4" step="0.05" value="0.1" />
+        <span id="speed-val">0.1×</span>
       </div>
       <div id="progress-wrap"><div id="progress-bar"></div></div>
     </div>

--- a/templates/ride_maplibre.html
+++ b/templates/ride_maplibre.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>3D Ride · MapLibre</title>
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/ride.css') }}"
+    />
+    <style>
+      /* simple top-down bus marker (map rotates so travel dir is "up") */
+      .bus-marker {
+        width: 16px;
+        height: 30px;
+        border-radius: 4px;
+        border: 2px solid #fff;
+        box-shadow: 0 0 6px rgba(0, 0, 0, 0.5);
+        position: relative;
+      }
+      .bus-marker::after {
+        content: "";
+        position: absolute;
+        top: 3px;
+        left: 2px;
+        right: 2px;
+        height: 6px;
+        background: rgba(255, 255, 255, 0.7);
+        border-radius: 2px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="map"></div>
+
+    <div id="ride-topbar">
+      <span class="route-title" id="route-title">Loading…</span>
+      <span class="engine-badge">MapLibre</span>
+      <span class="spacer"></span>
+      <a id="exit" href="/">✕ Exit</a>
+    </div>
+
+    <div id="stop-banner"></div>
+    <div id="minimap"></div>
+
+    <div id="ride-controls">
+      <button id="playpause" title="Play/Pause">⏸</button>
+      <div class="speed">
+        <span>Speed</span>
+        <input id="speed" type="range" min="0.25" max="4" step="0.25" value="1" />
+        <span id="speed-val">1×</span>
+      </div>
+      <div id="progress-wrap"><div id="progress-bar"></div></div>
+    </div>
+
+    <div id="ride-status">
+      <div>Preparing your ride…</div>
+      <div class="sub" id="ride-status-sub">Loading route & map</div>
+    </div>
+
+    <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
+    <script src="https://unpkg.com/@turf/turf@7.1.0/turf.min.js"></script>
+    <script src="{{ url_for('static', filename='js/config.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/route-path.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/minimap.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/maplibre-ride.js') }}"></script>
+  </body>
+</html>

--- a/templates/ride_three.html
+++ b/templates/ride_three.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>3D Ride · Three.js</title>
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/ride.css') }}"
+    />
+  </head>
+  <body>
+    <canvas id="scene"></canvas>
+
+    <div id="ride-topbar">
+      <span class="route-title" id="route-title">Loading…</span>
+      <span class="engine-badge">Three.js</span>
+      <span class="spacer"></span>
+      <a id="exit" href="/">✕ Exit</a>
+    </div>
+
+    <div id="stop-banner"></div>
+    <div id="minimap"></div>
+
+    <div id="ride-controls">
+      <button id="playpause" title="Play/Pause">⏸</button>
+      <div class="speed">
+        <span>Speed</span>
+        <input id="speed" type="range" min="0.25" max="4" step="0.25" value="1" />
+        <span id="speed-val">1×</span>
+      </div>
+      <div id="progress-wrap"><div id="progress-bar"></div></div>
+    </div>
+
+    <div id="ride-status">
+      <div>Preparing your ride…</div>
+      <div class="sub" id="ride-status-sub">Loading route & map tiles</div>
+    </div>
+
+    <!-- Shared config (ROUTE_COLORS) + geometry helper, then the ES module -->
+    <script src="{{ url_for('static', filename='js/config.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/route-path.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/minimap.js') }}"></script>
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js"
+        }
+      }
+    </script>
+    <script
+      type="module"
+      src="{{ url_for('static', filename='js/ride/three-ride.js') }}"
+    ></script>
+  </body>
+</html>

--- a/templates/ride_three.html
+++ b/templates/ride_three.html
@@ -25,10 +25,12 @@
 
     <div id="ride-controls">
       <button id="playpause" title="Play/Pause">⏸</button>
+      <button id="toggle-stops" class="toggle-btn active" title="Show/hide stops" aria-pressed="true">🚏 Stops</button>
+      <button id="toggle-minimap" class="toggle-btn active" title="Show/hide minimap" aria-pressed="true">🗺 Map</button>
       <div class="speed">
         <span>Speed</span>
-        <input id="speed" type="range" min="0.25" max="4" step="0.25" value="1" />
-        <span id="speed-val">1×</span>
+        <input id="speed" type="range" min="0.1" max="4" step="0.05" value="0.1" />
+        <span id="speed-val">0.1×</span>
       </div>
       <div id="progress-wrap"><div id="progress-bar"></div></div>
     </div>


### PR DESCRIPTION
## Summary
Adds a 3D "ride the route" experience: pick a route and ride it as a bus drives the path, in either of two engines (Three.js or MapLibre), with a live OSM minimap, on-screen controls, and a journey scrubber.

## What's included
**Ride modes**
- Three.js ride — chase cam following a procedural bus over OSM-textured ground.
- MapLibre ride — tilted real OSM map chasing a bus marker; stops rendered as a circle layer.
- Route chooser modal on the main map launches either engine (same tab).

**Backend (app.py)**
- `/ride/three` and `/ride/maplibre` pages.
- `/data/route-geometry/<file>` parses route KML into JSON (drive segments, named stops, bounds), using defusedxml (XXE guard) with path-traversal protection.

**Controls & HUD**
- Play/pause, speed slider (down to 0.1x, defaults to slowest).
- Stops toggle and minimap show/hide toggle in both rides.
- Scrubbable progress bar — click/drag to jump anywhere in the ride.

**Minimap**
- Real OSM slippy map: re-fetches higher-zoom tiles per visible window (centered on the bus) so zoom stays sharp at any level.
- Fixed z7–z19 range, default z15, with +/- and a reset-zoom button.
- Route line and bus arrow drawn at constant on-screen size; tile cache + retina rendering.

## Notes
Uses only free, keyless resources (OSM tiles + Three.js/MapLibre/Turf via public CDNs) — no API keys or billable services. A public, at-scale deployment should move off OSM's public tile servers per their tile usage policy.

## Test plan
- [ ] Main map → "🚌 3D Ride" → pick a numbered route.
- [ ] Launch each engine; confirm it opens in the same tab and the bus drives the route.
- [ ] Toggle stops and minimap; scrub the progress bar; change speed.
- [ ] Zoom the minimap in/out; tiles stay sharp; reset button returns to z15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)