### PR TITLE
Make shipped routes read-only; add copy-to-my-routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -504,8 +504,13 @@ def save_edit(filename):
     year = _resolve_year(request.args.get("year"))
     is_geojson = filename.lower().endswith(".geojson")
     finder = _find_geojson if is_geojson else _find_kml
-    # Allow editing a shipped route OR an existing user-created (DB-only) route.
-    if not finder(filename, year) and db.latest_version(year, filename) is None:
+    # Shipped routes are read-only — they can only be copied into a user route.
+    # Editing is allowed only for user-created (DB-only, no shipped file) routes.
+    if finder(filename, year):
+        return jsonify(
+            {"error": "shipped routes are read-only; copy it to your routes to edit"}
+        ), 403
+    if db.latest_version(year, filename) is None:
         return jsonify({"error": "Route not found"}), 404
     payload = request.get_json(silent=True)
     geom, err = _validate_geometry(payload)

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -207,7 +207,8 @@ body.editing #sidebar {
 
 .route-edit-btn,
 .route-ride-btn,
-.route-del-btn {
+.route-del-btn,
+.route-copy-btn {
   flex: 0 0 auto;
   margin-left: 6px;
   text-decoration: none;
@@ -217,7 +218,8 @@ body.editing #sidebar {
 }
 .route-edit-btn:hover,
 .route-ride-btn:hover,
-.route-del-btn:hover {
+.route-del-btn:hover,
+.route-copy-btn:hover {
   opacity: 1;
 }
 .route-del-btn {

--- a/static/js/config.js
+++ b/static/js/config.js
@@ -44,6 +44,11 @@ APP.MAP_STYLES = {
   },
 };
 
+// Dataset year that owns user-created/editable routes. Shipped routes from
+// other years are read-only and can only be copied into this year for editing.
+// Must match USER_ROUTE_YEAR in app.py.
+APP.USER_ROUTE_YEAR = "2026";
+
 // Distinct colors assigned per route so overlapping routes are
 // visually distinguishable. Cycled by route index; the palette is
 // ordered so adjacent routes get well-separated hues.

--- a/static/js/editor-manager.js
+++ b/static/js/editor-manager.js
@@ -50,6 +50,18 @@ APP.EditorManager = class {
       );
     });
 
+    // Copy a read-only shipped route into a new editable user route.
+    $("#routes").on("click", ".route-copy-btn", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const el = $(e.currentTarget);
+      this.copyToUserRoute(
+        el.attr("data-file"),
+        el.attr("data-kind") || "kml",
+        el.attr("data-year")
+      );
+    });
+
     // Toolbar buttons.
     const t = (sel, fn) => $(sel).on("click", (e) => { e.preventDefault(); fn(); });
     t("#newRouteBtn", () => this.createNew());
@@ -118,7 +130,8 @@ APP.EditorManager = class {
     this.active = true;
     this.file = null;
     this.kind = "kml";
-    this.year = "2026"; // new routes are created only for 2026 (enforced server-side)
+    // New routes are created only for the user-route year (enforced server-side).
+    this.year = APP.USER_ROUTE_YEAR;
     this.creating = true;
     this.isUserRoute = true;
     this.routeName = name.trim() || "New route";
@@ -139,6 +152,52 @@ APP.EditorManager = class {
     this._updateButtons();
     this.setTool("drawline");
     this._flash("Draw the route line, then Save");
+  }
+
+  /**
+   * Duplicate a read-only shipped route into a new editable user route (in the
+   * user-route year), then open the copy for editing. The geometry copied is
+   * whatever is currently served for the route (any DB overlay, else on-disk).
+   */
+  copyToUserRoute(file, kind, year) {
+    if (!file) return;
+    if (this.active) {
+      if (!confirm("Finish the current edit first? Unsaved changes will be lost.")) {
+        return;
+      }
+      this.exit();
+    }
+    const q = `?year=${encodeURIComponent(year)}`;
+    fetch(`/data/route-geometry/${encodeURIComponent(file)}${q}`)
+      .then((r) => r.json())
+      .then((geo) => {
+        const segments = geo.segments || [];
+        if (!segments.length) {
+          alert("This layer has no route line to copy.");
+          return;
+        }
+        const baseName = geo.name || file.replace(/\.(kml|geojson)$/, "");
+        const body = { segments, stops: geo.stops || [], name: `${baseName} (copy)` };
+        const yr = APP.USER_ROUTE_YEAR;
+        return fetch(`/data/create?year=${encodeURIComponent(yr)}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        })
+          .then((r) => r.json().then((j) => ({ ok: r.ok, j })))
+          .then(({ ok, j }) => {
+            if (!ok) throw new Error(j.error || "copy failed");
+            this.routeManager.addUserRouteRow(yr, j.filename, body.name);
+            this.routeManager.reloadRoute(yr, j.filename, "kml");
+            // Open the editable copy straight away — that's the point of copying.
+            this.enter(j.filename, "kml", yr);
+            this._flash("Copied to your routes");
+          });
+      })
+      .catch((err) => {
+        APP.MapUtils.handleError(err, "Copying route");
+        alert("Copy failed: " + err.message);
+      });
   }
 
   exit() {

--- a/static/js/route-manager.js
+++ b/static/js/route-manager.js
@@ -215,12 +215,19 @@ APP.RouteManager = class {
       "data-year": meta.year,
     };
     label.append(input).append(swatch).append(name);
-    if (!NON_ROUTE.test(meta.file)) {
+    const isRouteLike = !NON_ROUTE.test(meta.file);
+    if (isRouteLike) {
       label.append($('<a class="route-ride-btn" title="3D ride">🚌</a>').attr(attrs));
     }
-    label.append($('<a class="route-edit-btn" title="Edit">✎</a>').attr(attrs));
     if (isUser) {
+      // Only the user's own routes are editable.
+      label.append($('<a class="route-edit-btn" title="Edit">✎</a>').attr(attrs));
       label.append($('<a class="route-del-btn" title="Delete route">✕</a>').attr(attrs));
+    } else if (isRouteLike && this.canCreateUserRoutes) {
+      // Shipped routes are read-only — offer to copy into an editable route.
+      label.append(
+        $('<a class="route-copy-btn" title="Copy to my routes">📋</a>').attr(attrs)
+      );
     }
     return label;
   }
@@ -232,6 +239,9 @@ APP.RouteManager = class {
         const out = $("#routes").empty();
         this.colors.clear();
         this.meta.clear();
+        // Copy/create is only possible when the user-route dataset exists.
+        this.canCreateUserRoutes =
+          (cat.years || []).indexOf(APP.USER_ROUTE_YEAR) >= 0;
         const palette = APP.ROUTE_COLORS;
         let i = 0;
         const header = (text) =>
@@ -259,7 +269,7 @@ APP.RouteManager = class {
           const d = cat[year] || {};
           const names = d.names || {};
           if (d.routes && d.routes.length) {
-            header(`${year} · Routes`);
+            header(`${year} · Routes (kml)`);
             d.routes.forEach((f) => addRow(year, f, "kml", false, names));
           }
           if (d.geojson && d.geojson.length) {
@@ -267,8 +277,8 @@ APP.RouteManager = class {
             d.geojson.forEach((f) => addRow(year, f, "geojson", false, names));
           }
         });
-        // New-route creation is only offered when the 2026 dataset exists.
-        $("#newRouteBtn").toggle((cat.years || []).indexOf("2026") >= 0);
+        // New-route creation is only offered when the user-route dataset exists.
+        $("#newRouteBtn").toggle(this.canCreateUserRoutes);
       })
       .catch((e) => APP.MapUtils.handleError(e, "Loading catalog"));
   }


### PR DESCRIPTION
Shipped routes (2016 KML + GeoJSON) are no longer editable in place. Their per-row pencil is replaced with a 📋 copy button that duplicates the route geometry into a new editable user route (in the user-route year) and opens it for editing. User-created routes keep edit + delete.

`POST /data/edit` now rejects shipped routes (403) as defense in depth, so the read-only rule holds even against a direct API call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)