### PR TITLE
Tidy ride HUD + minimal in-credit music player

### DIFF
--- a/static/css/ride.css
+++ b/static/css/ride.css
@@ -65,10 +65,10 @@ body {
   background: rgba(0, 0, 0, 0.7);
 }
 
-/* Minimap overlay (bottom-right, above the control bar) */
+/* Minimap overlay (bottom-right, clear above the control bar) */
 #minimap {
   position: absolute;
-  bottom: 72px;
+  bottom: 112px;
   right: 12px;
   width: 180px;
   height: 180px;
@@ -189,12 +189,15 @@ body {
   color: #ffd166;
 }
 
-/* Now-playing music attribution (bottom-left; required for CC-BY tracks) */
+/* Now-playing music pill (bottom-left): minimal controls + CC-BY attribution */
 #music-credit {
   position: absolute;
   left: 12px;
-  bottom: 84px; /* clear the bottom control bar */
-  max-width: 40vw;
+  bottom: 104px; /* clear the bottom control bar */
+  max-width: 46vw;
+  display: flex;
+  align-items: center;
+  gap: 6px;
   padding: 4px 10px;
   background: rgba(20, 20, 24, 0.6);
   border-radius: 8px;
@@ -202,20 +205,85 @@ body {
   font-size: 11px;
   line-height: 1.3;
   z-index: 10;
-  pointer-events: none;
   opacity: 0;
   transition: opacity 0.25s ease;
 }
 #music-credit.show {
   opacity: 1;
 }
+/* Don't capture clicks while hidden. */
+#music-credit:not(.show) {
+  pointer-events: none;
+}
+/* Pre-interaction prompt: invite the rider to start the (muted) music. */
+#music-credit.hint {
+  cursor: pointer;
+  background: rgba(20, 20, 24, 0.82);
+  animation: music-hint-pulse 1.6s ease-in-out infinite;
+}
+@keyframes music-hint-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 209, 102, 0);
+  }
+  50% {
+    box-shadow: 0 0 0 3px rgba(255, 209, 102, 0.4);
+  }
+}
+#music-credit .mc-btn {
+  flex: 0 0 auto;
+  background: transparent;
+  border: none;
+  padding: 0 1px;
+  color: #fff;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+}
+#music-credit .mc-btn:active {
+  transform: scale(0.92);
+}
+#music-credit .mc-vol {
+  flex: 0 0 auto;
+  width: 60px;
+  height: 4px;
+  margin: 0 1px;
+  accent-color: #ffd166;
+  cursor: pointer;
+}
+#music-credit .mc-toggle {
+  font-size: 13px;
+  opacity: 0.6;
+}
+#music-credit .mc-toggle:hover {
+  opacity: 1;
+}
+/* Compact mode: keep just the mute button + the expander. */
+#music-credit.collapsed .mc-vol,
+#music-credit.collapsed #music-next,
+#music-credit.collapsed .mc-text {
+  display: none;
+}
+/* Keep the pre-interaction prompt clean: just the ▶ and the call-to-action. */
+#music-credit.hint .mc-vol,
+#music-credit.hint #music-next,
+#music-credit.hint .mc-toggle {
+  display: none;
+}
+#music-credit .mc-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-/* Bottom control bar */
+/* Bottom control bar: spans from the stop indicator's left edge (12px) to the
+   minimap's right edge (12px) — i.e. full width with matching side margins. */
 #ride-controls {
   position: absolute;
-  left: 50%;
-  bottom: 18px;
-  transform: translateX(-50%);
+  left: 12px;
+  right: 12px;
+  bottom: 40px; /* lifted clear of the OSM attribution in the bottom corners */
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   gap: 14px;
@@ -225,7 +293,6 @@ body {
   color: #fff;
   z-index: 10;
   box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
-  max-width: 92vw;
 }
 
 #ride-controls button {
@@ -264,61 +331,9 @@ body {
   white-space: nowrap;
 }
 
-/* Music: a single 🎵 button that pops up a compact control panel */
-#ride-controls .music-controls {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-#ride-controls .music-controls.open .toggle-btn {
-  outline: 2px solid rgba(255, 209, 102, 0.7);
-}
-#music-panel {
-  position: absolute;
-  bottom: calc(100% + 10px);
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 10px;
-  background: rgba(20, 20, 24, 0.95);
-  border-radius: 10px;
-  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.45);
-  z-index: 11;
-}
-#music-panel.hidden {
-  display: none;
-}
-/* Little pointer connecting the panel to the 🎵 button */
-#music-panel::after {
-  content: "";
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  border: 6px solid transparent;
-  border-top-color: rgba(20, 20, 24, 0.95);
-}
-#music-panel .mini-btn {
-  width: 32px;
-  font-size: 13px;
-}
-#music-panel input[type="range"] {
-  width: 78px;
-}
-#music-panel .vol-icon {
-  width: auto;
-  padding: 0 2px;
-  background: transparent;
-  color: #fff;
-  font-size: 16px;
-  line-height: 1;
-}
-
 #progress-wrap {
   position: relative;
-  width: 34vw;
+  flex: 1 1 auto; /* grow to fill the now full-width bar */
   min-width: 120px;
   height: 8px;
   background: rgba(255, 255, 255, 0.25);

--- a/static/js/ride/maplibre-ride.js
+++ b/static/js/ride/maplibre-ride.js
@@ -104,7 +104,7 @@
       pitch: 68,
       bearing: 0,
       interactive: false, // on-rails: the user doesn't control the view
-      attributionControl: { compact: true },
+      attributionControl: { compact: true }, // bottom-right
     });
 
     // Bus marker (top-down; map rotates so travel direction points up)

--- a/static/js/ride/ride-music.js
+++ b/static/js/ride/ride-music.js
@@ -1,12 +1,22 @@
 // Optional lo-fi background music for the ride-along, shared by both engines.
 // Tracks are whatever audio sits in static/audio (served via /data/ride-music).
-// Off by default — browsers block autoplay with sound until a user gesture, so
-// playback starts when the rider clicks the 🎵 Music toggle. Tracks loop as a
-// continuous playlist; the rider can skip tracks and set the volume, and the
-// per-track attribution (required for CC-BY music) shows while it plays.
+//
+// The controls are intentionally minimal and live inside the now-playing credit
+// pill (bottom-left): a mute toggle and a skip-track button, alongside the
+// track's attribution (required for the bundled CC-BY tracks).
+//
+// Autoplay: browsers only permit autoplay when muted, so we always start muted
+// the moment the ride loads, then restore the rider's real preference — fading
+// the sound in — on their first click/keypress/scroll. A rider who saved
+// "muted" simply stays silent.
+//
+// Settings persist across rides in localStorage: the volume level and the mute
+// state — so if you muted the music last time, it stays muted next time.
 window.APP = window.APP || {};
 
 const VOLUME_KEY = "ride.musicVolume";
+const MUTED_KEY = "ride.musicMuted";
+const COLLAPSED_KEY = "ride.musicCollapsed";
 
 APP.RideMusic = class {
   /**
@@ -15,76 +25,188 @@ APP.RideMusic = class {
   constructor(tracks) {
     this.tracks = (tracks || []).filter((t) => t && t.src);
     this.playing = false;
-    this.muted = false;
+    // While true, audio is held silent (post-autoplay) until the first gesture.
+    this._pendingUnmute = false;
+    this._fadeToken = 0;
     // Vary the opening track so repeated rides don't always start the same.
     this.idx = this.tracks.length
       ? Math.floor(Math.random() * this.tracks.length)
       : 0;
 
-    // Control elements (all optional; degrade gracefully if absent).
-    this.group = document.getElementById("music-controls");
-    this.button = document.getElementById("toggle-music"); // opens the panel
-    this.panel = document.getElementById("music-panel");
-    this.playBtn = document.getElementById("music-playpause");
-    this.prevBtn = document.getElementById("music-prev");
-    this.nextBtn = document.getElementById("music-next");
-    this.muteBtn = document.getElementById("music-mute");
-    this.volInput = document.getElementById("music-volume");
+    // Control elements (the credit pill is also the control surface).
     this.creditEl = document.getElementById("music-credit");
+    this.creditTextEl = document.getElementById("music-credit-text");
+    this.muteBtn = document.getElementById("music-mute");
+    this.nextBtn = document.getElementById("music-next");
+    this.volInput = document.getElementById("music-volume");
+    this.toggleBtn = document.getElementById("music-toggle");
 
-    // No tracks → hide the whole music cluster and bail.
+    // No tracks → hide the pill and bail.
     if (!this.tracks.length) {
-      if (this.group) this.group.style.display = "none";
+      if (this.creditEl) this.creditEl.style.display = "none";
       return;
     }
 
+    // Restore remembered settings.
     this.volume = this._loadVolume();
+    this.muted = this._loadMuted();
+
     this.audio = new Audio();
     this.audio.preload = "none";
     this.audio.volume = this.volume;
+    this.audio.muted = this.muted;
     // Single track loops on its own; multiple tracks advance as a playlist.
     this.audio.loop = this.tracks.length === 1;
     this.audio.addEventListener("ended", () => this._next());
 
+    this.collapsed = this._loadCollapsed();
+    this._applyCollapsed();
+
     this._wire();
     this._reflectVolume();
+    this._autostart();
   }
 
   _wire() {
-    // The 🎵 button opens/closes the popover; playback lives inside it.
-    if (this.button)
-      this.button.addEventListener("click", (e) => {
-        e.stopPropagation();
-        this.togglePanel();
-      });
-    if (this.playBtn) this.playBtn.addEventListener("click", () => this.toggle());
-    if (this.prevBtn) this.prevBtn.addEventListener("click", () => this.skip(-1));
-    if (this.nextBtn) this.nextBtn.addEventListener("click", () => this.skip(1));
+    // While waiting for the first interaction the buttons (and the pill itself)
+    // act as "start playback"; afterwards they're the normal mute/skip controls.
     if (this.muteBtn)
-      this.muteBtn.addEventListener("click", () => this.toggleMute());
-    if (this.volInput) {
-      this.volInput.value = String(Math.round(this.volume * 100));
-      this.volInput.addEventListener("input", () =>
-        this.setVolume(parseInt(this.volInput.value, 10) / 100)
+      this.muteBtn.addEventListener("click", () =>
+        this._pendingUnmute ? this._resolvePending() : this.toggleMute()
+      );
+    if (this.nextBtn) {
+      if (this.tracks.length < 2) this.nextBtn.style.display = "none";
+      this.nextBtn.addEventListener("click", () =>
+        this._pendingUnmute ? this._resolvePending() : this.skip(1)
       );
     }
-    // Click outside the cluster closes the panel.
-    document.addEventListener("click", (e) => {
-      if (this.group && !this.group.contains(e.target)) this.openPanel(false);
-    });
+    if (this.volInput)
+      this.volInput.addEventListener("input", () => {
+        if (this._pendingUnmute) this._resolvePending();
+        this.setVolume(parseInt(this.volInput.value, 10) / 100);
+      });
+    if (this.toggleBtn)
+      this.toggleBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.toggleCollapsed();
+      });
+    if (this.creditEl)
+      this.creditEl.addEventListener("click", () => {
+        if (this._pendingUnmute) this._resolvePending();
+      });
   }
 
-  // --- panel -----------------------------------------------------------------
+  // --- collapse / compact ----------------------------------------------------
 
-  openPanel(open) {
-    if (!this.panel) return;
-    this.panel.classList.toggle("hidden", !open);
-    if (this.group) this.group.classList.toggle("open", open);
-    if (this.button) this.button.setAttribute("aria-expanded", String(open));
+  toggleCollapsed() {
+    this.collapsed = !this.collapsed;
+    this._applyCollapsed();
+    try {
+      localStorage.setItem(COLLAPSED_KEY, this.collapsed ? "1" : "0");
+    } catch (_) {
+      /* ignore */
+    }
   }
 
-  togglePanel() {
-    this.openPanel(this.panel ? this.panel.classList.contains("hidden") : false);
+  _applyCollapsed() {
+    if (this.creditEl) this.creditEl.classList.toggle("collapsed", this.collapsed);
+    if (this.toggleBtn) {
+      this.toggleBtn.textContent = this.collapsed ? "›" : "‹";
+      this.toggleBtn.title = this.collapsed ? "Show music player" : "Collapse";
+    }
+  }
+
+  _loadCollapsed() {
+    try {
+      return localStorage.getItem(COLLAPSED_KEY) === "1";
+    } catch (_) {
+      return false;
+    }
+  }
+
+  // --- autoplay --------------------------------------------------------------
+
+  _autostart() {
+    this._load();
+    // Force a silent start so the browser permits autoplay.
+    this.audio.muted = true;
+    this.audio.volume = this.volume;
+    this.audio.play().then(
+      () => {
+        this.playing = true;
+        if (!this.muted) {
+          // Rider wants sound — hold silent and prompt for the first gesture.
+          this._pendingUnmute = true;
+          this.audio.volume = 0;
+          this._armFirstGesture();
+        }
+        this._reflectVolume();
+        this._showCredit();
+      },
+      () => {
+        // Even muted autoplay was refused (rare) — start on the first gesture.
+        this.playing = false;
+        this._showCredit();
+        const once = () => {
+          document.removeEventListener("pointerdown", once);
+          document.removeEventListener("keydown", once);
+          this._play();
+        };
+        document.addEventListener("pointerdown", once, { passive: true });
+        document.addEventListener("keydown", once, { passive: true });
+      }
+    );
+  }
+
+  /** Listen (once) for the rider's first off-pill interaction. */
+  _armFirstGesture() {
+    const events = ["pointerdown", "keydown", "wheel", "touchstart"];
+    const handler = (e) => {
+      // Clicks on the pill are handled by its own controls.
+      if (e.type !== "keydown" && this.creditEl && this.creditEl.contains(e.target)) {
+        return;
+      }
+      this._resolvePending();
+    };
+    this._firstGestureEvents = events;
+    this._firstGestureHandler = handler;
+    events.forEach((ev) =>
+      document.addEventListener(ev, handler, { passive: true })
+    );
+  }
+
+  _removeFirstGesture() {
+    if (!this._firstGestureHandler) return;
+    this._firstGestureEvents.forEach((ev) =>
+      document.removeEventListener(ev, this._firstGestureHandler)
+    );
+    this._firstGestureHandler = null;
+  }
+
+  /** First interaction: bring the sound in (fading), or honor a saved mute. */
+  _resolvePending() {
+    if (!this._pendingUnmute) return;
+    this._pendingUnmute = false;
+    this._removeFirstGesture();
+    this._reflectVolume();
+    if (this.muted) {
+      this._applyAudio(); // stays muted by preference
+      this._showCredit();
+      return;
+    }
+    this.audio.muted = false;
+    const target = this.volume;
+    const token = ++this._fadeToken;
+    this.audio.volume = 0;
+    const t0 = performance.now();
+    const step = (t) => {
+      if (token !== this._fadeToken) return; // superseded by a manual change
+      const k = Math.min(1, (t - t0) / 800);
+      this.audio.volume = target * k;
+      if (k < 1) requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+    this._showCredit();
   }
 
   // --- playback --------------------------------------------------------------
@@ -93,32 +215,27 @@ APP.RideMusic = class {
     this.audio.src = this.tracks[this.idx].src;
   }
 
+  _applyAudio() {
+    if (!this.audio) return;
+    this._fadeToken++; // cancel any in-flight fade-in
+    this.audio.volume = this.volume;
+    // Stay silent while a track is auto-playing pre-interaction.
+    this.audio.muted = this.muted || this._pendingUnmute;
+  }
+
   _play() {
     if (!this.audio.src) this._load();
-    // play() rejects if no gesture was registered — revert the UI then.
+    this._applyAudio();
     return this.audio.play().then(
       () => {
         this.playing = true;
-        this._reflect();
         this._showCredit();
       },
       () => {
         this.playing = false;
-        this._reflect();
         this._showCredit();
       }
     );
-  }
-
-  toggle() {
-    if (this.playing) {
-      this.audio.pause();
-      this.playing = false;
-      this._reflect();
-      this._showCredit();
-    } else {
-      this._play();
-    }
   }
 
   /** Move to another track. dir = +1 (next) / -1 (previous). */
@@ -128,33 +245,31 @@ APP.RideMusic = class {
     this.idx = (this.idx + dir + n) % n;
     this._load();
     if (this.playing) this._play();
-    else this._showCredit(); // brief peek at the now-selected track
+    else this._showCredit();
   }
 
   _next() {
     this.skip(1);
   }
 
-  // --- volume / mute ---------------------------------------------------------
+  // --- mute (the only volume control, kept minimal) --------------------------
 
   setVolume(v) {
     this.volume = Math.min(1, Math.max(0, v));
+    // Dragging to zero mutes; dragging up unmutes.
     this.muted = this.volume === 0;
-    if (this.audio) this.audio.volume = this.volume;
-    this._saveVolume(this.volume);
+    this._applyAudio();
+    this._save();
     this._reflectVolume();
   }
 
   toggleMute() {
-    if (this.muted || this.volume === 0) {
-      // Unmute to the previous level (or a sensible default).
-      this.setVolume(this._preMuteVolume || 0.5);
-    } else {
-      this._preMuteVolume = this.volume;
-      this.muted = true;
-      if (this.audio) this.audio.volume = 0;
-      this._reflectVolume();
-    }
+    this.muted = !this.muted;
+    // Unmuting needs an audible level to come back to.
+    if (!this.muted && this.volume === 0) this.volume = 0.5;
+    this._applyAudio();
+    this._save();
+    this._reflectVolume();
   }
 
   _loadVolume() {
@@ -167,9 +282,18 @@ APP.RideMusic = class {
     return 0.5;
   }
 
-  _saveVolume(v) {
+  _loadMuted() {
     try {
-      localStorage.setItem(VOLUME_KEY, String(v));
+      return localStorage.getItem(MUTED_KEY) === "1";
+    } catch (_) {
+      return false;
+    }
+  }
+
+  _save() {
+    try {
+      localStorage.setItem(VOLUME_KEY, String(this.volume));
+      localStorage.setItem(MUTED_KEY, this.muted ? "1" : "0");
     } catch (_) {
       /* ignore */
     }
@@ -178,13 +302,17 @@ APP.RideMusic = class {
   // --- UI --------------------------------------------------------------------
 
   _reflectVolume() {
-    const effective = this.muted ? 0 : this.volume;
-    if (this.volInput) this.volInput.value = String(Math.round(effective * 100));
-    if (this.muteBtn) {
-      const icon = effective === 0 ? "🔇" : effective < 0.5 ? "🔈" : "🔊";
-      this.muteBtn.textContent = icon;
-      this.muteBtn.title = effective === 0 ? "Unmute" : "Mute";
+    const shown = this.muted ? 0 : this.volume;
+    if (this.volInput) this.volInput.value = String(Math.round(shown * 100));
+    if (!this.muteBtn) return;
+    if (this._pendingUnmute) {
+      // Pre-interaction: invite the rider to start it.
+      this.muteBtn.textContent = "▶";
+      this.muteBtn.title = "Click to play music";
+      return;
     }
+    this.muteBtn.textContent = shown === 0 ? "🔇" : shown < 0.5 ? "🔈" : "🔊";
+    this.muteBtn.title = this.muted ? "Unmute" : "Mute";
   }
 
   /** Format a credit object into an attribution line. */
@@ -196,32 +324,24 @@ APP.RideMusic = class {
     const tail = [c.license, c.source && `via ${c.source}`]
       .filter(Boolean)
       .join(", ");
-    return ["♪ Music:", who, tail && `(${tail})`].filter(Boolean).join(" ");
+    return [who, tail && `(${tail})`].filter(Boolean).join(" ");
   }
 
+  /** Show the credit pill (and its controls) whenever music is active. */
   _showCredit() {
     if (!this.creditEl) return;
-    const text = this.playing ? this._creditText(this.tracks[this.idx].credit) : "";
-    this.creditEl.textContent = text;
-    this.creditEl.classList.toggle("show", !!text);
-  }
-
-  _reflect() {
-    // The 🎵 button stays highlighted while music plays, even when the panel
-    // is closed, so playback state is visible at a glance.
-    if (this.button) {
-      this.button.classList.toggle("active", this.playing);
-      this.button.setAttribute("aria-pressed", String(this.playing));
-    }
-    if (this.playBtn) {
-      this.playBtn.textContent = this.playing ? "⏸" : "▶";
-      this.playBtn.title = this.playing ? "Pause" : "Play";
-    }
+    let text = "";
+    if (this._pendingUnmute) text = "Click to play music ♪";
+    else if (this.playing) text = this._creditText(this.tracks[this.idx].credit);
+    if (this.creditTextEl) this.creditTextEl.textContent = text;
+    const visible = this.playing || this._pendingUnmute;
+    this.creditEl.classList.toggle("show", visible);
+    this.creditEl.classList.toggle("hint", this._pendingUnmute);
   }
 };
 
 document.addEventListener("DOMContentLoaded", () => {
-  if (!document.getElementById("music-controls")) return;
+  if (!document.getElementById("music-credit")) return;
   fetch("/data/ride-music")
     .then((r) => r.json())
     .then((tracks) => new APP.RideMusic(tracks))

--- a/templates/ride_maplibre.html
+++ b/templates/ride_maplibre.html
@@ -59,22 +59,20 @@
     </div>
 
     <div id="minimap"></div>
-    <div id="music-credit"></div>
+
+    <!-- Minimal music controls live inside the now-playing credit pill. -->
+    <div id="music-credit">
+      <button id="music-mute" class="mc-btn" title="Mute">🔊</button>
+      <input id="music-volume" type="range" min="0" max="100" step="5" value="50" class="mc-vol" aria-label="Volume" />
+      <button id="music-next" class="mc-btn" title="Next track">⏭</button>
+      <span id="music-credit-text" class="mc-text"></span>
+      <button id="music-toggle" class="mc-btn mc-toggle" title="Collapse" aria-label="Collapse music player">‹</button>
+    </div>
 
     <div id="ride-controls">
       <button id="playpause" title="Play/Pause">⏸</button>
       <button id="toggle-stops" class="toggle-btn active" title="Show/hide stops" aria-pressed="true">🚏 Stops</button>
       <button id="toggle-minimap" class="toggle-btn active" title="Show/hide minimap" aria-pressed="true">🗺 Map</button>
-      <span id="music-controls" class="music-controls">
-        <button id="toggle-music" class="toggle-btn" title="Music" aria-pressed="false" aria-expanded="false">🎵 Music</button>
-        <div id="music-panel" class="music-panel hidden" role="group" aria-label="Music controls">
-          <button id="music-playpause" class="mini-btn" title="Play/Pause">▶</button>
-          <button id="music-prev" class="mini-btn" title="Previous track">⏮</button>
-          <button id="music-next" class="mini-btn" title="Next track">⏭</button>
-          <button id="music-mute" class="vol-icon" title="Mute">🔊</button>
-          <input id="music-volume" type="range" min="0" max="100" step="5" value="50" aria-label="Volume" />
-        </div>
-      </span>
       <div class="speed">
         <span>Speed</span>
         <input id="speed" type="range" min="10" max="120" step="5" value="40" />

--- a/templates/ride_three.html
+++ b/templates/ride_three.html
@@ -34,22 +34,20 @@
     </div>
 
     <div id="minimap"></div>
-    <div id="music-credit"></div>
+
+    <!-- Minimal music controls live inside the now-playing credit pill. -->
+    <div id="music-credit">
+      <button id="music-mute" class="mc-btn" title="Mute">🔊</button>
+      <input id="music-volume" type="range" min="0" max="100" step="5" value="50" class="mc-vol" aria-label="Volume" />
+      <button id="music-next" class="mc-btn" title="Next track">⏭</button>
+      <span id="music-credit-text" class="mc-text"></span>
+      <button id="music-toggle" class="mc-btn mc-toggle" title="Collapse" aria-label="Collapse music player">‹</button>
+    </div>
 
     <div id="ride-controls">
       <button id="playpause" title="Play/Pause">⏸</button>
       <button id="toggle-stops" class="toggle-btn active" title="Show/hide stops" aria-pressed="true">🚏 Stops</button>
       <button id="toggle-minimap" class="toggle-btn active" title="Show/hide minimap" aria-pressed="true">🗺 Map</button>
-      <span id="music-controls" class="music-controls">
-        <button id="toggle-music" class="toggle-btn" title="Music" aria-pressed="false" aria-expanded="false">🎵 Music</button>
-        <div id="music-panel" class="music-panel hidden" role="group" aria-label="Music controls">
-          <button id="music-playpause" class="mini-btn" title="Play/Pause">▶</button>
-          <button id="music-prev" class="mini-btn" title="Previous track">⏮</button>
-          <button id="music-next" class="mini-btn" title="Next track">⏭</button>
-          <button id="music-mute" class="vol-icon" title="Mute">🔊</button>
-          <input id="music-volume" type="range" min="0" max="100" step="5" value="50" aria-label="Volume" />
-        </div>
-      </span>
       <div class="speed">
         <span>Speed</span>
         <input id="speed" type="range" min="10" max="120" step="5" value="40" />


### PR DESCRIPTION
Tidies the 3D ride-along HUD and reworks the background music into a minimal player that lives in the now-playing credit pill.

### HUD layout
- Control bar lifted clear of the OpenStreetMap attribution and stretched edge-to-edge — its left edge matches the stop indicator, its right edge the minimap; the progress bar grows to fill.
- Minimap and music pill raised so nothing overlaps the bar.
- OSM attribution kept in the bottom-right (no longer covered).

### In-credit music player
- Removed the 🎵 button + popover from the control bar.
- The credit pill (bottom-left) now holds minimal controls: mute, a slim volume slider, skip, and a collapse toggle — alongside the CC-BY attribution.
- **Autoplay:** starts muted on load (browsers only permit muted autoplay), then fades the sound in on the rider's first interaction. A pulsing **"▶ Click to play music"** prompt makes that discoverable so it doesn't look broken.
- **Persistence:** volume, mute, and collapsed/compact state are remembered across rides (localStorage).

Applies to both the Three.js and MapLibre ride engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)