### PR TITLE
Add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Normalize line endings: store text as LF in the repo and check it out as LF
+# everywhere (keeps Windows clients from rewriting our source to CRLF).
+* text=auto eol=lf
+
+# Binary assets — never run EOL normalization on these.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mp3 binary
+*.ogg binary
+*.m4a binary
+*.wav binary
+*.db binary


### PR DESCRIPTION
Adds a `.gitattributes` so text files are stored and checked out as LF, stopping Windows clients from rewriting source to CRLF (silences the LF→CRLF warnings seen during recent commits). Binary assets (images, audio, the edits db) are marked `binary` to skip normalization.

`git add --renormalize .` touched nothing else — the repo's tracked files are already LF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)