### PR TITLE
Official stop-list signboard panel + per-route triage notes

### DIFF
--- a/app.py
+++ b/app.py
@@ -557,6 +557,30 @@ def stop_image(year, filename):
     return send_from_directory(os.path.dirname(path), os.path.basename(path))
 
 
+@app.route("/data/route-note")
+def get_route_note():
+    """Free-text triage note for a route, keyed by (year, route)."""
+    year = _resolve_year(request.args.get("year"))
+    route = (request.args.get("route") or "").strip()[:120]
+    if not route:
+        return jsonify({"error": "route required"}), 400
+    return jsonify({"year": year, "route": route, "note": db.get_note(year, route)})
+
+
+@app.route("/data/route-note", methods=["POST"])
+def save_route_note():
+    payload = request.get_json(silent=True) or {}
+    year = _resolve_year(payload.get("year"))
+    route = (payload.get("route") or "").strip()[:120]
+    note = payload.get("note", "")
+    if not route:
+        return jsonify({"error": "route required"}), 400
+    if not isinstance(note, str):
+        return jsonify({"error": "note must be a string"}), 400
+    saved = db.set_note(year, route, note[:10000])
+    return jsonify({"ok": True, "year": year, "route": route, "note": saved})
+
+
 @app.route("/data/edit/<path:filename>", methods=["POST"])
 def save_edit(filename):
     # Save a new edited version of a route's geometry into the SQLite store.

--- a/app.py
+++ b/app.py
@@ -98,6 +98,33 @@ def _find_geojson(filename, year=None):
     return None
 
 
+# Official JPD stop-list signboards live under docs/<year>/images/stops/ (outside
+# static/, so they need their own serving route). Resolved from this file's dir so
+# the working directory doesn't matter.
+DOCS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "docs")
+
+
+def _stop_images_dir(year):
+    return os.path.join(DOCS_DIR, year, "images", "stops")
+
+
+def _route_from_image(filename):
+    """Derive a route label from a signboard filename:
+    '20 [20150131].jpg' -> '20', '01A.jpg' -> '01A'."""
+    stem = os.path.splitext(filename)[0]
+    return re.split(r"\s*\[", stem)[0].strip()
+
+
+def _find_stop_image(year, filename):
+    """Locate a signboard image, rejecting path traversal / bad years."""
+    if not re.fullmatch(r"\d{4}", year or ""):
+        return None
+    if os.path.isabs(filename) or ".." in filename.replace("\\", "/").split("/"):
+        return None
+    path = os.path.join(_stop_images_dir(year), filename)
+    return path if os.path.isfile(path) else None
+
+
 def _localname(tag):
     """Strip the XML namespace from a tag, e.g. '{ns}LineString' -> 'LineString'."""
     return tag.rsplit("}", 1)[-1]
@@ -496,6 +523,37 @@ def serve_geojson(filename):
         geom = db.latest_geometry(year, filename)
         if geom is not None:
             return jsonify(geometry_to_geojson(geom))
+    return send_from_directory(os.path.dirname(path), os.path.basename(path))
+
+
+@app.route("/data/stop-images")
+def stop_images():
+    """Official JPD stop-list signboard images, grouped by year (newest first).
+    Used by the in-app reference panel while drawing/placing stops."""
+    out = {}
+    years = []
+    if os.path.isdir(DOCS_DIR):
+        year_dirs = (n for n in os.listdir(DOCS_DIR) if re.fullmatch(r"\d{4}", n))
+        for y in sorted(year_dirs, reverse=True):
+            d = _stop_images_dir(y)
+            if not os.path.isdir(d):
+                continue
+            imgs = sorted(
+                f for f in os.listdir(d)
+                if f.lower().endswith((".jpg", ".jpeg", ".png"))
+            )
+            if not imgs:
+                continue
+            years.append(y)
+            out[y] = [{"file": f, "route": _route_from_image(f)} for f in imgs]
+    return jsonify({"years": years, "images": out})
+
+
+@app.route("/data/stop-image/<year>/<path:filename>")
+def stop_image(year, filename):
+    path = _find_stop_image(year, filename)
+    if not path:
+        return "Stop image not found", 404
     return send_from_directory(os.path.dirname(path), os.path.basename(path))
 
 

--- a/db.py
+++ b/db.py
@@ -37,6 +37,19 @@ def init_db(db_path):
             ON route_versions (year, filename, version DESC)
             """
         )
+        # Free-text triage notes, one per route (year, route key). Independent of
+        # the version history above — notes are about a route, not a geometry edit.
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS route_notes (
+                year       TEXT NOT NULL,
+                route      TEXT NOT NULL,
+                note       TEXT NOT NULL DEFAULT '',
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (year, route)
+            )
+            """
+        )
 
 
 def _connect():
@@ -155,6 +168,32 @@ def add_version(year, filename, geometry, label=None):
             except sqlite3.IntegrityError:
                 continue
     raise sqlite3.IntegrityError("could not allocate a version number")
+
+
+def get_note(year, route):
+    """Free-text note for a route, or '' if none."""
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT note FROM route_notes WHERE year=? AND route=?",
+            (year, route),
+        ).fetchone()
+    return row["note"] if row else ""
+
+
+def set_note(year, route, note):
+    """Upsert a route's note. Returns the saved text."""
+    with _connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO route_notes (year, route, note, updated_at)
+            VALUES (?, ?, ?, datetime('now'))
+            ON CONFLICT(year, route) DO UPDATE SET
+                note = excluded.note, updated_at = excluded.updated_at
+            """,
+            (year, route, note),
+        )
+        conn.commit()
+    return note
 
 
 def delete_all(year, filename):

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -337,6 +337,34 @@ body.editing #sidebar {
   color: #888;
   font-size: 13px;
 }
+#stopImageNotes {
+  flex: 0 0 auto;
+  padding: 6px 8px 8px;
+  background: #fff;
+  border-top: 1px solid #ddd;
+}
+.sip-notes-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  font-weight: 600;
+  color: #444;
+  margin-bottom: 4px;
+}
+.sip-notes-status {
+  font-weight: 400;
+  font-size: 11px;
+  color: #2e7d32;
+}
+#stopImageNotesText {
+  width: 100%;
+  resize: vertical;
+  font-size: 12px;
+  padding: 4px 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
 #stopImageResize {
   position: absolute;
   right: 0;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -271,3 +271,78 @@ body.editing #sidebar {
 .ed-hist-btns .btn {
   margin-left: 4px;
 }
+
+/* --- Official stop-list signboard reference panel --- */
+#stopImagePanel {
+  position: absolute;
+  top: 120px;
+  left: 12px;
+  width: 340px;
+  height: 480px;
+  min-width: 220px;
+  min-height: 200px;
+  max-width: calc(100% - 24px);
+  max-height: calc(100% - 80px);
+  z-index: 1100;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border: 1px solid #aaa;
+  border-radius: 6px;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+#stopImageHeader {
+  flex: 0 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 6px;
+  background: #2c3e50;
+  color: #fff;
+  cursor: move;
+  user-select: none;
+}
+#stopImageHeader .sip-title {
+  font-weight: 600;
+  font-size: 12px;
+  margin-right: 2px;
+}
+#stopImageHeader select {
+  width: auto;
+  max-width: 140px;
+  height: 24px;
+  padding: 1px 4px;
+  font-size: 12px;
+  color: #333;
+}
+#stopImageHeader .sip-tools {
+  margin-left: auto;
+  white-space: nowrap;
+}
+#stopImageBody {
+  flex: 1 1 auto;
+  overflow: auto;
+  background: #f2f2f2;
+  text-align: center;
+}
+#stopImageImg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.sip-empty {
+  padding: 24px 16px;
+  color: #888;
+  font-size: 13px;
+}
+#stopImageResize {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 16px;
+  height: 16px;
+  cursor: nwse-resize;
+  background: linear-gradient(135deg, transparent 50%, #b0b0b0 50%);
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -28,11 +28,13 @@ APP.BusMap = class {
       this.routeManager,
       this.infoManager
     );
+    this.stopImageManager = new APP.StopImageManager(this.editorManager);
 
     this.locationTracker.init();
     this.routeManager.init();
     this.infoManager.init();
     this.editorManager.init();
+    this.stopImageManager.init();
   }
 
   /**

--- a/static/js/editor-manager.js
+++ b/static/js/editor-manager.js
@@ -116,15 +116,17 @@ APP.EditorManager = class {
     this.setTool("move");
   }
 
-  /** Start a brand-new (file-less) route — only for the 2026 dataset. */
-  createNew() {
+  /** Start a brand-new (file-less) route — only for the 2026 dataset.
+   * @param {string} [defaultName] pre-fills the name prompt (e.g. a route number
+   *   when launched from the official-stops reference panel). */
+  createNew(defaultName) {
     if (this.active) {
       if (!confirm("Finish the current edit first? Unsaved changes will be lost.")) {
         return;
       }
       this.exit();
     }
-    const name = window.prompt("New route name:", "");
+    const name = window.prompt("New route name:", defaultName || "");
     if (name == null) return;
 
     this.active = true;

--- a/static/js/stop-image-manager.js
+++ b/static/js/stop-image-manager.js
@@ -1,0 +1,189 @@
+// Floating reference panel for the official JPD stop-list signboards
+// (docs/<year>/images/stops/, served via /data/stop-image/...). It lets you keep
+// the official signboard on screen while you create a route, draw its line and
+// place stops on the map. Draggable by its header, resizable from the corner,
+// and zoomable. The "+ Route" button hands off to EditorManager.createNew().
+window.APP = window.APP || {};
+
+APP.StopImageManager = class {
+  /** @param {APP.EditorManager} editorManager */
+  constructor(editorManager) {
+    this.editorManager = editorManager;
+    this.zoom = 1;
+    this.loaded = false;
+  }
+
+  init() {
+    this.panel = document.getElementById("stopImagePanel");
+    this.img = document.getElementById("stopImageImg");
+    this.empty = document.getElementById("stopImageEmpty");
+    this.select = $("#stopImageSelect");
+    this._bind();
+  }
+
+  // --- Data --------------------------------------------------------------
+
+  _load() {
+    if (this.loaded) return Promise.resolve();
+    return fetch("/data/stop-images")
+      .then((r) => r.json())
+      .then((d) => {
+        this.select.empty();
+        (d.years || []).forEach((y) => {
+          const group = $("<optgroup>").attr("label", `${y} signboards`);
+          (d.images[y] || []).forEach((im) => {
+            $("<option>")
+              .val(im.file)
+              .attr("data-year", y)
+              .text(im.route)
+              .appendTo(group);
+          });
+          this.select.append(group);
+        });
+        this.loaded = true;
+      })
+      .catch((err) => {
+        if (APP.MapUtils) APP.MapUtils.handleError(err, "Loading stop images");
+        console.error("stop-images load failed", err);
+      });
+  }
+
+  // --- Show / hide -------------------------------------------------------
+
+  toggle() {
+    if (this.panel.style.display === "none" || !this.panel.style.display) {
+      this.show();
+    } else {
+      this.hide();
+    }
+  }
+
+  /** @param {string} [routeHint] route number to preselect (e.g. "20"). */
+  show(routeHint) {
+    this._load().then(() => {
+      this.panel.style.display = "flex";
+      if (routeHint) this.selectByRoute(routeHint);
+      if (!this.select.val() && this.select.find("option").length) {
+        this.select.prop("selectedIndex", 0);
+      }
+      this._showSelected();
+    });
+  }
+
+  hide() {
+    this.panel.style.display = "none";
+  }
+
+  /** Preselect the first signboard whose route label matches (newest year wins,
+   * since years are listed newest-first). */
+  selectByRoute(route) {
+    const opt = this.select
+      .find("option")
+      .filter((_, o) => o.text === route)
+      .first();
+    if (opt.length) this.select.val(opt.val());
+  }
+
+  _showSelected() {
+    const opt = this.select.find("option:selected");
+    const year = opt.attr("data-year");
+    const file = opt.val();
+    if (!year || !file) {
+      this.img.style.display = "none";
+      this.empty.style.display = "";
+      this.empty.textContent = "No signboard selected.";
+      return;
+    }
+    this.empty.style.display = "none";
+    this.img.style.display = "";
+    this.img.src =
+      "/data/stop-image/" +
+      encodeURIComponent(year) +
+      "/" +
+      encodeURIComponent(file);
+    this._setZoom(1); // fit to width on each new image
+  }
+
+  // --- Zoom --------------------------------------------------------------
+
+  _setZoom(z) {
+    this.zoom = Math.min(6, Math.max(0.3, z));
+    this.img.style.width = this.zoom * 100 + "%";
+  }
+
+  // --- Create route handoff ---------------------------------------------
+
+  _createRoute() {
+    if (!this.editorManager) return;
+    const route = this.select.find("option:selected").text();
+    // Keep the panel open so the signboard stays visible while drawing.
+    this.editorManager.createNew(route || "");
+  }
+
+  // --- Events ------------------------------------------------------------
+
+  _bind() {
+    $("#stopImageToggle").on("click", () => this.toggle());
+    $("#sipClose").on("click", () => this.hide());
+    this.select.on("change", () => this._showSelected());
+    $("#sipZoomIn").on("click", () => this._setZoom(this.zoom * 1.25));
+    $("#sipZoomOut").on("click", () => this._setZoom(this.zoom / 1.25));
+    $("#sipFit").on("click", () => this._setZoom(1));
+    $("#sipCreate").on("click", () => this._createRoute());
+    this._enableDrag();
+    this._enableResize();
+  }
+
+  _enableDrag() {
+    const header = document.getElementById("stopImageHeader");
+    let sx, sy, sl, st, dragging = false;
+    const onMove = (e) => {
+      if (!dragging) return;
+      this.panel.style.left = sl + (e.clientX - sx) + "px";
+      this.panel.style.top = st + (e.clientY - sy) + "px";
+      this.panel.style.right = "auto";
+    };
+    const onUp = () => {
+      dragging = false;
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    };
+    header.addEventListener("mousedown", (e) => {
+      // Don't start a drag when interacting with the header controls.
+      if (e.target.closest("button, select")) return;
+      const r = this.panel.getBoundingClientRect();
+      sx = e.clientX; sy = e.clientY; sl = r.left; st = r.top;
+      this.panel.style.left = r.left + "px";
+      this.panel.style.top = r.top + "px";
+      this.panel.style.right = "auto";
+      dragging = true;
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+      e.preventDefault();
+    });
+  }
+
+  _enableResize() {
+    const handle = document.getElementById("stopImageResize");
+    let sx, sy, sw, sh, resizing = false;
+    const onMove = (e) => {
+      if (!resizing) return;
+      this.panel.style.width = Math.max(220, sw + (e.clientX - sx)) + "px";
+      this.panel.style.height = Math.max(200, sh + (e.clientY - sy)) + "px";
+    };
+    const onUp = () => {
+      resizing = false;
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    };
+    handle.addEventListener("mousedown", (e) => {
+      const r = this.panel.getBoundingClientRect();
+      sx = e.clientX; sy = e.clientY; sw = r.width; sh = r.height;
+      resizing = true;
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+      e.preventDefault();
+      e.stopPropagation();
+    });
+  }
+};

--- a/static/js/stop-image-manager.js
+++ b/static/js/stop-image-manager.js
@@ -18,6 +18,11 @@ APP.StopImageManager = class {
     this.img = document.getElementById("stopImageImg");
     this.empty = document.getElementById("stopImageEmpty");
     this.select = $("#stopImageSelect");
+    this.notes = document.getElementById("stopImageNotesText");
+    this.notesRoute = document.getElementById("stopImageNotesRoute");
+    this.notesStatus = document.getElementById("stopImageNotesStatus");
+    this.current = null; // { year, route }
+    this._saveTimer = null;
     this._bind();
   }
 
@@ -71,6 +76,12 @@ APP.StopImageManager = class {
   }
 
   hide() {
+    // Persist any unsaved note before closing.
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer);
+      this._saveTimer = null;
+      this._saveNote();
+    }
     this.panel.style.display = "none";
   }
 
@@ -88,10 +99,12 @@ APP.StopImageManager = class {
     const opt = this.select.find("option:selected");
     const year = opt.attr("data-year");
     const file = opt.val();
+    const route = opt.text();
     if (!year || !file) {
       this.img.style.display = "none";
       this.empty.style.display = "";
       this.empty.textContent = "No signboard selected.";
+      this._loadNote(null);
       return;
     }
     this.empty.style.display = "none";
@@ -102,6 +115,75 @@ APP.StopImageManager = class {
       "/" +
       encodeURIComponent(file);
     this._setZoom(1); // fit to width on each new image
+    this._loadNote({ year, route });
+  }
+
+  // --- Per-route notes ---------------------------------------------------
+
+  _loadNote(ctx) {
+    // Flush any pending save for the route we're leaving before switching.
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer);
+      this._saveTimer = null;
+      this._saveNote();
+    }
+    this.current = ctx;
+    if (!ctx) {
+      this.notes.value = "";
+      this.notes.disabled = true;
+      this.notesRoute.textContent = "—";
+      this.notesStatus.textContent = "";
+      return;
+    }
+    this.notesRoute.textContent = `${ctx.route} (${ctx.year})`;
+    this.notes.disabled = true;
+    this.notesStatus.textContent = "Loading…";
+    const q = `?year=${encodeURIComponent(ctx.year)}&route=${encodeURIComponent(ctx.route)}`;
+    fetch(`/data/route-note${q}`)
+      .then((r) => r.json())
+      .then((d) => {
+        // Ignore a stale response if the selection changed meanwhile.
+        if (!this.current || this.current.route !== ctx.route || this.current.year !== ctx.year) {
+          return;
+        }
+        this.notes.value = d.note || "";
+        this.notes.disabled = false;
+        this.notesStatus.textContent = "";
+      })
+      .catch((err) => {
+        this.notesStatus.textContent = "Load failed";
+        console.error("route-note load failed", err);
+      });
+  }
+
+  _queueSave() {
+    if (!this.current) return;
+    this.notesStatus.textContent = "Saving…";
+    if (this._saveTimer) clearTimeout(this._saveTimer);
+    this._saveTimer = setTimeout(() => {
+      this._saveTimer = null;
+      this._saveNote();
+    }, 600);
+  }
+
+  _saveNote() {
+    if (!this.current) return;
+    const ctx = this.current;
+    fetch("/data/route-note", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ year: ctx.year, route: ctx.route, note: this.notes.value }),
+    })
+      .then((r) => r.json())
+      .then(() => {
+        if (this.current && this.current.route === ctx.route) {
+          this.notesStatus.textContent = "Saved ✓";
+        }
+      })
+      .catch((err) => {
+        this.notesStatus.textContent = "Save failed";
+        console.error("route-note save failed", err);
+      });
   }
 
   // --- Zoom --------------------------------------------------------------
@@ -130,6 +212,7 @@ APP.StopImageManager = class {
     $("#sipZoomOut").on("click", () => this._setZoom(this.zoom / 1.25));
     $("#sipFit").on("click", () => this._setZoom(1));
     $("#sipCreate").on("click", () => this._createRoute());
+    $(this.notes).on("input", () => this._queueSave());
     this._enableDrag();
     this._enableResize();
   }

--- a/templates/index.html
+++ b/templates/index.html
@@ -143,6 +143,18 @@
           <img id="stopImageImg" alt="Official stop list" style="display: none" />
           <div id="stopImageEmpty" class="sip-empty">No signboard selected.</div>
         </div>
+        <div id="stopImageNotes">
+          <div class="sip-notes-head">
+            <span>📝 Notes — <span id="stopImageNotesRoute">—</span></span>
+            <span id="stopImageNotesStatus" class="sip-notes-status"></span>
+          </div>
+          <textarea
+            id="stopImageNotesText"
+            rows="3"
+            placeholder="Notes for this route — discrepancies vs the poster, source comparisons, decisions…"
+            disabled
+          ></textarea>
+        </div>
         <div id="stopImageResize" title="Drag to resize"></div>
       </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -58,6 +58,14 @@
         >
           ☰ Routes
         </button>
+        <button
+          id="stopImageToggle"
+          type="button"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          title="View official stop-list signboards while building a route"
+        >
+          🚏 Official stops
+        </button>
       </div>
     </nav>
 
@@ -118,6 +126,26 @@
         </div>
         <div class="list-group" id="routes"></div>
       </div>
+      <!-- Official stop-list signboard reference (floating, draggable, resizable) -->
+      <div id="stopImagePanel" style="display: none">
+        <div id="stopImageHeader">
+          <span class="sip-title">🚏 Official stops</span>
+          <select id="stopImageSelect" class="form-control input-sm" title="Pick a route signboard"></select>
+          <span class="sip-tools">
+            <button type="button" class="btn btn-default btn-xs" id="sipZoomOut" title="Zoom out">−</button>
+            <button type="button" class="btn btn-default btn-xs" id="sipZoomIn" title="Zoom in">+</button>
+            <button type="button" class="btn btn-default btn-xs" id="sipFit" title="Fit to width">Fit</button>
+            <button type="button" class="btn btn-success btn-xs" id="sipCreate" title="Create a new route while viewing this signboard">+ Route</button>
+            <button type="button" class="btn btn-danger btn-xs" id="sipClose" title="Close">×</button>
+          </span>
+        </div>
+        <div id="stopImageBody">
+          <img id="stopImageImg" alt="Official stop list" style="display: none" />
+          <div id="stopImageEmpty" class="sip-empty">No signboard selected.</div>
+        </div>
+        <div id="stopImageResize" title="Drag to resize"></div>
+      </div>
+
       <div id="loading">Loading... <a class="btn btn-danger">X</a></div>
       <footer>
         Data via Land Transport Department docs provided for EOI for the
@@ -175,6 +203,7 @@
     <script src="{{ url_for('static', filename='js/route-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/info-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/editor-manager.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/stop-image-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
     <script src="{{ url_for('static', filename='js/ride/launcher.js') }}"></script>
   </body>


### PR DESCRIPTION
Adds a workflow for building routes against the official JPD stop-list signboards as the source of truth.

## Official stops reference panel
- Floating, draggable, resizable, zoomable panel showing the JPD signboards (`docs/<year>/images/stops/`).
- Route picker grouped by year (2026 + 2016).
- **+ Route** hands off to the editor (pre-fills the route number) so you place stops on the map against the official image.
- New backend routes serve `docs/` images (not served before): `/data/stop-images` and `/data/stop-image/<year>/<file>`, both path-traversal guarded.

## Per-route triage notes
- Free-text note per route, saved alongside the signboard — for source comparisons, discrepancies vs the poster, and decisions.
- `route_notes` table in SQLite (independent of geometry version history); `GET`/`POST /data/route-note`.
- Notes box in the panel: loads on select, debounced auto-save with a saved indicator, flushes on switch/close.

## Verification
- Endpoints return 200 (incl. 2016 filenames with spaces/brackets); traversal guarded (404).
- Notes round-trip and persist across a server restart.
- All changed JS passes `node --check`; no Flask errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)