### PR TITLE
GTFS workbench: editor, schedules, validator, and data-entry guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ full flow is draw → schedule → download. The GTFS pane covers:
 Exports also include auto-generated walking **`transfers.txt`** (distinct
 stops within 100 m), and `feed_version` is stamped with the export date.
 
+A **data entry guide** for transcription personnel lives at
+[`/gtfs/guide`](http://localhost:8000/gtfs/guide) (the **？ Guide** button in
+the workbench): what goes where, the per-route checklist, signboard usage,
+and a field-to-GTFS reference.
+
 Edits auto-save to the local SQLite store (`instance/edits.db`) and are merged
 into every subsequent export from both the endpoint and the CLI.
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ full flow is draw → schedule → download. The GTFS pane covers:
 - **Timing signboard reference** — the official JPD timing photo for the route
   (`docs/<year>/images/timings/`) is shown beside the form so departure times
   can be transcribed directly
+- **✔ Validate** — builds the feed in memory and runs structural checks
+  (required files/columns, duplicate ids, referential integrity, time/date
+  formats, per-trip monotonicity, unused entities) with results in a modal;
+  also available as `scripts/build_gtfs.py --validate`. For publish-grade
+  conformance, additionally run [MobilityData's canonical
+  validator](https://gtfs-validator.mobilitydata.org/)
 
 Edits auto-save to the local SQLite store (`instance/edits.db`) and are merged
 into every subsequent export from both the endpoint and the CLI.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,11 @@ The **🕐 GTFS** button in the navbar opens an editor panel for filling in the
 real values:
 
 - **Per-route schedule** — headway, first/last bus, operating days (becomes
-  `frequencies.txt` and per-pattern `calendar.txt` services)
+  `frequencies.txt` and per-pattern `calendar.txt` services), or **exact
+  departure times** transcribed from the signboard — routes with departures
+  export one real trip per departure (pure schedule-based GTFS, no synthetic
+  frequency entry), with intermediate stop times spread over the route's run
+  time (entered, or estimated from shape length at ~18 km/h)
 - **Route metadata** — route number, long name, color (`routes.txt`)
 - **Feed settings** — agency details and flat fare (`agency.txt`,
   `fare_attributes.txt`)

--- a/README.md
+++ b/README.md
@@ -165,13 +165,15 @@ agency and fare settings live under **⚙ Feed settings** in the top bar, and
 full flow is draw → schedule → download. The GTFS pane covers:
 
 - **Per-route schedules in day-type blocks** — each block has its own
-  operating days, headway, first/last bus, run time, and optional **exact
-  departure times** transcribed from the signboard, so a route can carry e.g.
-  a weekday and a different weekend timetable (each block becomes its own
-  `calendar.txt` service). Routes with departures export one real trip per
-  departure (pure schedule-based GTFS, no synthetic frequency entry), with
-  intermediate stop times spread over the run time (entered, or estimated
-  from shape length at ~18 km/h)
+  operating days, run time, optional **exact departure times** transcribed
+  from the signboard, and **time-of-day frequency bands** (peak/off-peak:
+  "every 10 min 06:00–08:30, every 30 min 08:30–16:00…" → one
+  `frequencies.txt` row per band). A route can carry e.g. a weekday and a
+  different weekend timetable (each block becomes its own `calendar.txt`
+  service). Routes with departures export one real trip per departure (pure
+  schedule-based GTFS, no synthetic frequency entry), with intermediate stop
+  times spread over the run time (entered, or estimated from shape length at
+  ~18 km/h)
 - **Route metadata** — route number, long name, color, and the operator
   running the route (`routes.txt`, including per-route `agency_id`)
 - **Directions & headsigns** — mark a route *out & back* to export both
@@ -184,7 +186,9 @@ full flow is draw → schedule → download. The GTFS pane covers:
   edits save as new geometry versions (official routes become editable via
   the ✎ copy flow)
 - **Feed settings** — the operator list (multiple companies supported; the
-  first is the default for unassigned routes) and flat fare (`agency.txt`,
+  first is the default for unassigned routes), holiday exceptions ("no
+  service" or "Sunday timetable" per date → weekday-aware
+  `calendar_dates.txt` rows), and flat fare (`agency.txt`,
   `fare_attributes.txt`)
 - **Timing signboard reference** — the official JPD timing photo for the route
   (`docs/<year>/images/timings/`) is shown beside the form so departure times

--- a/README.md
+++ b/README.md
@@ -152,6 +152,23 @@ These are placeholders to be replaced with real values transcribed from the JPD
 timing signboards. A single placeholder agency (ADBS) is used until the real
 operator-per-route mapping is known.
 
+### GTFS editor
+
+The **🕐 GTFS** button in the navbar opens an editor panel for filling in the
+real values:
+
+- **Per-route schedule** — headway, first/last bus, operating days (becomes
+  `frequencies.txt` and per-pattern `calendar.txt` services)
+- **Route metadata** — route number, long name, color (`routes.txt`)
+- **Feed settings** — agency details and flat fare (`agency.txt`,
+  `fare_attributes.txt`)
+- **Timing signboard reference** — the official JPD timing photo for the route
+  (`docs/<year>/images/timings/`) is shown beside the form so departure times
+  can be transcribed directly
+
+Edits auto-save to the local SQLite store (`instance/edits.db`) and are merged
+into every subsequent export from both the endpoint and the CLI.
+
 ## Technologies Used
 
 - [Flask](https://flask.palletsprojects.com/) — Python web server

--- a/README.md
+++ b/README.md
@@ -179,9 +179,10 @@ full flow is draw → schedule → download. The GTFS pane covers:
   departures offset by the run time) and set the bus's destination signs
   (`trip_headsign`); loops/one-ways stay single-direction
 - **Stops list** — every stop of the selected route in sequence order, with
-  editable names and coordinates, reorder/remove, and click-to-locate on the
-  map; edits save as new geometry versions (official routes become editable
-  via the ✎ copy flow)
+  editable public stop codes (`stop_code`, à la Singapore's numbered stops),
+  names and coordinates, reorder/remove, and click-to-locate on the map;
+  edits save as new geometry versions (official routes become editable via
+  the ✎ copy flow)
 - **Feed settings** — the operator list (multiple companies supported; the
   first is the default for unassigned routes) and flat fare (`agency.txt`,
   `fare_attributes.txt`)

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ full flow is draw → schedule → download. The GTFS pane covers:
   frequency entry), with intermediate stop times spread over the route's run
   time (entered, or estimated from shape length at ~18 km/h)
 - **Route metadata** — route number, long name, color (`routes.txt`)
+- **Stops list** — every stop of the selected route in sequence order, with
+  editable names and coordinates, reorder/remove, and click-to-locate on the
+  map; edits save as new geometry versions (official routes become editable
+  via the ✎ copy flow)
 - **Feed settings** — agency details and flat fare (`agency.txt`,
   `fare_attributes.txt`)
 - **Timing signboard reference** — the official JPD timing photo for the route

--- a/README.md
+++ b/README.md
@@ -164,12 +164,14 @@ agency and fare settings live under **⚙ Feed settings** in the top bar, and
 **⬇ Download GTFS** grabs the zip. User-drawn routes are exported too, so the
 full flow is draw → schedule → download. The GTFS pane covers:
 
-- **Per-route schedule** — headway, first/last bus, operating days (becomes
-  `frequencies.txt` and per-pattern `calendar.txt` services), or **exact
-  departure times** transcribed from the signboard — routes with departures
-  export one real trip per departure (pure schedule-based GTFS, no synthetic
-  frequency entry), with intermediate stop times spread over the route's run
-  time (entered, or estimated from shape length at ~18 km/h)
+- **Per-route schedules in day-type blocks** — each block has its own
+  operating days, headway, first/last bus, run time, and optional **exact
+  departure times** transcribed from the signboard, so a route can carry e.g.
+  a weekday and a different weekend timetable (each block becomes its own
+  `calendar.txt` service). Routes with departures export one real trip per
+  departure (pure schedule-based GTFS, no synthetic frequency entry), with
+  intermediate stop times spread over the run time (entered, or estimated
+  from shape length at ~18 km/h)
 - **Route metadata** — route number, long name, color, and the operator
   running the route (`routes.txt`, including per-route `agency_id`)
 - **Directions & headsigns** — mark a route *out & back* to export both

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ full flow is draw → schedule → download. The GTFS pane covers:
   time (entered, or estimated from shape length at ~18 km/h)
 - **Route metadata** — route number, long name, color, and the operator
   running the route (`routes.txt`, including per-route `agency_id`)
+- **Directions & headsigns** — mark a route *out & back* to export both
+  directions (`direction_id` 0/1 with reversed shape and stop order, return
+  departures offset by the run time) and set the bus's destination signs
+  (`trip_headsign`); loops/one-ways stay single-direction
 - **Stops list** — every stop of the selected route in sequence order, with
   editable names and coordinates, reorder/remove, and click-to-locate on the
   map; edits save as new geometry versions (official routes become editable

--- a/README.md
+++ b/README.md
@@ -177,9 +177,16 @@ full flow is draw → schedule → download. The GTFS pane covers:
 - **Route metadata** — route number, long name, color, and the operator
   running the route (`routes.txt`, including per-route `agency_id`)
 - **Directions & headsigns** — mark a route *out & back* to export both
-  directions (`direction_id` 0/1 with reversed shape and stop order, return
-  departures offset by the run time) and set the bus's destination signs
-  (`trip_headsign`); loops/one-ways stay single-direction
+  directions (`direction_id` 0/1 with reversed shape and stop order) and set
+  the bus's destination signs (`trip_headsign`); return departures can be
+  transcribed exactly per block, or are derived (outbound + run time) when
+  left empty. Loops/one-ways stay single-direction
+- **Description & hail-and-ride** — per-route `route_desc`, and a *hail &
+  ride* flag for Brunei's flag-down culture (`continuous_pickup`/
+  `continuous_drop_off`)
+- **Transcription progress** — each route in the list carries a 4-segment
+  meter (schedule · departures · operator · headsign) showing what's left
+  to transcribe
 - **Stops list** — every stop of the selected route in sequence order, with
   editable public stop codes (`stop_code`, à la Singapore's numbered stops),
   names and coordinates, reorder/remove, and click-to-locate on the map;
@@ -195,10 +202,14 @@ full flow is draw → schedule → download. The GTFS pane covers:
   can be transcribed directly
 - **✔ Validate** — builds the feed in memory and runs structural checks
   (required files/columns, duplicate ids, referential integrity, time/date
-  formats, per-trip monotonicity, unused entities) with results in a modal;
-  also available as `scripts/build_gtfs.py --validate`. For publish-grade
+  formats, per-trip monotonicity, frequency-window overlap, stops far off
+  their route's line, unused entities) with results in a modal; also
+  available as `scripts/build_gtfs.py --validate`. For publish-grade
   conformance, additionally run [MobilityData's canonical
   validator](https://gtfs-validator.mobilitydata.org/)
+
+Exports also include auto-generated walking **`transfers.txt`** (distinct
+stops within 100 m), and `feed_version` is stamped with the export date.
 
 Edits auto-save to the local SQLite store (`instance/edits.db`) and are merged
 into every subsequent export from both the endpoint and the CLI.

--- a/README.md
+++ b/README.md
@@ -155,12 +155,14 @@ operator-per-route mapping is known.
 ### GTFS workbench
 
 The **🕐 GTFS** button in the navbar opens a dedicated page at
-[`/gtfs`](http://localhost:8000/gtfs): a three-column workbench with the route
-list, the map with the full geometry editor (draw the line, place/rename stops,
-undo/history — the same editor as the main page), and a docked GTFS pane.
-Toggling a route shows it on the map *and* loads it into the GTFS form.
-User-drawn routes are exported too, so the full flow is draw → schedule →
-download. The GTFS pane covers:
+[`/gtfs`](http://localhost:8000/gtfs) where **one selected route drives
+everything**: click a route in the list and it shows on the map, becomes the
+editing target, and fills the GTFS pane. **✎ Edit route** on the map opens the
+full geometry editor (line/stop tools, undo, version history) — official routes
+are edited as an automatically created copy, reused on later edits. Feed-wide
+agency and fare settings live under **⚙ Feed settings** in the top bar, and
+**⬇ Download GTFS** grabs the zip. User-drawn routes are exported too, so the
+full flow is draw → schedule → download. The GTFS pane covers:
 
 - **Per-route schedule** — headway, first/last bus, operating days (becomes
   `frequencies.txt` and per-pattern `calendar.txt` services), or **exact

--- a/README.md
+++ b/README.md
@@ -152,10 +152,15 @@ These are placeholders to be replaced with real values transcribed from the JPD
 timing signboards. A single placeholder agency (ADBS) is used until the real
 operator-per-route mapping is known.
 
-### GTFS editor
+### GTFS workbench
 
-The **🕐 GTFS** button in the navbar opens an editor panel for filling in the
-real values:
+The **🕐 GTFS** button in the navbar opens a dedicated page at
+[`/gtfs`](http://localhost:8000/gtfs): a three-column workbench with the route
+list, the map with the full geometry editor (draw the line, place/rename stops,
+undo/history — the same editor as the main page), and a docked GTFS pane.
+Toggling a route shows it on the map *and* loads it into the GTFS form.
+User-drawn routes are exported too, so the full flow is draw → schedule →
+download. The GTFS pane covers:
 
 - **Per-route schedule** — headway, first/last bus, operating days (becomes
   `frequencies.txt` and per-pattern `calendar.txt` services), or **exact

--- a/README.md
+++ b/README.md
@@ -170,12 +170,14 @@ full flow is draw → schedule → download. The GTFS pane covers:
   export one real trip per departure (pure schedule-based GTFS, no synthetic
   frequency entry), with intermediate stop times spread over the route's run
   time (entered, or estimated from shape length at ~18 km/h)
-- **Route metadata** — route number, long name, color (`routes.txt`)
+- **Route metadata** — route number, long name, color, and the operator
+  running the route (`routes.txt`, including per-route `agency_id`)
 - **Stops list** — every stop of the selected route in sequence order, with
   editable names and coordinates, reorder/remove, and click-to-locate on the
   map; edits save as new geometry versions (official routes become editable
   via the ✎ copy flow)
-- **Feed settings** — agency details and flat fare (`agency.txt`,
+- **Feed settings** — the operator list (multiple companies supported; the
+  first is the default for unassigned routes) and flat fare (`agency.txt`,
   `fare_attributes.txt`)
 - **Timing signboard reference** — the official JPD timing photo for the route
   (`docs/<year>/images/timings/`) is shown beside the form so departure times

--- a/app.py
+++ b/app.py
@@ -515,6 +515,27 @@ def _validate_gtfs_route_meta(payload):
                     or any(d not in (0, 1, True, False) for d in days)):
                 return None, "days must be 7 values of 0/1"
             sched["days"] = [int(bool(d)) for d in days]
+        # Exact departure times transcribed from the timing signboard. When
+        # present the export emits one real trip per departure for this route
+        # instead of a synthetic frequency entry.
+        deps = sched_in.get("departures")
+        if deps is not None:
+            if not isinstance(deps, list) or len(deps) > 300:
+                return None, "departures must be a list of times (max 300)"
+            norm = []
+            for d in deps:
+                t = _norm_time(d) if isinstance(d, str) else None
+                if t is None:
+                    return None, f"bad departure time: {str(d)[:20]!r}"
+                norm.append(t)
+            if norm:
+                sched["departures"] = sorted(set(norm))
+        run = sched_in.get("run_secs")
+        if run is not None:
+            if not isinstance(run, (int, float)) or isinstance(run, bool) \
+                    or not (60 <= run <= 6 * 3600):
+                return None, "run_secs must be 60..21600"
+            sched["run_secs"] = int(run)
         if sched:
             meta["schedule"] = sched
     return meta, None

--- a/app.py
+++ b/app.py
@@ -441,6 +441,9 @@ def gather_gtfs_routes(year):
             "long_name": meta.get("long_name") or geom.get("name") or long_name,
             "color": meta.get("color", ""),
             "agency_id": meta.get("agency_id", ""),
+            "direction": meta.get("direction", ""),
+            "headsign": meta.get("headsign", ""),
+            "return_headsign": meta.get("return_headsign", ""),
             "schedule": meta.get("schedule") or None,
             "segments": geom.get("segments", []),
             "stops": geom.get("stops", []),
@@ -511,6 +514,18 @@ def _validate_gtfs_route_meta(payload):
             return None, "agency_id must be a string"
         if agency_id.strip():
             meta["agency_id"] = agency_id.strip()[:30]
+    direction = payload.get("direction")
+    if direction:
+        if direction != "outback":
+            return None, "direction must be 'outback' or omitted (loop/one-way)"
+        meta["direction"] = "outback"
+    for field in ("headsign", "return_headsign"):
+        v = payload.get(field)
+        if v is not None:
+            if not isinstance(v, str):
+                return None, f"{field} must be a string"
+            if v.strip():
+                meta[field] = v.strip()[:120]
     sched_in = payload.get("schedule")
     if sched_in:
         if not isinstance(sched_in, dict):

--- a/app.py
+++ b/app.py
@@ -418,13 +418,16 @@ def _gtfs_route_meta(filename):
 def gather_gtfs_routes(year):
     """Collect this year's KML routes as gtfs.build_feed inputs, preferring an
     edited geometry from the DB over the shipped file. Skips marker-only layers
-    and routes with no stops (a frequency-based feed needs stops to time)."""
+    and routes with no stops (a frequency-based feed needs stops to time).
+    Per-route GTFS metadata saved via the editor (names, color, schedule)
+    overrides the derived defaults."""
     rp = os.path.join(app.static_folder, "data", year, "routes.json")
     if not os.path.exists(rp):
         return []
     with open(rp, "r") as f:
         filenames = json.load(f)
 
+    meta_by_file = db.all_gtfs_meta(year)
     routes = []
     for filename in filenames:
         if _GTFS_SKIP.match(os.path.basename(filename)):
@@ -441,25 +444,251 @@ def gather_gtfs_routes(year):
         if not geom.get("stops"):
             continue  # no stops -> nothing to time against
         route_id, short, long_name = _gtfs_route_meta(filename)
+        meta = meta_by_file.get(filename, {})
         routes.append({
             "route_id": route_id,
-            "short_name": short,
-            "long_name": geom.get("name") or long_name,
+            "short_name": meta.get("short_name") or short,
+            "long_name": meta.get("long_name") or geom.get("name") or long_name,
+            "color": meta.get("color", ""),
+            "schedule": meta.get("schedule") or None,
             "segments": geom.get("segments", []),
             "stops": geom.get("stops", []),
         })
     return routes
 
 
+_TIME_RE = re.compile(r"^(\d{1,2}):([0-5]\d)(?::([0-5]\d))?$")
+
+
+def _norm_time(t):
+    """Normalize 'H:MM[:SS]' to 'HH:MM:SS', or None if invalid. GTFS allows
+    hours past 24 for service spanning midnight."""
+    m = _TIME_RE.match((t or "").strip())
+    if not m:
+        return None
+    h, mi, s = int(m.group(1)), m.group(2), m.group(3) or "00"
+    if h > 47:
+        return None
+    return f"{h:02d}:{mi}:{s}"
+
+
+def _validate_gtfs_route_meta(payload):
+    """Validate a per-route GTFS metadata payload. Returns (meta, error)."""
+    if not isinstance(payload, dict):
+        return None, "meta must be a JSON object"
+    meta = {}
+    for field in ("short_name", "long_name"):
+        v = payload.get(field)
+        if v is not None:
+            if not isinstance(v, str):
+                return None, f"{field} must be a string"
+            if v.strip():
+                meta[field] = v.strip()[:200]
+    color = payload.get("color")
+    if color:
+        if not isinstance(color, str) or not re.fullmatch(
+            r"#?[0-9A-Fa-f]{6}", color.strip()
+        ):
+            return None, "color must be a 6-digit hex value"
+        meta["color"] = color.strip().lstrip("#").upper()
+    sched_in = payload.get("schedule")
+    if sched_in:
+        if not isinstance(sched_in, dict):
+            return None, "schedule must be an object"
+        sched = {}
+        hw = sched_in.get("headway_secs")
+        if hw is not None:
+            if not isinstance(hw, (int, float)) or isinstance(hw, bool) \
+                    or not (60 <= hw <= 24 * 3600):
+                return None, "headway_secs must be 60..86400"
+            sched["headway_secs"] = int(hw)
+        for field in ("start_time", "end_time"):
+            v = sched_in.get(field)
+            if v:
+                t = _norm_time(v)
+                if t is None:
+                    return None, f"{field} must be HH:MM or HH:MM:SS"
+                sched[field] = t
+        days = sched_in.get("days")
+        if days is not None:
+            if (not isinstance(days, list) or len(days) != 7
+                    or any(d not in (0, 1, True, False) for d in days)):
+                return None, "days must be 7 values of 0/1"
+            sched["days"] = [int(bool(d)) for d in days]
+        if sched:
+            meta["schedule"] = sched
+    return meta, None
+
+
+def _validate_gtfs_feed_config(payload):
+    """Validate feed-level config (agency + fare). Returns (config, error)."""
+    if not isinstance(payload, dict):
+        return None, "config must be a JSON object"
+    config = {}
+    agency_in = payload.get("agency")
+    if agency_in:
+        if not isinstance(agency_in, dict):
+            return None, "agency must be an object"
+        agency = {}
+        for field in ("name", "url", "phone", "email"):
+            v = agency_in.get(field)
+            if v is not None:
+                if not isinstance(v, str):
+                    return None, f"agency.{field} must be a string"
+                if v.strip():
+                    agency[field] = v.strip()[:300]
+        if agency:
+            config["agency"] = agency
+    fare_in = payload.get("fare")
+    if fare_in:
+        if not isinstance(fare_in, dict):
+            return None, "fare must be an object"
+        fare = {}
+        price = fare_in.get("price")
+        if price is not None and price != "":
+            try:
+                price = float(price)
+            except (TypeError, ValueError):
+                return None, "fare.price must be a number"
+            if not (0 <= price <= 1000):
+                return None, "fare.price out of range"
+            fare["price"] = price
+        currency = fare_in.get("currency")
+        if currency:
+            if not isinstance(currency, str) or not re.fullmatch(
+                r"[A-Za-z]{3}", currency.strip()
+            ):
+                return None, "fare.currency must be a 3-letter code"
+            fare["currency"] = currency.strip().upper()
+        if fare:
+            config["fare"] = fare
+    return config, None
+
+
+@app.route("/data/gtfs-meta")
+def get_gtfs_meta():
+    """Per-route GTFS metadata overrides (names, color, schedule)."""
+    year = _resolve_year(request.args.get("year"))
+    route = (request.args.get("route") or "").strip()[:200]
+    if not route or route.startswith("_"):
+        return jsonify({"error": "route required"}), 400
+    return jsonify({"year": year, "route": route,
+                    "meta": db.get_gtfs_meta(year, route)})
+
+
+@app.route("/data/gtfs-meta", methods=["POST"])
+def save_gtfs_meta():
+    payload = request.get_json(silent=True) or {}
+    year = _resolve_year(payload.get("year"))
+    route = (payload.get("route") or "").strip()[:200]
+    if not route or route.startswith("_"):
+        return jsonify({"error": "route required"}), 400
+    meta, err = _validate_gtfs_route_meta(payload.get("meta"))
+    if err:
+        return jsonify({"error": err}), 400
+    saved = db.set_gtfs_meta(year, route, meta)
+    return jsonify({"ok": True, "year": year, "route": route, "meta": saved})
+
+
+@app.route("/data/gtfs-config")
+def get_gtfs_config():
+    """Feed-level GTFS settings (agency + fare), plus the built-in defaults so
+    the editor can show placeholders."""
+    year = _resolve_year(request.args.get("year"))
+    return jsonify({
+        "year": year,
+        "config": db.get_gtfs_meta(year, "_feed"),
+        "defaults": {
+            "agency": {"name": GTFS_AGENCY["name"], "url": GTFS_AGENCY["url"],
+                       "phone": GTFS_AGENCY["phone"], "email": GTFS_AGENCY["email"]},
+            "headway_secs": GTFS_PARAMS["headway_secs"],
+            "start_time": GTFS_PARAMS["start_time"],
+            "end_time": GTFS_PARAMS["end_time"],
+        },
+    })
+
+
+@app.route("/data/gtfs-config", methods=["POST"])
+def save_gtfs_config():
+    payload = request.get_json(silent=True) or {}
+    year = _resolve_year(payload.get("year"))
+    config, err = _validate_gtfs_feed_config(payload.get("config"))
+    if err:
+        return jsonify({"error": err}), 400
+    saved = db.set_gtfs_meta(year, "_feed", config)
+    return jsonify({"ok": True, "year": year, "config": saved})
+
+
+def _timing_images_dir(year):
+    return os.path.join(DOCS_DIR, year, "images", "timings")
+
+
+@app.route("/data/timing-images")
+def timing_images():
+    """Official JPD timing signboard photos, grouped by year (newest first).
+    Shown beside the GTFS schedule form so real times can be transcribed."""
+    out = {}
+    years = []
+    if os.path.isdir(DOCS_DIR):
+        year_dirs = (n for n in os.listdir(DOCS_DIR) if re.fullmatch(r"\d{4}", n))
+        for y in sorted(year_dirs, reverse=True):
+            d = _timing_images_dir(y)
+            if not os.path.isdir(d):
+                continue
+            imgs = sorted(
+                f for f in os.listdir(d)
+                if f.lower().endswith((".jpg", ".jpeg", ".png"))
+            )
+            if not imgs:
+                continue
+            years.append(y)
+            # Route code is the leading token: '01 seri timing.jpg' -> '01',
+            # '20 time details [20160402].jpg' -> '20'.
+            out[y] = [
+                {"file": f, "route": os.path.splitext(f)[0].split()[0]}
+                for f in imgs
+            ]
+    return jsonify({"years": years, "images": out})
+
+
+@app.route("/data/timing-image/<year>/<path:filename>")
+def timing_image(year, filename):
+    if not re.fullmatch(r"\d{4}", year or ""):
+        return "Timing image not found", 404
+    if os.path.isabs(filename) or ".." in filename.replace("\\", "/").split("/"):
+        return "Timing image not found", 404
+    path = os.path.join(_timing_images_dir(year), filename)
+    if not os.path.isfile(path):
+        return "Timing image not found", 404
+    return send_from_directory(os.path.dirname(path), os.path.basename(path))
+
+
+def gtfs_feed_inputs(year):
+    """(routes, agency, params) for gtfs.build_feed, with the year's saved
+    feed-level settings (agency, fare) merged over the built-in defaults.
+    Shared by the /data/gtfs.zip endpoint and scripts/build_gtfs.py."""
+    routes = gather_gtfs_routes(year)
+    config = db.get_gtfs_meta(year, "_feed")
+    agency = dict(GTFS_AGENCY)
+    for field in ("name", "url", "phone", "email"):
+        v = (config.get("agency") or {}).get(field)
+        if v:
+            agency[field] = v
+    params = dict(GTFS_PARAMS, feed_version=f"{year}.1")
+    if config.get("fare"):
+        params["fare"] = config["fare"]
+    return routes, agency, params
+
+
 @app.route("/data/gtfs.zip")
 def gtfs_feed():
-    # On-demand GTFS feed for the year, reflecting DB edits (via gather).
+    # On-demand GTFS feed for the year, reflecting DB edits (via gather) and
+    # any feed-level settings saved through the GTFS editor.
     year = _resolve_year(request.args.get("year"))
-    routes = gather_gtfs_routes(year)
+    routes, agency, params = gtfs_feed_inputs(year)
     if not routes:
         return jsonify({"error": "no routes to export"}), 404
-    params = dict(GTFS_PARAMS, feed_version=f"{year}.1")
-    data, _stats = gtfs.build_feed(routes, GTFS_AGENCY, params)
+    data, _stats = gtfs.build_feed(routes, agency, params)
     return Response(
         data,
         mimetype="application/zip",

--- a/app.py
+++ b/app.py
@@ -440,6 +440,7 @@ def gather_gtfs_routes(year):
             "short_name": meta.get("short_name") or short,
             "long_name": meta.get("long_name") or geom.get("name") or long_name,
             "color": meta.get("color", ""),
+            "agency_id": meta.get("agency_id", ""),
             "schedule": meta.get("schedule") or None,
             "segments": geom.get("segments", []),
             "stops": geom.get("stops", []),
@@ -504,6 +505,12 @@ def _validate_gtfs_route_meta(payload):
         ):
             return None, "color must be a 6-digit hex value"
         meta["color"] = color.strip().lstrip("#").upper()
+    agency_id = payload.get("agency_id")
+    if agency_id:
+        if not isinstance(agency_id, str):
+            return None, "agency_id must be a string"
+        if agency_id.strip():
+            meta["agency_id"] = agency_id.strip()[:30]
     sched_in = payload.get("schedule")
     if sched_in:
         if not isinstance(sched_in, dict):
@@ -555,10 +562,45 @@ def _validate_gtfs_route_meta(payload):
 
 
 def _validate_gtfs_feed_config(payload):
-    """Validate feed-level config (agency + fare). Returns (config, error)."""
+    """Validate feed-level config (operators + fare). Returns (config, error)."""
     if not isinstance(payload, dict):
         return None, "config must be a JSON object"
     config = {}
+    # Operators: a list of agencies; the first is the default for routes
+    # without an explicit assignment.
+    agencies_in = payload.get("agencies")
+    if agencies_in is not None:
+        if not isinstance(agencies_in, list) or len(agencies_in) > 20:
+            return None, "agencies must be a list (max 20)"
+        agencies = []
+        seen = set()
+        for a in agencies_in:
+            if not isinstance(a, dict):
+                return None, "each operator must be an object"
+            name = a.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue  # blank rows are dropped silently
+            name = name.strip()[:200]
+            aid = a.get("id")
+            if aid is not None and not isinstance(aid, str):
+                return None, "operator id must be a string"
+            aid = (aid or "").strip()[:30]
+            if not aid:
+                aid = re.sub(r"[^A-Za-z0-9]+", "-", name).strip("-").upper()[:30] or "OP"
+            if aid in seen:
+                return None, f"duplicate operator id: {aid}"
+            seen.add(aid)
+            entry = {"id": aid, "name": name}
+            for field in ("url", "phone", "email"):
+                v = a.get(field)
+                if v is not None:
+                    if not isinstance(v, str):
+                        return None, f"operator {field} must be a string"
+                    if v.strip():
+                        entry[field] = v.strip()[:300]
+            agencies.append(entry)
+        if agencies:
+            config["agencies"] = agencies
     agency_in = payload.get("agency")
     if agency_in:
         if not isinstance(agency_in, dict):
@@ -626,12 +668,18 @@ def save_gtfs_meta():
 
 @app.route("/data/gtfs-config")
 def get_gtfs_config():
-    """Feed-level GTFS settings (agency + fare), plus the built-in defaults so
-    the editor can show placeholders."""
+    """Feed-level GTFS settings (operators + fare), the resolved operator list
+    (saved or default — what the export will actually use), and the built-in
+    defaults so the editor can show placeholders."""
     year = _resolve_year(request.args.get("year"))
     return jsonify({
         "year": year,
         "config": db.get_gtfs_meta(year, "_feed"),
+        "agencies": [
+            {"id": a["id"], "name": a["name"], "url": a.get("url", ""),
+             "phone": a.get("phone", "")}
+            for a in resolved_agencies(year)
+        ],
         "defaults": {
             "agency": {"name": GTFS_AGENCY["name"], "url": GTFS_AGENCY["url"],
                        "phone": GTFS_AGENCY["phone"], "email": GTFS_AGENCY["email"]},
@@ -697,21 +745,45 @@ def timing_image(year, filename):
     return send_from_directory(os.path.dirname(path), os.path.basename(path))
 
 
-def gtfs_feed_inputs(year):
-    """(routes, agency, params) for gtfs.build_feed, with the year's saved
-    feed-level settings (agency, fare) merged over the built-in defaults.
-    Shared by the /data/gtfs.zip endpoint and scripts/build_gtfs.py."""
-    routes = gather_gtfs_routes(year)
+def resolved_agencies(year):
+    """The year's operator list for the feed, ready for gtfs.build_feed.
+    Saved operators (config.agencies) win; else the legacy single-agency
+    override; else the built-in default. First entry = default operator."""
     config = db.get_gtfs_meta(year, "_feed")
+    saved = config.get("agencies")
+    if saved:
+        return [
+            {
+                "id": a.get("id") or "AGENCY",
+                "name": a.get("name") or GTFS_AGENCY["name"],
+                # agency_url is required by the GTFS spec — fall back rather
+                # than emit a blank.
+                "url": a.get("url") or GTFS_AGENCY["url"],
+                "timezone": GTFS_AGENCY["timezone"],
+                "lang": GTFS_AGENCY["lang"],
+                "phone": a.get("phone", ""),
+                "email": a.get("email", ""),
+            }
+            for a in saved
+        ]
     agency = dict(GTFS_AGENCY)
     for field in ("name", "url", "phone", "email"):
         v = (config.get("agency") or {}).get(field)
         if v:
             agency[field] = v
+    return [agency]
+
+
+def gtfs_feed_inputs(year):
+    """(routes, agencies, params) for gtfs.build_feed, with the year's saved
+    feed-level settings (operators, fare) merged over the built-in defaults.
+    Shared by the /data/gtfs.zip endpoint and scripts/build_gtfs.py."""
+    routes = gather_gtfs_routes(year)
+    config = db.get_gtfs_meta(year, "_feed")
     params = dict(GTFS_PARAMS, feed_version=f"{year}.1")
     if config.get("fare"):
         params["fare"] = config["fare"]
-    return routes, agency, params
+    return routes, resolved_agencies(year), params
 
 
 @app.route("/data/gtfs.zip")
@@ -719,10 +791,10 @@ def gtfs_feed():
     # On-demand GTFS feed for the year, reflecting DB edits (via gather) and
     # any feed-level settings saved through the GTFS editor.
     year = _resolve_year(request.args.get("year"))
-    routes, agency, params = gtfs_feed_inputs(year)
+    routes, agencies, params = gtfs_feed_inputs(year)
     if not routes:
         return jsonify({"error": "no routes to export"}), 404
-    data, _stats = gtfs.build_feed(routes, agency, params)
+    data, _stats = gtfs.build_feed(routes, agencies, params)
     return Response(
         data,
         mimetype="application/zip",

--- a/app.py
+++ b/app.py
@@ -451,6 +451,8 @@ def gather_gtfs_routes(year):
             "direction": meta.get("direction", ""),
             "headsign": meta.get("headsign", ""),
             "return_headsign": meta.get("return_headsign", ""),
+            "desc": meta.get("desc", ""),
+            "hail": bool(meta.get("hail")),
             "schedules": meta.get("schedules")
                 or ([meta["schedule"]] if meta.get("schedule") else None),
             "segments": geom.get("segments", []),
@@ -534,6 +536,14 @@ def _validate_gtfs_route_meta(payload):
                 return None, f"{field} must be a string"
             if v.strip():
                 meta[field] = v.strip()[:120]
+    desc = payload.get("desc")
+    if desc is not None:
+        if not isinstance(desc, str):
+            return None, "desc must be a string"
+        if desc.strip():
+            meta["desc"] = desc.strip()[:500]
+    if payload.get("hail"):
+        meta["hail"] = True  # hail & ride: continuous pickup/drop-off
     # Schedules: a list of day-type blocks (weekday/weekend…). The legacy
     # single `schedule` key is accepted as one block.
     sched_in = payload.get("schedule")
@@ -614,18 +624,19 @@ def _validate_schedule_block(sched_in):
     # Exact departure times transcribed from the timing signboard. When
     # present the export emits one real trip per departure for this route
     # instead of a synthetic frequency entry.
-    deps = sched_in.get("departures")
-    if deps is not None:
-        if not isinstance(deps, list) or len(deps) > 300:
-            return None, "departures must be a list of times (max 300)"
-        norm = []
-        for d in deps:
-            t = _norm_time(d) if isinstance(d, str) else None
-            if t is None:
-                return None, f"bad departure time: {str(d)[:20]!r}"
-            norm.append(t)
-        if norm:
-            sched["departures"] = sorted(set(norm))
+    for field in ("departures", "return_departures"):
+        deps = sched_in.get(field)
+        if deps is not None:
+            if not isinstance(deps, list) or len(deps) > 300:
+                return None, f"{field} must be a list of times (max 300)"
+            norm = []
+            for d in deps:
+                t = _norm_time(d) if isinstance(d, str) else None
+                if t is None:
+                    return None, f"bad departure time: {str(d)[:20]!r}"
+                norm.append(t)
+            if norm:
+                sched[field] = sorted(set(norm))
     run = sched_in.get("run_secs")
     if run is not None:
         if not isinstance(run, (int, float)) or isinstance(run, bool) \
@@ -770,6 +781,28 @@ def save_gtfs_meta():
     return jsonify({"ok": True, "year": year, "route": route, "meta": saved})
 
 
+@app.route("/data/gtfs-meta-summary")
+def gtfs_meta_summary():
+    """Per-route transcription status for the workbench list badges:
+    {filename: {schedule, departures, operator, headsign}} for every route
+    with saved GTFS metadata."""
+    year = _resolve_year(request.args.get("year"))
+    out = {}
+    for key, m in db.all_gtfs_meta(year).items():
+        if key.startswith("_"):
+            continue
+        blocks = m.get("schedules") or ([m["schedule"]] if m.get("schedule") else [])
+        out[key] = {
+            "schedule": bool(blocks),
+            "departures": any(
+                b.get("departures") or b.get("return_departures") for b in blocks
+            ),
+            "operator": bool(m.get("agency_id")),
+            "headsign": bool(m.get("headsign")),
+        }
+    return jsonify({"year": year, "routes": out})
+
+
 @app.route("/data/gtfs-config")
 def get_gtfs_config():
     """Feed-level GTFS settings (operators + fare), the resolved operator list
@@ -884,7 +917,9 @@ def gtfs_feed_inputs(year):
     Shared by the /data/gtfs.zip endpoint and scripts/build_gtfs.py."""
     routes = gather_gtfs_routes(year)
     config = db.get_gtfs_meta(year, "_feed")
-    params = dict(GTFS_PARAMS, feed_version=f"{year}.1")
+    # Version stamps the export date so consumers can tell feeds apart.
+    today = datetime.date.today().strftime("%Y%m%d")
+    params = dict(GTFS_PARAMS, feed_version=f"{year}.{today}")
     if config.get("fare"):
         params["fare"] = config["fare"]
     if config.get("holidays"):

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from flask import (
     Flask, render_template, send_from_directory, jsonify, json, request, Response,
     url_for,
 )
+import datetime
 import os
 import re
 import math
@@ -576,6 +577,34 @@ def _validate_schedule_block(sched_in):
             if t is None:
                 return None, f"{field} must be HH:MM or HH:MM:SS"
             sched[field] = t
+    # Time-of-day frequency bands (peak/off-peak): each becomes its own
+    # frequencies.txt row. The legacy top-level fields above act as band one.
+    bands_in = sched_in.get("bands")
+    if bands_in is not None:
+        if not isinstance(bands_in, list) or len(bands_in) > 10:
+            return None, "bands must be a list (max 10)"
+        bands = []
+        for b in bands_in:
+            if not isinstance(b, dict):
+                return None, "each band must be an object"
+            band = {}
+            bh = b.get("headway_secs")
+            if bh is not None:
+                if not isinstance(bh, (int, float)) or isinstance(bh, bool) \
+                        or not (60 <= bh <= 24 * 3600):
+                    return None, "band headway_secs must be 60..86400"
+                band["headway_secs"] = int(bh)
+            for field in ("start_time", "end_time"):
+                v = b.get(field)
+                if v:
+                    t = _norm_time(v)
+                    if t is None:
+                        return None, f"band {field} must be HH:MM or HH:MM:SS"
+                    band[field] = t
+            if band:
+                bands.append(band)
+        if bands:
+            sched["bands"] = bands
     days = sched_in.get("days")
     if days is not None:
         if (not isinstance(days, list) or len(days) != 7
@@ -660,6 +689,36 @@ def _validate_gtfs_feed_config(payload):
                     agency[field] = v.strip()[:300]
         if agency:
             config["agency"] = agency
+    # Holiday exceptions -> calendar_dates.txt.
+    holidays_in = payload.get("holidays")
+    if holidays_in is not None:
+        if not isinstance(holidays_in, list) or len(holidays_in) > 50:
+            return None, "holidays must be a list (max 50)"
+        holidays = []
+        for h in holidays_in:
+            if not isinstance(h, dict):
+                return None, "each holiday must be an object"
+            date = h.get("date", "")
+            if not isinstance(date, str):
+                return None, "holiday date must be a string"
+            date = date.replace("-", "").strip()
+            try:
+                datetime.datetime.strptime(date, "%Y%m%d")
+            except ValueError:
+                return None, f"bad holiday date: {date[:12]!r}"
+            mode = h.get("mode", "none")
+            if mode not in ("none", "sunday"):
+                return None, "holiday mode must be 'none' or 'sunday'"
+            entry = {"date": date, "mode": mode}
+            name = h.get("name")
+            if name is not None:
+                if not isinstance(name, str):
+                    return None, "holiday name must be a string"
+                if name.strip():
+                    entry["name"] = name.strip()[:100]
+            holidays.append(entry)
+        if holidays:
+            config["holidays"] = sorted(holidays, key=lambda x: x["date"])
     fare_in = payload.get("fare")
     if fare_in:
         if not isinstance(fare_in, dict):
@@ -828,6 +887,8 @@ def gtfs_feed_inputs(year):
     params = dict(GTFS_PARAMS, feed_version=f"{year}.1")
     if config.get("fare"):
         params["fare"] = config["fare"]
+    if config.get("holidays"):
+        params["holidays"] = config["holidays"]
     return routes, resolved_agencies(year), params
 
 

--- a/app.py
+++ b/app.py
@@ -429,6 +429,22 @@ def gather_gtfs_routes(year):
 
     meta_by_file = db.all_gtfs_meta(year)
     routes = []
+
+    def add(filename, geom):
+        if not geom or not geom.get("stops"):
+            return  # no stops -> nothing to time against
+        route_id, short, long_name = _gtfs_route_meta(filename)
+        meta = meta_by_file.get(filename, {})
+        routes.append({
+            "route_id": route_id,
+            "short_name": meta.get("short_name") or short,
+            "long_name": meta.get("long_name") or geom.get("name") or long_name,
+            "color": meta.get("color", ""),
+            "schedule": meta.get("schedule") or None,
+            "segments": geom.get("segments", []),
+            "stops": geom.get("stops", []),
+        })
+
     for filename in filenames:
         if _GTFS_SKIP.match(os.path.basename(filename)):
             continue
@@ -441,19 +457,16 @@ def gather_gtfs_routes(year):
                 geom = parse_route_geometry(path)
             except (ValueError, ET.ParseError):
                 continue
-        if not geom.get("stops"):
-            continue  # no stops -> nothing to time against
-        route_id, short, long_name = _gtfs_route_meta(filename)
-        meta = meta_by_file.get(filename, {})
-        routes.append({
-            "route_id": route_id,
-            "short_name": meta.get("short_name") or short,
-            "long_name": meta.get("long_name") or geom.get("name") or long_name,
-            "color": meta.get("color", ""),
-            "schedule": meta.get("schedule") or None,
-            "segments": geom.get("segments", []),
-            "stops": geom.get("stops", []),
-        })
+        add(filename, geom)
+
+    # User-created routes (DB-only, no shipped file) belong in the feed too —
+    # the workbench flow is draw -> schedule -> export.
+    user_files = sorted(
+        f for f in db.distinct_files(year)
+        if not _find_kml(f, year) and not _find_geojson(f, year)
+    )
+    for filename in user_files:
+        add(filename, db.latest_geometry(year, filename))
     return routes
 
 
@@ -720,6 +733,12 @@ def gtfs_feed():
 @app.route("/")
 def index():
     return render_template("index.html")
+
+
+@app.route("/gtfs")
+def gtfs_page():
+    # Dedicated GTFS workbench: route list + geometry editor + schedule forms.
+    return render_template("gtfs.html")
 
 
 @app.route("/ride/three")

--- a/app.py
+++ b/app.py
@@ -437,8 +437,8 @@ def gather_gtfs_routes(year):
     routes = []
 
     def add(filename, geom):
-        if not geom or not geom.get("stops"):
-            return  # no stops -> nothing to time against
+        if not geom or len(geom.get("stops") or []) < 2:
+            return  # a valid trip needs at least 2 stops to time against
         route_id, short, long_name = _gtfs_route_meta(filename)
         meta = meta_by_file.get(filename, {})
         routes.append({
@@ -829,6 +829,26 @@ def gtfs_feed_inputs(year):
     if config.get("fare"):
         params["fare"] = config["fare"]
     return routes, resolved_agencies(year), params
+
+
+@app.route("/data/gtfs-validate")
+def gtfs_validate():
+    """Build the year's feed in memory and run the structural validator."""
+    year = _resolve_year(request.args.get("year"))
+    routes, agencies, params = gtfs_feed_inputs(year)
+    if not routes:
+        return jsonify({"error": "no routes to export"}), 404
+    data, stats = gtfs.build_feed(routes, agencies, params)
+    findings = gtfs.validate_feed(data)
+    errors = sum(1 for f in findings if f["severity"] == "error")
+    return jsonify({
+        "year": year,
+        "size": len(data),
+        "stats": stats,
+        "errors": errors,
+        "warnings": len(findings) - errors,
+        "findings": findings,
+    })
 
 
 @app.route("/data/gtfs.zip")

--- a/app.py
+++ b/app.py
@@ -444,7 +444,8 @@ def gather_gtfs_routes(year):
             "direction": meta.get("direction", ""),
             "headsign": meta.get("headsign", ""),
             "return_headsign": meta.get("return_headsign", ""),
-            "schedule": meta.get("schedule") or None,
+            "schedules": meta.get("schedules")
+                or ([meta["schedule"]] if meta.get("schedule") else None),
             "segments": geom.get("segments", []),
             "stops": geom.get("stops", []),
         })
@@ -526,54 +527,77 @@ def _validate_gtfs_route_meta(payload):
                 return None, f"{field} must be a string"
             if v.strip():
                 meta[field] = v.strip()[:120]
+    # Schedules: a list of day-type blocks (weekday/weekend…). The legacy
+    # single `schedule` key is accepted as one block.
     sched_in = payload.get("schedule")
     if sched_in:
-        if not isinstance(sched_in, dict):
-            return None, "schedule must be an object"
-        sched = {}
-        hw = sched_in.get("headway_secs")
-        if hw is not None:
-            if not isinstance(hw, (int, float)) or isinstance(hw, bool) \
-                    or not (60 <= hw <= 24 * 3600):
-                return None, "headway_secs must be 60..86400"
-            sched["headway_secs"] = int(hw)
-        for field in ("start_time", "end_time"):
-            v = sched_in.get(field)
-            if v:
-                t = _norm_time(v)
-                if t is None:
-                    return None, f"{field} must be HH:MM or HH:MM:SS"
-                sched[field] = t
-        days = sched_in.get("days")
-        if days is not None:
-            if (not isinstance(days, list) or len(days) != 7
-                    or any(d not in (0, 1, True, False) for d in days)):
-                return None, "days must be 7 values of 0/1"
-            sched["days"] = [int(bool(d)) for d in days]
-        # Exact departure times transcribed from the timing signboard. When
-        # present the export emits one real trip per departure for this route
-        # instead of a synthetic frequency entry.
-        deps = sched_in.get("departures")
-        if deps is not None:
-            if not isinstance(deps, list) or len(deps) > 300:
-                return None, "departures must be a list of times (max 300)"
-            norm = []
-            for d in deps:
-                t = _norm_time(d) if isinstance(d, str) else None
-                if t is None:
-                    return None, f"bad departure time: {str(d)[:20]!r}"
-                norm.append(t)
-            if norm:
-                sched["departures"] = sorted(set(norm))
-        run = sched_in.get("run_secs")
-        if run is not None:
-            if not isinstance(run, (int, float)) or isinstance(run, bool) \
-                    or not (60 <= run <= 6 * 3600):
-                return None, "run_secs must be 60..21600"
-            sched["run_secs"] = int(run)
+        sched, err = _validate_schedule_block(sched_in)
+        if err:
+            return None, err
         if sched:
             meta["schedule"] = sched
+    scheds_in = payload.get("schedules")
+    if scheds_in is not None:
+        if not isinstance(scheds_in, list) or len(scheds_in) > 7:
+            return None, "schedules must be a list of blocks (max 7)"
+        blocks = []
+        for b in scheds_in:
+            sched, err = _validate_schedule_block(b)
+            if err:
+                return None, err
+            if sched:
+                blocks.append(sched)
+        if blocks:
+            meta["schedules"] = blocks
     return meta, None
+
+
+def _validate_schedule_block(sched_in):
+    """Validate one schedule block. Returns (sched_dict, error)."""
+    if not isinstance(sched_in, dict):
+        return None, "schedule must be an object"
+    sched = {}
+    hw = sched_in.get("headway_secs")
+    if hw is not None:
+        if not isinstance(hw, (int, float)) or isinstance(hw, bool) \
+                or not (60 <= hw <= 24 * 3600):
+            return None, "headway_secs must be 60..86400"
+        sched["headway_secs"] = int(hw)
+    for field in ("start_time", "end_time"):
+        v = sched_in.get(field)
+        if v:
+            t = _norm_time(v)
+            if t is None:
+                return None, f"{field} must be HH:MM or HH:MM:SS"
+            sched[field] = t
+    days = sched_in.get("days")
+    if days is not None:
+        if (not isinstance(days, list) or len(days) != 7
+                or any(d not in (0, 1, True, False) for d in days)):
+            return None, "days must be 7 values of 0/1"
+        sched["days"] = [int(bool(d)) for d in days]
+    # Exact departure times transcribed from the timing signboard. When
+    # present the export emits one real trip per departure for this route
+    # instead of a synthetic frequency entry.
+    deps = sched_in.get("departures")
+    if deps is not None:
+        if not isinstance(deps, list) or len(deps) > 300:
+            return None, "departures must be a list of times (max 300)"
+        norm = []
+        for d in deps:
+            t = _norm_time(d) if isinstance(d, str) else None
+            if t is None:
+                return None, f"bad departure time: {str(d)[:20]!r}"
+            norm.append(t)
+        if norm:
+            sched["departures"] = sorted(set(norm))
+    run = sched_in.get("run_secs")
+    if run is not None:
+        if not isinstance(run, (int, float)) or isinstance(run, bool) \
+                or not (60 <= run <= 6 * 3600):
+            return None, "run_secs must be 60..21600"
+        sched["run_secs"] = int(run)
+    return sched, None
 
 
 def _validate_gtfs_feed_config(payload):

--- a/app.py
+++ b/app.py
@@ -343,7 +343,13 @@ def _validate_geometry(payload):
         name = s.get("name", "")
         if not isinstance(name, str):
             return None, "stop name must be a string"
-        stops.append({"name": name[:200], "lon": round(lon, 7), "lat": round(lat, 7)})
+        stop = {"name": name[:200], "lon": round(lon, 7), "lat": round(lat, 7)}
+        code = s.get("code", "")
+        if not isinstance(code, str):
+            return None, "stop code must be a string"
+        if code.strip():  # public stop number (GTFS stop_code)
+            stop["code"] = code.strip()[:30]
+        stops.append(stop)
 
     label = payload.get("label")
     if label is not None and not isinstance(label, str):

--- a/app.py
+++ b/app.py
@@ -974,6 +974,12 @@ def gtfs_page():
     return render_template("gtfs.html")
 
 
+@app.route("/gtfs/guide")
+def gtfs_guide_page():
+    # Data-entry guide for transcription personnel.
+    return render_template("gtfs_guide.html")
+
+
 @app.route("/ride/three")
 def ride_three():
     return render_template("ride_three.html")

--- a/db.py
+++ b/db.py
@@ -64,6 +64,19 @@ def init_db(db_path):
             )
             """
         )
+        # Every overwritten gtfs_meta value is archived here, so a bad
+        # autosave is recoverable (via SQL; no UI). Append-only.
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS gtfs_meta_history (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                year        TEXT NOT NULL,
+                key         TEXT NOT NULL,
+                data        TEXT NOT NULL,
+                replaced_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+            """
+        )
 
 
 def _connect():
@@ -227,8 +240,18 @@ def get_gtfs_meta(year, key):
 
 
 def set_gtfs_meta(year, key, data):
-    """Upsert GTFS metadata for a route (or '_feed'). Returns the saved dict."""
+    """Upsert GTFS metadata for a route (or '_feed'), archiving the value
+    being replaced into gtfs_meta_history. Returns the saved dict."""
+    payload = json.dumps(data, ensure_ascii=False)
     with _connect() as conn:
+        row = conn.execute(
+            "SELECT data FROM gtfs_meta WHERE year=? AND key=?", (year, key)
+        ).fetchone()
+        if row and row["data"] != payload:
+            conn.execute(
+                "INSERT INTO gtfs_meta_history (year, key, data) VALUES (?, ?, ?)",
+                (year, key, row["data"]),
+            )
         conn.execute(
             """
             INSERT INTO gtfs_meta (year, key, data, updated_at)
@@ -236,7 +259,7 @@ def set_gtfs_meta(year, key, data):
             ON CONFLICT(year, key) DO UPDATE SET
                 data = excluded.data, updated_at = excluded.updated_at
             """,
-            (year, key, json.dumps(data, ensure_ascii=False)),
+            (year, key, payload),
         )
         conn.commit()
     return data

--- a/db.py
+++ b/db.py
@@ -50,6 +50,20 @@ def init_db(db_path):
             )
             """
         )
+        # GTFS metadata overrides as JSON blobs. `key` is a route filename for
+        # per-route data (schedule, names, color) or '_feed' for feed-level
+        # settings (agency, fare). Upsert-only, like route_notes.
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS gtfs_meta (
+                year       TEXT NOT NULL,
+                key        TEXT NOT NULL,
+                data       TEXT NOT NULL DEFAULT '{}',
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (year, key)
+            )
+            """
+        )
 
 
 def _connect():
@@ -194,6 +208,55 @@ def set_note(year, route, note):
         )
         conn.commit()
     return note
+
+
+def get_gtfs_meta(year, key):
+    """GTFS metadata dict for a route filename (or '_feed'), or {} if none."""
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT data FROM gtfs_meta WHERE year=? AND key=?",
+            (year, key),
+        ).fetchone()
+    if not row:
+        return {}
+    try:
+        data = json.loads(row["data"])
+    except (ValueError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def set_gtfs_meta(year, key, data):
+    """Upsert GTFS metadata for a route (or '_feed'). Returns the saved dict."""
+    with _connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO gtfs_meta (year, key, data, updated_at)
+            VALUES (?, ?, ?, datetime('now'))
+            ON CONFLICT(year, key) DO UPDATE SET
+                data = excluded.data, updated_at = excluded.updated_at
+            """,
+            (year, key, json.dumps(data, ensure_ascii=False)),
+        )
+        conn.commit()
+    return data
+
+
+def all_gtfs_meta(year):
+    """All GTFS metadata for a year: {key: dict} (includes '_feed' if set)."""
+    out = {}
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT key, data FROM gtfs_meta WHERE year=?", (year,)
+        ).fetchall()
+    for r in rows:
+        try:
+            data = json.loads(r["data"])
+        except (ValueError, TypeError):
+            continue
+        if isinstance(data, dict):
+            out[r["key"]] = data
+    return out
 
 
 def delete_all(year, filename):

--- a/gtfs.py
+++ b/gtfs.py
@@ -150,6 +150,225 @@ class _StopPool:
         } for e in self._entries]
 
 
+# --- validation ----------------------------------------------------------------
+# Required files and the columns each must carry (a subset of the spec
+# sufficient for this feed's structure).
+_REQUIRED = {
+    "agency.txt": ["agency_id", "agency_name", "agency_url", "agency_timezone"],
+    "stops.txt": ["stop_id", "stop_name", "stop_lat", "stop_lon"],
+    "routes.txt": ["route_id", "agency_id", "route_long_name", "route_type"],
+    "trips.txt": ["route_id", "service_id", "trip_id"],
+    "stop_times.txt": ["trip_id", "arrival_time", "departure_time", "stop_id",
+                       "stop_sequence"],
+    "calendar.txt": ["service_id", "monday", "tuesday", "wednesday", "thursday",
+                     "friday", "saturday", "sunday", "start_date", "end_date"],
+}
+
+_TIME_OK = re.compile(r"^\d{1,2}:[0-5]\d:[0-5]\d$")
+_DATE_OK = re.compile(r"^\d{8}$")
+
+
+def validate_feed(data):
+    """Structural validation of a GTFS zip (bytes). Returns a list of
+    findings, errors first: [{severity, code, message, count, examples[<=5]}].
+    Covers file/column presence, duplicate ids, referential integrity,
+    time/date/coordinate formats, per-trip sequence and time monotonicity,
+    and unused-entity warnings — the checks that break consumers. For
+    publish-grade conformance, run MobilityData's canonical gtfs-validator."""
+    agg = {}
+
+    def add(severity, code, message, example=None):
+        f = agg.setdefault(code, {
+            "severity": severity, "code": code, "message": message,
+            "count": 0, "examples": [],
+        })
+        f["count"] += 1
+        if example is not None and len(f["examples"]) < 5:
+            f["examples"].append(str(example)[:120])
+
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(data))
+    except zipfile.BadZipFile:
+        return [{"severity": "error", "code": "bad_zip",
+                 "message": "not a readable zip archive", "count": 1,
+                 "examples": []}]
+    names = set(zf.namelist())
+
+    def table(fname):
+        if fname not in names:
+            return None
+        with zf.open(fname) as fh:
+            return list(csv.DictReader(io.TextIOWrapper(fh, "utf-8-sig")))
+
+    tables = {}
+    for fname, cols in _REQUIRED.items():
+        if fname not in names:
+            add("error", "missing_file", f"required file absent: {fname}", fname)
+            tables[fname] = []
+            continue
+        rows = table(fname)
+        tables[fname] = rows
+        have = set(rows[0].keys()) if rows else set()
+        if rows:
+            for c in cols:
+                if c not in have:
+                    add("error", "missing_column",
+                        f"required column absent", f"{fname}: {c}")
+    for opt in ("shapes.txt", "frequencies.txt", "feed_info.txt",
+                "fare_attributes.txt"):
+        tables[opt] = table(opt) or []
+    if "feed_info.txt" not in names:
+        add("warning", "no_feed_info", "feed_info.txt is recommended")
+
+    def ids(fname, col):
+        out = set()
+        for row in tables[fname]:
+            v = row.get(col, "")
+            if v in out:
+                add("error", "duplicate_id", f"duplicate {col}", f"{fname}: {v}")
+            if v:
+                out.add(v)
+        return out
+
+    agency_ids = ids("agency.txt", "agency_id")
+    stop_ids = ids("stops.txt", "stop_id")
+    route_ids = ids("routes.txt", "route_id")
+    trip_ids = ids("trips.txt", "trip_id")
+    service_ids = ids("calendar.txt", "service_id")
+    shape_ids = {s.get("shape_id", "") for s in tables["shapes.txt"]}
+
+    for a in tables["agency.txt"]:
+        if not a.get("agency_timezone"):
+            add("error", "no_timezone", "agency_timezone is required",
+                a.get("agency_id"))
+
+    for s in tables["stops.txt"]:
+        try:
+            lat, lon = float(s.get("stop_lat", "")), float(s.get("stop_lon", ""))
+            if not (-90 <= lat <= 90 and -180 <= lon <= 180):
+                raise ValueError
+            if lat == 0 and lon == 0:
+                add("warning", "null_island", "stop at coordinates 0,0",
+                    s.get("stop_id"))
+        except ValueError:
+            add("error", "bad_coords", "unparseable/out-of-range stop coords",
+                s.get("stop_id"))
+
+    for r in tables["routes.txt"]:
+        if r.get("agency_id") and r["agency_id"] not in agency_ids:
+            add("error", "bad_reference", "routes.agency_id not in agency.txt",
+                r.get("route_id"))
+        if not (r.get("route_type") or "").isdigit():
+            add("error", "bad_route_type", "route_type must be an integer",
+                r.get("route_id"))
+        color = r.get("route_color", "")
+        if color and not re.fullmatch(r"[0-9A-Fa-f]{6}", color):
+            add("warning", "bad_color", "route_color is not 6-digit hex",
+                f"{r.get('route_id')}: {color}")
+
+    used_routes, used_services = set(), set()
+    for t in tables["trips.txt"]:
+        if t.get("route_id") not in route_ids:
+            add("error", "bad_reference", "trips.route_id not in routes.txt",
+                t.get("trip_id"))
+        if t.get("service_id") not in service_ids:
+            add("error", "bad_reference", "trips.service_id not in calendar.txt",
+                t.get("trip_id"))
+        if t.get("shape_id") and t["shape_id"] not in shape_ids:
+            add("error", "bad_reference", "trips.shape_id not in shapes.txt",
+                t.get("trip_id"))
+        used_routes.add(t.get("route_id"))
+        used_services.add(t.get("service_id"))
+    for rid in route_ids - used_routes:
+        add("warning", "route_without_trips", "route has no trips", rid)
+    for sid in service_ids - used_services:
+        add("warning", "service_without_trips", "calendar service unused", sid)
+
+    by_trip = {}
+    used_stops = set()
+    for st in tables["stop_times.txt"]:
+        tid = st.get("trip_id", "")
+        if tid not in trip_ids:
+            add("error", "bad_reference", "stop_times.trip_id not in trips.txt", tid)
+        if st.get("stop_id") not in stop_ids:
+            add("error", "bad_reference", "stop_times.stop_id not in stops.txt",
+                st.get("stop_id"))
+        used_stops.add(st.get("stop_id"))
+        for col in ("arrival_time", "departure_time"):
+            if st.get(col) and not _TIME_OK.match(st[col]):
+                add("error", "bad_time", "stop time is not HH:MM:SS",
+                    f"{tid}: {st[col]}")
+        try:
+            seq = int(st.get("stop_sequence", ""))
+        except ValueError:
+            add("error", "bad_sequence", "stop_sequence must be an integer", tid)
+            continue
+        by_trip.setdefault(tid, []).append((seq, st.get("departure_time", "")))
+    for tid in trip_ids:
+        rows = by_trip.get(tid, [])
+        if len(rows) < 2:
+            add("error", "trip_too_short", "trip has fewer than 2 stop_times", tid)
+            continue
+        rows.sort()
+        seqs = [r[0] for r in rows]
+        if len(set(seqs)) != len(seqs):
+            add("error", "bad_sequence", "duplicate stop_sequence in trip", tid)
+        times = [r[1] for r in rows if r[1]]
+        if times != sorted(times):
+            add("error", "nonmonotonic_times", "stop times go backwards", tid)
+    for sid in stop_ids - used_stops:
+        add("warning", "stop_unused", "stop is never visited", sid)
+
+    for c in tables["calendar.txt"]:
+        for col in ("start_date", "end_date"):
+            if not _DATE_OK.match(c.get(col, "")):
+                add("error", "bad_date", "calendar date is not YYYYMMDD",
+                    f"{c.get('service_id')}: {c.get(col)}")
+        if (c.get("start_date", "") and c.get("end_date", "")
+                and c["start_date"] > c["end_date"]):
+            add("error", "bad_date", "calendar start_date after end_date",
+                c.get("service_id"))
+        if not any(c.get(d) == "1" for d in (
+                "monday", "tuesday", "wednesday", "thursday", "friday",
+                "saturday", "sunday")):
+            add("warning", "service_no_days", "service runs on no days",
+                c.get("service_id"))
+
+    for f in tables["frequencies.txt"]:
+        if f.get("trip_id") not in trip_ids:
+            add("error", "bad_reference", "frequencies.trip_id not in trips.txt",
+                f.get("trip_id"))
+        try:
+            if int(f.get("headway_secs", "")) <= 0:
+                raise ValueError
+        except ValueError:
+            add("error", "bad_headway", "headway_secs must be a positive integer",
+                f.get("trip_id"))
+        if (f.get("start_time", "") and f.get("end_time", "")
+                and _hhmmss_to_secs(f["start_time"]) >= _hhmmss_to_secs(f["end_time"])):
+            add("error", "bad_window", "frequency start_time not before end_time",
+                f.get("trip_id"))
+
+    prev = {}
+    for s in tables["shapes.txt"]:
+        sid = s.get("shape_id", "")
+        try:
+            seq = int(s.get("shape_pt_sequence", ""))
+            dist = float(s.get("shape_dist_traveled") or 0)
+        except ValueError:
+            add("error", "bad_shape", "unparseable shape sequence/distance", sid)
+            continue
+        if sid in prev and (seq <= prev[sid][0] or dist < prev[sid][1]):
+            add("warning", "shape_disorder",
+                "shape sequence/distance not increasing", sid)
+        prev[sid] = (seq, dist)
+
+    findings = sorted(
+        agg.values(), key=lambda f: (f["severity"] != "error", f["code"])
+    )
+    return findings
+
+
 # --- csv / zip helpers -------------------------------------------------------
 def _csv(header, rows):
     """Render rows (list of dicts) as a CSV string with the given header order."""

--- a/gtfs.py
+++ b/gtfs.py
@@ -62,15 +62,31 @@ def _cumulative_dist(points):
     return out
 
 
-def _project_dist(stop, points, cum):
-    """Distance along the shape (metres) of the vertex nearest to `stop`."""
-    best_i, best_d = 0, float("inf")
-    sp = [stop["lon"], stop["lat"]]
-    for i, p in enumerate(points):
-        d = _haversine(sp, p)
-        if d < best_d:
-            best_i, best_d = i, d
-    return cum[best_i]
+def _project_stops(stops, points, cum):
+    """Distance along the shape (metres) for each stop, in stop order.
+
+    Stops are listed in travel order in the source KML, so the search moves
+    monotonically forward through the shape — and among near-equal candidates
+    the EARLIEST vertex wins. Both guards matter for loop routes, where the
+    terminal appears at the start and the end of the shape: a plain global
+    nearest-vertex search can snap every stop to the closing vertices,
+    collapsing all stop times at the end of the trip."""
+    dists = []
+    start = 0
+    for s in stops:
+        sp = [s["lon"], s["lat"]]
+        best_i, best_d = start, float("inf")
+        for i in range(start, len(points)):
+            d = _haversine(sp, points[i])
+            if d < best_d:
+                best_i, best_d = i, d
+        for i in range(start, best_i):  # earliest within tolerance wins
+            if _haversine(sp, points[i]) <= best_d + 25.0:
+                best_i = i
+                break
+        dists.append(cum[best_i])
+        start = best_i
+    return dists
 
 
 def _secs_to_hhmmss(s):
@@ -146,11 +162,18 @@ def build_feed(routes, agency, params):
 
     routes: [{route_id, short_name, long_name, segments, stops, color?,
               schedule?}] where schedule overrides the feed defaults per route:
-             {headway_secs?, start_time?, end_time?, days?[7]}
+             {headway_secs?, start_time?, end_time?, days?[7],
+              departures?: [HH:MM:SS, ...], run_secs?}
     agency: {id, name, url, phone, timezone, lang, email?}
     params: {headway_secs, start_time, end_time, service_id, days[7],
              start_date, end_date, feed_version, publisher_name, publisher_url,
              feed_lang, fare?: {price, currency}}
+
+    Routes WITH transcribed departures get one real trip per departure time
+    (pure schedule-based GTFS, no frequencies.txt entry). Routes without fall
+    back to a single representative trip plus a frequency-based headway.
+    Intermediate stop times are interpolated along the shape over the route's
+    run time (run_secs if given, else estimated from shape length at ~18 km/h).
     """
     agency_id = agency["id"]
     default_service_id = params["service_id"]
@@ -177,7 +200,6 @@ def build_feed(routes, agency, params):
     for r in routes:
         rid = r["route_id"]
         shape_id = f"shp_{rid}"
-        trip_id = f"trip_{rid}"
 
         # Per-route schedule overrides, falling back to the feed defaults.
         sched = r.get("schedule") or {}
@@ -185,12 +207,20 @@ def build_feed(routes, agency, params):
         start_time = sched.get("start_time") or params["start_time"]
         end_time = sched.get("end_time") or params["end_time"]
         days = sched.get("days") or default_days
+        departures = sched.get("departures") or []
         service_id = _service_for(days)
-        win_start = _hhmmss_to_secs(start_time)
 
         points = _flatten_segments(r.get("segments", []))
         cum = _cumulative_dist(points)
         total = cum[-1] if cum else 0.0
+        has_shape = len(points) >= 2
+
+        # End-to-end run time used to spread intermediate stop times: explicit
+        # run_secs, else estimated from shape length at ~18 km/h (5 m/s) city
+        # bus average, else one headway as a last resort.
+        run = int(sched.get("run_secs") or 0)
+        if run <= 0:
+            run = int(total / 5.0) if total > 0 else headway
 
         routes_rows.append({
             "route_id": rid,
@@ -210,49 +240,66 @@ def build_feed(routes, agency, params):
                 "shape_dist_traveled": f"{cum[i]:.1f}",
             })
 
-        has_shape = len(points) >= 2
-        trips_rows.append({
-            "route_id": rid,
-            "service_id": service_id,
-            "trip_id": trip_id,
-            "shape_id": shape_id if has_shape else "",
-        })
-
-        # Stop times: project each stop onto the shape, then map its distance to
-        # a time proportional to the service window. Enforce monotonic times so
-        # the trip is valid even when projection order wobbles.
+        # Project each stop onto the shape once; every trip reuses the offsets.
+        # Times are spread over the first->last stop span (not the full shape),
+        # so a trip departs its first stop exactly at the departure time.
         stops = r.get("stops", [])
-        run = headway  # nominal end-to-end run time for one trip = one headway
-        prev_secs = None
-        seq = 0
-        for s in stops:
-            sid = pool.resolve(s)
-            if has_shape and total > 0:
-                frac = _project_dist(s, points, cum) / total
+        n = len(stops)
+        if has_shape and total > 0 and stops:
+            dists = _project_stops(stops, points, cum)
+        else:
+            dists = [0.0] * n
+        span = (dists[-1] - dists[0]) if n > 1 else 0.0
+        stop_entries = []  # (stop_id, time fraction 0..1, dist along shape)
+        for idx, (s, dist) in enumerate(zip(stops, dists)):
+            if span > 0:
+                frac = (dist - dists[0]) / span
             else:
-                frac = (seq / (len(stops) - 1)) if len(stops) > 1 else 0.0
-            t = win_start + frac * run
-            if prev_secs is not None and t <= prev_secs:
-                t = prev_secs + 1
-            prev_secs = t
-            seq += 1
-            hhmm = _secs_to_hhmmss(t)
-            stop_times_rows.append({
-                "trip_id": trip_id,
-                "arrival_time": hhmm,
-                "departure_time": hhmm,
-                "stop_id": sid,
-                "stop_sequence": seq,
-                "shape_dist_traveled": f"{frac * total:.1f}" if has_shape else "",
-            })
+                frac = (idx / (n - 1)) if n > 1 else 0.0
+            stop_entries.append((pool.resolve(s), frac, dist))
 
-        freq_rows.append({
-            "trip_id": trip_id,
-            "start_time": start_time,
-            "end_time": end_time,
-            "headway_secs": headway,
-            "exact_times": 0,
-        })
+        # Transcribed departures -> one real trip each (no frequencies entry).
+        # Otherwise a single representative trip + a frequency-based headway.
+        if departures:
+            trip_starts = [
+                (f"trip_{rid}_{i + 1}", _hhmmss_to_secs(d))
+                for i, d in enumerate(departures)
+            ]
+        else:
+            trip_starts = [(f"trip_{rid}", _hhmmss_to_secs(start_time))]
+
+        for trip_id, dep_secs in trip_starts:
+            trips_rows.append({
+                "route_id": rid,
+                "service_id": service_id,
+                "trip_id": trip_id,
+                "shape_id": shape_id if has_shape else "",
+            })
+            # Monotonic times keep the trip valid even when projection wobbles.
+            prev_secs = None
+            for seq, (sid, frac, dist) in enumerate(stop_entries, 1):
+                t = dep_secs + frac * run
+                if prev_secs is not None and t <= prev_secs:
+                    t = prev_secs + 1
+                prev_secs = t
+                hhmm = _secs_to_hhmmss(t)
+                stop_times_rows.append({
+                    "trip_id": trip_id,
+                    "arrival_time": hhmm,
+                    "departure_time": hhmm,
+                    "stop_id": sid,
+                    "stop_sequence": seq,
+                    "shape_dist_traveled": f"{dist:.1f}" if has_shape else "",
+                })
+
+        if not departures:
+            freq_rows.append({
+                "trip_id": f"trip_{rid}",
+                "start_time": start_time,
+                "end_time": end_time,
+                "headway_secs": headway,
+                "exact_times": 0,
+            })
 
     calendar_rows = [
         {
@@ -300,9 +347,6 @@ def build_feed(routes, agency, params):
         "shapes.txt": _csv(
             ["shape_id", "shape_pt_lat", "shape_pt_lon", "shape_pt_sequence",
              "shape_dist_traveled"], shapes_rows),
-        "frequencies.txt": _csv(
-            ["trip_id", "start_time", "end_time", "headway_secs", "exact_times"],
-            freq_rows),
         "calendar.txt": _csv(
             ["service_id", "monday", "tuesday", "wednesday", "thursday",
              "friday", "saturday", "sunday", "start_date", "end_date"],
@@ -311,6 +355,13 @@ def build_feed(routes, agency, params):
             ["feed_publisher_name", "feed_publisher_url", "feed_lang",
              "feed_version"], feed_info_rows),
     }
+
+    # Only routes still on the synthetic headway need frequencies.txt; a fully
+    # transcribed feed (every route has departures) is pure schedule-based.
+    if freq_rows:
+        tables["frequencies.txt"] = _csv(
+            ["trip_id", "start_time", "end_time", "headway_secs", "exact_times"],
+            freq_rows)
 
     # Optional flat fare (e.g. Brunei's B$1): payment on board, no transfers info.
     fare = params.get("fare") or {}
@@ -333,6 +384,8 @@ def build_feed(routes, agency, params):
 
     return out.getvalue(), {
         "routes": len(routes_rows),
+        "trips": len(trips_rows),
+        "scheduled_routes": len(routes_rows) - len(freq_rows),
         "stops": len(pool._entries),
         "stop_times": len(stop_times_rows),
         "shape_points": len(shapes_rows),

--- a/gtfs.py
+++ b/gtfs.py
@@ -157,14 +157,16 @@ def _hhmmss_to_secs(t):
     return h * 3600 + m * 60 + s
 
 
-def build_feed(routes, agency, params):
+def build_feed(routes, agencies, params):
     """Build a GTFS feed and return it as zip bytes.
 
     routes: [{route_id, short_name, long_name, segments, stops, color?,
-              schedule?}] where schedule overrides the feed defaults per route:
-             {headway_secs?, start_time?, end_time?, days?[7],
-              departures?: [HH:MM:SS, ...], run_secs?}
-    agency: {id, name, url, phone, timezone, lang, email?}
+              agency_id?, schedule?}] where schedule overrides the feed
+             defaults per route: {headway_secs?, start_time?, end_time?,
+              days?[7], departures?: [HH:MM:SS, ...], run_secs?}
+    agencies: list of {id, name, url, phone, timezone, lang, email?} —
+              the FIRST is the default operator for unassigned routes.
+              (A single dict is accepted for backward compatibility.)
     params: {headway_secs, start_time, end_time, service_id, days[7],
              start_date, end_date, feed_version, publisher_name, publisher_url,
              feed_lang, fare?: {price, currency}}
@@ -175,7 +177,10 @@ def build_feed(routes, agency, params):
     Intermediate stop times are interpolated along the shape over the route's
     run time (run_secs if given, else estimated from shape length at ~18 km/h).
     """
-    agency_id = agency["id"]
+    if isinstance(agencies, dict):
+        agencies = [agencies]
+    default_agency_id = agencies[0]["id"]
+    known_agency_ids = {a["id"] for a in agencies}
     default_service_id = params["service_id"]
     default_days = list(params["days"])
 
@@ -222,9 +227,13 @@ def build_feed(routes, agency, params):
         if run <= 0:
             run = int(total / 5.0) if total > 0 else headway
 
+        # Per-route operator; unknown/unset assignments fall back to the default.
+        aid = r.get("agency_id")
+        if aid not in known_agency_ids:
+            aid = default_agency_id
         routes_rows.append({
             "route_id": rid,
-            "agency_id": agency_id,
+            "agency_id": aid,
             "route_short_name": r.get("short_name", "") or "",
             "route_long_name": r.get("long_name", "") or "",
             "route_type": 3,  # 3 = bus
@@ -314,14 +323,14 @@ def build_feed(routes, agency, params):
     ]
 
     agency_rows = [{
-        "agency_id": agency_id,
-        "agency_name": agency["name"],
-        "agency_url": agency["url"],
-        "agency_timezone": agency["timezone"],
-        "agency_lang": agency.get("lang", ""),
-        "agency_phone": agency.get("phone", ""),
-        "agency_email": agency.get("email", ""),
-    }]
+        "agency_id": a["id"],
+        "agency_name": a["name"],
+        "agency_url": a["url"],
+        "agency_timezone": a["timezone"],
+        "agency_lang": a.get("lang", ""),
+        "agency_phone": a.get("phone", ""),
+        "agency_email": a.get("email", ""),
+    } for a in agencies]
 
     feed_info_rows = [{
         "feed_publisher_name": params["publisher_name"],

--- a/gtfs.py
+++ b/gtfs.py
@@ -161,10 +161,12 @@ def build_feed(routes, agencies, params):
     """Build a GTFS feed and return it as zip bytes.
 
     routes: [{route_id, short_name, long_name, segments, stops, color?,
-              agency_id?, direction?, headsign?, return_headsign?, schedule?}]
-             where schedule overrides the feed defaults per route:
-             {headway_secs?, start_time?, end_time?, days?[7],
-              departures?: [HH:MM:SS, ...], run_secs?}.
+              agency_id?, direction?, headsign?, return_headsign?,
+              schedules?, schedule?}]
+             where schedules is a list of day-type blocks (weekday/weekend…),
+             each overriding the feed defaults: {headway_secs?, start_time?,
+              end_time?, days?[7], departures?: [HH:MM:SS, ...], run_secs?}.
+             A legacy single `schedule` dict is treated as one block.
              direction="outback" additionally emits a return pattern
              (direction_id 1, reversed shape/stops, departures offset by one
              run time); anything else is a loop/one-way single pattern.
@@ -210,26 +212,10 @@ def build_feed(routes, agencies, params):
         rid = r["route_id"]
         shape_id = f"shp_{rid}"
 
-        # Per-route schedule overrides, falling back to the feed defaults.
-        sched = r.get("schedule") or {}
-        headway = int(sched.get("headway_secs") or params["headway_secs"])
-        start_time = sched.get("start_time") or params["start_time"]
-        end_time = sched.get("end_time") or params["end_time"]
-        days = sched.get("days") or default_days
-        departures = sched.get("departures") or []
-        service_id = _service_for(days)
-
         points = _flatten_segments(r.get("segments", []))
         cum = _cumulative_dist(points)
         total = cum[-1] if cum else 0.0
         has_shape = len(points) >= 2
-
-        # End-to-end run time used to spread intermediate stop times: explicit
-        # run_secs, else estimated from shape length at ~18 km/h (5 m/s) city
-        # bus average, else one headway as a last resort.
-        run = int(sched.get("run_secs") or 0)
-        if run <= 0:
-            run = int(total / 5.0) if total > 0 else headway
 
         # Per-route operator; unknown/unset assignments fall back to the default.
         aid = r.get("agency_id")
@@ -264,8 +250,7 @@ def build_feed(routes, agencies, params):
 
         # Direction patterns. Loop/one-way routes have a single pattern.
         # Out-and-back routes additionally get a return pattern (direction_id
-        # 1): reversed shape, reversed stop order, and — since the bus turns
-        # around at the far terminal — departures offset by one run time.
+        # 1): reversed shape and reversed stop order.
         patterns = [{
             "suffix": "",
             "shape_id": shape_id,
@@ -274,7 +259,6 @@ def build_feed(routes, agencies, params):
             "direction_id": 0,
             "headsign": r.get("headsign", "") or "",
             "entries": stop_entries,
-            "dep_offset": 0,
         }]
         if r.get("direction") == "outback":
             entries_r = [
@@ -289,7 +273,6 @@ def build_feed(routes, agencies, params):
                 "direction_id": 1,
                 "headsign": r.get("return_headsign", "") or "",
                 "entries": entries_r,
-                "dep_offset": run,
             })
 
         for pat in patterns:
@@ -302,51 +285,76 @@ def build_feed(routes, agencies, params):
                     "shape_dist_traveled": f"{pat['cum'][i]:.1f}",
                 })
 
-            # Transcribed departures -> one real trip each (no frequencies
-            # entry). Otherwise one representative trip + a headway.
-            base = f"trip_{rid}{pat['suffix']}"
-            if departures:
-                trip_starts = [
-                    (f"{base}_{i + 1}", _hhmmss_to_secs(d) + pat["dep_offset"])
-                    for i, d in enumerate(departures)
-                ]
-            else:
-                trip_starts = [(base, _hhmmss_to_secs(start_time) + pat["dep_offset"])]
+        # Schedule blocks: day-type variants (e.g. weekday vs weekend), each
+        # with its own days/headway/window/run/departures -> its own
+        # service_id and trip set. A legacy single `schedule` is one block.
+        blocks = r.get("schedules") or [r.get("schedule") or {}]
+        for bi, sched in enumerate(blocks[:7]):
+            headway = int(sched.get("headway_secs") or params["headway_secs"])
+            start_time = sched.get("start_time") or params["start_time"]
+            end_time = sched.get("end_time") or params["end_time"]
+            days = sched.get("days") or default_days
+            departures = sched.get("departures") or []
+            service_id = _service_for(days)
 
-            for trip_id, dep_secs in trip_starts:
-                trips_rows.append({
-                    "route_id": rid,
-                    "service_id": service_id,
-                    "trip_id": trip_id,
-                    "trip_headsign": pat["headsign"],
-                    "direction_id": pat["direction_id"],
-                    "shape_id": pat["shape_id"] if has_shape else "",
-                })
-                # Monotonic times keep the trip valid even when projection wobbles.
-                prev_secs = None
-                for seq, (sid, frac, dist) in enumerate(pat["entries"], 1):
-                    t = dep_secs + frac * run
-                    if prev_secs is not None and t <= prev_secs:
-                        t = prev_secs + 1
-                    prev_secs = t
-                    hhmm = _secs_to_hhmmss(t)
-                    stop_times_rows.append({
+            # End-to-end run time used to spread intermediate stop times:
+            # explicit run_secs, else estimated from shape length at ~18 km/h
+            # (5 m/s) city bus average, else one headway as a last resort.
+            run = int(sched.get("run_secs") or 0)
+            if run <= 0:
+                run = int(total / 5.0) if total > 0 else headway
+
+            bsuf = "" if bi == 0 else f"_b{bi + 1}"
+            for pat in patterns:
+                # The bus turns around at the far terminal, so the return
+                # direction departs one run time after the outbound.
+                offset = run if pat["direction_id"] else 0
+                base = f"trip_{rid}{bsuf}{pat['suffix']}"
+
+                # Transcribed departures -> one real trip each (no frequencies
+                # entry). Otherwise one representative trip + a headway.
+                if departures:
+                    trip_starts = [
+                        (f"{base}_{i + 1}", _hhmmss_to_secs(d) + offset)
+                        for i, d in enumerate(departures)
+                    ]
+                else:
+                    trip_starts = [(base, _hhmmss_to_secs(start_time) + offset)]
+
+                for trip_id, dep_secs in trip_starts:
+                    trips_rows.append({
+                        "route_id": rid,
+                        "service_id": service_id,
                         "trip_id": trip_id,
-                        "arrival_time": hhmm,
-                        "departure_time": hhmm,
-                        "stop_id": sid,
-                        "stop_sequence": seq,
-                        "shape_dist_traveled": f"{dist:.1f}" if has_shape else "",
+                        "trip_headsign": pat["headsign"],
+                        "direction_id": pat["direction_id"],
+                        "shape_id": pat["shape_id"] if has_shape else "",
                     })
+                    # Monotonic times keep the trip valid even when projection wobbles.
+                    prev_secs = None
+                    for seq, (sid, frac, dist) in enumerate(pat["entries"], 1):
+                        t = dep_secs + frac * run
+                        if prev_secs is not None and t <= prev_secs:
+                            t = prev_secs + 1
+                        prev_secs = t
+                        hhmm = _secs_to_hhmmss(t)
+                        stop_times_rows.append({
+                            "trip_id": trip_id,
+                            "arrival_time": hhmm,
+                            "departure_time": hhmm,
+                            "stop_id": sid,
+                            "stop_sequence": seq,
+                            "shape_dist_traveled": f"{dist:.1f}" if has_shape else "",
+                        })
 
-            if not departures:
-                freq_rows.append({
-                    "trip_id": base,
-                    "start_time": start_time,
-                    "end_time": end_time,
-                    "headway_secs": headway,
-                    "exact_times": 0,
-                })
+                if not departures:
+                    freq_rows.append({
+                        "trip_id": base,
+                        "start_time": start_time,
+                        "end_time": end_time,
+                        "headway_secs": headway,
+                        "exact_times": 0,
+                    })
 
     calendar_rows = [
         {

--- a/gtfs.py
+++ b/gtfs.py
@@ -12,6 +12,7 @@ placeholder headways with real values (e.g. transcribed from the JPD timing
 signboards) when they're known.
 """
 import csv
+import datetime
 import io
 import math
 import re
@@ -24,11 +25,11 @@ import zipfile
 STOP_MERGE_RADIUS_M = 40.0
 
 # GTFS files we emit, in a stable order (zip listing reads sensibly).
-# fare_attributes.txt is only present when a fare is configured.
+# fare_attributes.txt / calendar_dates.txt are only present when configured.
 _FILE_ORDER = [
     "agency.txt", "stops.txt", "routes.txt", "trips.txt", "stop_times.txt",
-    "shapes.txt", "frequencies.txt", "calendar.txt", "fare_attributes.txt",
-    "feed_info.txt",
+    "shapes.txt", "frequencies.txt", "calendar.txt", "calendar_dates.txt",
+    "fare_attributes.txt", "feed_info.txt",
 ]
 
 
@@ -215,7 +216,7 @@ def validate_feed(data):
                     add("error", "missing_column",
                         f"required column absent", f"{fname}: {c}")
     for opt in ("shapes.txt", "frequencies.txt", "feed_info.txt",
-                "fare_attributes.txt"):
+                "fare_attributes.txt", "calendar_dates.txt"):
         tables[opt] = table(opt) or []
     if "feed_info.txt" not in names:
         add("warning", "no_feed_info", "feed_info.txt is recommended")
@@ -334,6 +335,7 @@ def validate_feed(data):
             add("warning", "service_no_days", "service runs on no days",
                 c.get("service_id"))
 
+    freq_windows = {}
     for f in tables["frequencies.txt"]:
         if f.get("trip_id") not in trip_ids:
             add("error", "bad_reference", "frequencies.trip_id not in trips.txt",
@@ -344,10 +346,32 @@ def validate_feed(data):
         except ValueError:
             add("error", "bad_headway", "headway_secs must be a positive integer",
                 f.get("trip_id"))
-        if (f.get("start_time", "") and f.get("end_time", "")
-                and _hhmmss_to_secs(f["start_time"]) >= _hhmmss_to_secs(f["end_time"])):
-            add("error", "bad_window", "frequency start_time not before end_time",
-                f.get("trip_id"))
+        if f.get("start_time", "") and f.get("end_time", ""):
+            s, e = _hhmmss_to_secs(f["start_time"]), _hhmmss_to_secs(f["end_time"])
+            if s >= e:
+                add("error", "bad_window",
+                    "frequency start_time not before end_time", f.get("trip_id"))
+            freq_windows.setdefault(f.get("trip_id"), []).append((s, e))
+    for tid, wins in freq_windows.items():
+        wins.sort()
+        for (s1, e1), (s2, e2) in zip(wins, wins[1:]):
+            if s2 < e1:
+                add("error", "freq_overlap",
+                    "overlapping frequency windows for one trip", tid)
+                break
+
+    for cd in tables["calendar_dates.txt"]:
+        if cd.get("service_id") not in service_ids:
+            add("error", "bad_reference",
+                "calendar_dates.service_id not in calendar.txt",
+                cd.get("service_id"))
+        if not _DATE_OK.match(cd.get("date", "")):
+            add("error", "bad_date", "calendar_dates date is not YYYYMMDD",
+                f"{cd.get('service_id')}: {cd.get('date')}")
+        if cd.get("exception_type") not in ("1", "2"):
+            add("error", "bad_exception",
+                "calendar_dates exception_type must be 1 or 2",
+                cd.get("service_id"))
 
     prev = {}
     for s in tables["shapes.txt"]:
@@ -518,9 +542,16 @@ def build_feed(routes, agencies, params):
         # service_id and trip set. A legacy single `schedule` is one block.
         blocks = r.get("schedules") or [r.get("schedule") or {}]
         for bi, sched in enumerate(blocks[:7]):
-            headway = int(sched.get("headway_secs") or params["headway_secs"])
-            start_time = sched.get("start_time") or params["start_time"]
-            end_time = sched.get("end_time") or params["end_time"]
+            # Time-of-day bands: [{start_time, end_time, headway_secs}, ...]
+            # (peak vs off-peak). Legacy top-level fields are band one.
+            bands = sched.get("bands") or [{
+                k: sched[k]
+                for k in ("headway_secs", "start_time", "end_time")
+                if sched.get(k)
+            }]
+            headway = int(bands[0].get("headway_secs") or params["headway_secs"])
+            start_time = bands[0].get("start_time") or params["start_time"]
+            end_time = bands[0].get("end_time") or params["end_time"]
             days = sched.get("days") or default_days
             departures = sched.get("departures") or []
             service_id = _service_for(days)
@@ -580,13 +611,16 @@ def build_feed(routes, agencies, params):
                         })
 
                 if not departures:
-                    freq_rows.append({
-                        "trip_id": base,
-                        "start_time": start_time,
-                        "end_time": end_time,
-                        "headway_secs": headway,
-                        "exact_times": 0,
-                    })
+                    # One frequencies.txt row per time-of-day band, all
+                    # against the same representative trip.
+                    for band in bands:
+                        freq_rows.append({
+                            "trip_id": base,
+                            "start_time": band.get("start_time") or params["start_time"],
+                            "end_time": band.get("end_time") or params["end_time"],
+                            "headway_secs": int(band.get("headway_secs") or params["headway_secs"]),
+                            "exact_times": 0,
+                        })
 
     calendar_rows = [
         {
@@ -599,6 +633,34 @@ def build_feed(routes, agencies, params):
         }
         for key, sid in sorted(services.items(), key=lambda kv: kv[1])
     ]
+
+    # Holiday exceptions (calendar_dates.txt). Each service is adjusted
+    # relative to what it normally does on that date's weekday, so no
+    # redundant added-but-already-active rows are emitted:
+    #   mode "none":   services active that weekday are removed (type 2)
+    #   mode "sunday": Sunday-running services are added where inactive
+    #                  (type 1), non-Sunday services are removed (type 2)
+    calendar_dates_rows = []
+    for h in params.get("holidays") or []:
+        date = h.get("date", "")
+        try:
+            wd = datetime.datetime.strptime(date, "%Y%m%d").weekday()  # Mon=0
+        except ValueError:
+            continue
+        sunday_mode = h.get("mode") == "sunday"
+        for key, sid in sorted(services.items(), key=lambda kv: kv[1]):
+            active = key[wd] == 1
+            if sunday_mode:
+                runs_sunday = key[6] == 1
+                if runs_sunday and not active:
+                    calendar_dates_rows.append(
+                        {"service_id": sid, "date": date, "exception_type": 1})
+                elif not runs_sunday and active:
+                    calendar_dates_rows.append(
+                        {"service_id": sid, "date": date, "exception_type": 2})
+            elif active:
+                calendar_dates_rows.append(
+                    {"service_id": sid, "date": date, "exception_type": 2})
 
     agency_rows = [{
         "agency_id": a["id"],
@@ -652,6 +714,10 @@ def build_feed(routes, agencies, params):
         tables["frequencies.txt"] = _csv(
             ["trip_id", "start_time", "end_time", "headway_secs", "exact_times"],
             freq_rows)
+
+    if calendar_dates_rows:
+        tables["calendar_dates.txt"] = _csv(
+            ["service_id", "date", "exception_type"], calendar_dates_rows)
 
     # Optional flat fare (e.g. Brunei's B$1): payment on board, no transfers info.
     fare = params.get("fare") or {}

--- a/gtfs.py
+++ b/gtfs.py
@@ -161,9 +161,13 @@ def build_feed(routes, agencies, params):
     """Build a GTFS feed and return it as zip bytes.
 
     routes: [{route_id, short_name, long_name, segments, stops, color?,
-              agency_id?, schedule?}] where schedule overrides the feed
-             defaults per route: {headway_secs?, start_time?, end_time?,
-              days?[7], departures?: [HH:MM:SS, ...], run_secs?}
+              agency_id?, direction?, headsign?, return_headsign?, schedule?}]
+             where schedule overrides the feed defaults per route:
+             {headway_secs?, start_time?, end_time?, days?[7],
+              departures?: [HH:MM:SS, ...], run_secs?}.
+             direction="outback" additionally emits a return pattern
+             (direction_id 1, reversed shape/stops, departures offset by one
+             run time); anything else is a loop/one-way single pattern.
     agencies: list of {id, name, url, phone, timezone, lang, email?} —
               the FIRST is the default operator for unassigned routes.
               (A single dict is accepted for backward compatibility.)
@@ -240,15 +244,6 @@ def build_feed(routes, agencies, params):
             "route_color": (r.get("color") or "").lstrip("#").upper(),
         })
 
-        for i, p in enumerate(points):
-            shapes_rows.append({
-                "shape_id": shape_id,
-                "shape_pt_lon": f"{p[0]:.6f}",
-                "shape_pt_lat": f"{p[1]:.6f}",
-                "shape_pt_sequence": i,
-                "shape_dist_traveled": f"{cum[i]:.1f}",
-            })
-
         # Project each stop onto the shape once; every trip reuses the offsets.
         # Times are spread over the first->last stop span (not the full shape),
         # so a trip departs its first stop exactly at the departure time.
@@ -267,48 +262,91 @@ def build_feed(routes, agencies, params):
                 frac = (idx / (n - 1)) if n > 1 else 0.0
             stop_entries.append((pool.resolve(s), frac, dist))
 
-        # Transcribed departures -> one real trip each (no frequencies entry).
-        # Otherwise a single representative trip + a frequency-based headway.
-        if departures:
-            trip_starts = [
-                (f"trip_{rid}_{i + 1}", _hhmmss_to_secs(d))
-                for i, d in enumerate(departures)
+        # Direction patterns. Loop/one-way routes have a single pattern.
+        # Out-and-back routes additionally get a return pattern (direction_id
+        # 1): reversed shape, reversed stop order, and — since the bus turns
+        # around at the far terminal — departures offset by one run time.
+        patterns = [{
+            "suffix": "",
+            "shape_id": shape_id,
+            "points": points,
+            "cum": cum,
+            "direction_id": 0,
+            "headsign": r.get("headsign", "") or "",
+            "entries": stop_entries,
+            "dep_offset": 0,
+        }]
+        if r.get("direction") == "outback":
+            entries_r = [
+                (sid, 1.0 - frac, total - dist)
+                for sid, frac, dist in reversed(stop_entries)
             ]
-        else:
-            trip_starts = [(f"trip_{rid}", _hhmmss_to_secs(start_time))]
-
-        for trip_id, dep_secs in trip_starts:
-            trips_rows.append({
-                "route_id": rid,
-                "service_id": service_id,
-                "trip_id": trip_id,
-                "shape_id": shape_id if has_shape else "",
+            patterns.append({
+                "suffix": "_r",
+                "shape_id": f"{shape_id}_r",
+                "points": points[::-1],
+                "cum": [total - c for c in reversed(cum)],
+                "direction_id": 1,
+                "headsign": r.get("return_headsign", "") or "",
+                "entries": entries_r,
+                "dep_offset": run,
             })
-            # Monotonic times keep the trip valid even when projection wobbles.
-            prev_secs = None
-            for seq, (sid, frac, dist) in enumerate(stop_entries, 1):
-                t = dep_secs + frac * run
-                if prev_secs is not None and t <= prev_secs:
-                    t = prev_secs + 1
-                prev_secs = t
-                hhmm = _secs_to_hhmmss(t)
-                stop_times_rows.append({
-                    "trip_id": trip_id,
-                    "arrival_time": hhmm,
-                    "departure_time": hhmm,
-                    "stop_id": sid,
-                    "stop_sequence": seq,
-                    "shape_dist_traveled": f"{dist:.1f}" if has_shape else "",
+
+        for pat in patterns:
+            for i, p in enumerate(pat["points"]):
+                shapes_rows.append({
+                    "shape_id": pat["shape_id"],
+                    "shape_pt_lon": f"{p[0]:.6f}",
+                    "shape_pt_lat": f"{p[1]:.6f}",
+                    "shape_pt_sequence": i,
+                    "shape_dist_traveled": f"{pat['cum'][i]:.1f}",
                 })
 
-        if not departures:
-            freq_rows.append({
-                "trip_id": f"trip_{rid}",
-                "start_time": start_time,
-                "end_time": end_time,
-                "headway_secs": headway,
-                "exact_times": 0,
-            })
+            # Transcribed departures -> one real trip each (no frequencies
+            # entry). Otherwise one representative trip + a headway.
+            base = f"trip_{rid}{pat['suffix']}"
+            if departures:
+                trip_starts = [
+                    (f"{base}_{i + 1}", _hhmmss_to_secs(d) + pat["dep_offset"])
+                    for i, d in enumerate(departures)
+                ]
+            else:
+                trip_starts = [(base, _hhmmss_to_secs(start_time) + pat["dep_offset"])]
+
+            for trip_id, dep_secs in trip_starts:
+                trips_rows.append({
+                    "route_id": rid,
+                    "service_id": service_id,
+                    "trip_id": trip_id,
+                    "trip_headsign": pat["headsign"],
+                    "direction_id": pat["direction_id"],
+                    "shape_id": pat["shape_id"] if has_shape else "",
+                })
+                # Monotonic times keep the trip valid even when projection wobbles.
+                prev_secs = None
+                for seq, (sid, frac, dist) in enumerate(pat["entries"], 1):
+                    t = dep_secs + frac * run
+                    if prev_secs is not None and t <= prev_secs:
+                        t = prev_secs + 1
+                    prev_secs = t
+                    hhmm = _secs_to_hhmmss(t)
+                    stop_times_rows.append({
+                        "trip_id": trip_id,
+                        "arrival_time": hhmm,
+                        "departure_time": hhmm,
+                        "stop_id": sid,
+                        "stop_sequence": seq,
+                        "shape_dist_traveled": f"{dist:.1f}" if has_shape else "",
+                    })
+
+            if not departures:
+                freq_rows.append({
+                    "trip_id": base,
+                    "start_time": start_time,
+                    "end_time": end_time,
+                    "headway_secs": headway,
+                    "exact_times": 0,
+                })
 
     calendar_rows = [
         {
@@ -349,7 +387,8 @@ def build_feed(routes, agencies, params):
             ["route_id", "agency_id", "route_short_name", "route_long_name",
              "route_type", "route_color"], routes_rows),
         "trips.txt": _csv(
-            ["route_id", "service_id", "trip_id", "shape_id"], trips_rows),
+            ["route_id", "service_id", "trip_id", "trip_headsign",
+             "direction_id", "shape_id"], trips_rows),
         "stop_times.txt": _csv(
             ["trip_id", "arrival_time", "departure_time", "stop_id",
              "stop_sequence", "shape_dist_traveled"], stop_times_rows),

--- a/gtfs.py
+++ b/gtfs.py
@@ -24,12 +24,15 @@ import zipfile
 # small leaves duplicates.
 STOP_MERGE_RADIUS_M = 40.0
 
+# Distinct stops within this walking distance become transfers.txt pairs.
+TRANSFER_RADIUS_M = 100.0
+
 # GTFS files we emit, in a stable order (zip listing reads sensibly).
-# fare_attributes.txt / calendar_dates.txt are only present when configured.
+# fare_attributes/calendar_dates/transfers are only present when applicable.
 _FILE_ORDER = [
     "agency.txt", "stops.txt", "routes.txt", "trips.txt", "stop_times.txt",
     "shapes.txt", "frequencies.txt", "calendar.txt", "calendar_dates.txt",
-    "fare_attributes.txt", "feed_info.txt",
+    "transfers.txt", "fare_attributes.txt", "feed_info.txt",
 ]
 
 
@@ -150,6 +153,35 @@ class _StopPool:
             "stop_lon": f"{e['lon']:.6f}",
         } for e in self._entries]
 
+    def transfer_pairs(self, radius_m):
+        """Directed pairs of DISTINCT stops within walking radius — transfer
+        opportunities for transfers.txt. Grid-bucketed so the all-pairs scan
+        stays linear-ish."""
+        cell = radius_m / 111000.0  # ~degrees per radius
+        grid = {}
+        for i, e in enumerate(self._entries):
+            grid.setdefault(
+                (int(e["lat"] / cell), int(e["lon"] / cell)), []
+            ).append(i)
+        pairs = []
+        for (gy, gx), idxs in grid.items():
+            neighbours = [
+                j
+                for dy in (-1, 0, 1)
+                for dx in (-1, 0, 1)
+                for j in grid.get((gy + dy, gx + dx), [])
+            ]
+            for i in idxs:
+                a = self._entries[i]
+                for j in neighbours:
+                    if j <= i:
+                        continue
+                    b = self._entries[j]
+                    d = _haversine([a["lon"], a["lat"]], [b["lon"], b["lat"]])
+                    if d <= radius_m:
+                        pairs.append((a["stop_id"], b["stop_id"], d))
+        return pairs
+
 
 # --- validation ----------------------------------------------------------------
 # Required files and the columns each must carry (a subset of the spec
@@ -216,7 +248,7 @@ def validate_feed(data):
                     add("error", "missing_column",
                         f"required column absent", f"{fname}: {c}")
     for opt in ("shapes.txt", "frequencies.txt", "feed_info.txt",
-                "fare_attributes.txt", "calendar_dates.txt"):
+                "fare_attributes.txt", "calendar_dates.txt", "transfers.txt"):
         tables[opt] = table(opt) or []
     if "feed_info.txt" not in names:
         add("warning", "no_feed_info", "feed_info.txt is recommended")
@@ -243,11 +275,13 @@ def validate_feed(data):
             add("error", "no_timezone", "agency_timezone is required",
                 a.get("agency_id"))
 
+    stop_coords = {}
     for s in tables["stops.txt"]:
         try:
             lat, lon = float(s.get("stop_lat", "")), float(s.get("stop_lon", ""))
             if not (-90 <= lat <= 90 and -180 <= lon <= 180):
                 raise ValueError
+            stop_coords[s.get("stop_id")] = (lon, lat)
             if lat == 0 and lon == 0:
                 add("warning", "null_island", "stop at coordinates 0,0",
                     s.get("stop_id"))
@@ -268,7 +302,10 @@ def validate_feed(data):
                 f"{r.get('route_id')}: {color}")
 
     used_routes, used_services = set(), set()
+    shape_first_trip = {}  # shape_id -> a representative trip on it
     for t in tables["trips.txt"]:
+        if t.get("shape_id") and t["shape_id"] not in shape_first_trip:
+            shape_first_trip[t["shape_id"]] = t.get("trip_id")
         if t.get("route_id") not in route_ids:
             add("error", "bad_reference", "trips.route_id not in routes.txt",
                 t.get("trip_id"))
@@ -286,9 +323,11 @@ def validate_feed(data):
         add("warning", "service_without_trips", "calendar service unused", sid)
 
     by_trip = {}
+    trip_stops = {}
     used_stops = set()
     for st in tables["stop_times.txt"]:
         tid = st.get("trip_id", "")
+        trip_stops.setdefault(tid, set()).add(st.get("stop_id"))
         if tid not in trip_ids:
             add("error", "bad_reference", "stop_times.trip_id not in trips.txt", tid)
         if st.get("stop_id") not in stop_ids:
@@ -374,11 +413,15 @@ def validate_feed(data):
                 cd.get("service_id"))
 
     prev = {}
+    shape_pts = {}
     for s in tables["shapes.txt"]:
         sid = s.get("shape_id", "")
         try:
             seq = int(s.get("shape_pt_sequence", ""))
             dist = float(s.get("shape_dist_traveled") or 0)
+            shape_pts.setdefault(sid, []).append(
+                (float(s.get("shape_pt_lon", "")), float(s.get("shape_pt_lat", "")))
+            )
         except ValueError:
             add("error", "bad_shape", "unparseable shape sequence/distance", sid)
             continue
@@ -386,6 +429,39 @@ def validate_feed(data):
             add("warning", "shape_disorder",
                 "shape sequence/distance not increasing", sid)
         prev[sid] = (seq, dist)
+
+    for tr in tables["transfers.txt"]:
+        for col in ("from_stop_id", "to_stop_id"):
+            if tr.get(col) not in stop_ids:
+                add("error", "bad_reference",
+                    f"transfers.{col} not in stops.txt", tr.get(col))
+        if tr.get("transfer_type") not in ("", "0", "1", "2", "3"):
+            add("error", "bad_transfer_type",
+                "transfer_type must be 0..3", tr.get("from_stop_id"))
+        if tr.get("from_stop_id") == tr.get("to_stop_id"):
+            add("warning", "self_transfer", "transfer from a stop to itself",
+                tr.get("from_stop_id"))
+
+    # A stop far off its route's drawn line is almost always a placement or
+    # tracing error. Checked once per shape with a fast equirectangular
+    # approximation against shape vertices.
+    for sid, tid in shape_first_trip.items():
+        pts = shape_pts.get(sid)
+        if not pts:
+            continue
+        coslat = math.cos(math.radians(pts[0][1]))
+        for stop_id in trip_stops.get(tid, set()):
+            c = stop_coords.get(stop_id)
+            if not c:
+                continue
+            best = min(
+                (((c[0] - p[0]) * coslat) ** 2 + (c[1] - p[1]) ** 2)
+                for p in pts
+            )
+            if (best ** 0.5) * 111320.0 > 150.0:
+                add("warning", "stop_off_shape",
+                    "stop is over 150 m from its route's line",
+                    f"{stop_id} on {sid}")
 
     findings = sorted(
         agg.values(), key=lambda f: (f["severity"] != "error", f["code"])
@@ -473,13 +549,17 @@ def build_feed(routes, agencies, params):
         aid = r.get("agency_id")
         if aid not in known_agency_ids:
             aid = default_agency_id
+        hail = bool(r.get("hail"))  # hail & ride: continuous stopping allowed
         routes_rows.append({
             "route_id": rid,
             "agency_id": aid,
             "route_short_name": r.get("short_name", "") or "",
             "route_long_name": r.get("long_name", "") or "",
+            "route_desc": r.get("desc", "") or "",
             "route_type": 3,  # 3 = bus
             "route_color": (r.get("color") or "").lstrip("#").upper(),
+            "continuous_pickup": 0 if hail else "",
+            "continuous_drop_off": 0 if hail else "",
         })
 
         # Project each stop onto the shape once; every trip reuses the offsets.
@@ -554,6 +634,7 @@ def build_feed(routes, agencies, params):
             end_time = bands[0].get("end_time") or params["end_time"]
             days = sched.get("days") or default_days
             departures = sched.get("departures") or []
+            ret_departures = sched.get("return_departures") or []
             service_id = _service_for(days)
 
             # End-to-end run time used to spread intermediate stop times:
@@ -565,19 +646,28 @@ def build_feed(routes, agencies, params):
 
             bsuf = "" if bi == 0 else f"_b{bi + 1}"
             for pat in patterns:
-                # The bus turns around at the far terminal, so the return
-                # direction departs one run time after the outbound.
-                offset = run if pat["direction_id"] else 0
                 base = f"trip_{rid}{bsuf}{pat['suffix']}"
+                is_return = bool(pat["direction_id"])
 
                 # Transcribed departures -> one real trip each (no frequencies
-                # entry). Otherwise one representative trip + a headway.
-                if departures:
+                # entry). The return direction prefers exactly transcribed
+                # return times; else outbound + one run time (the bus turns
+                # around at the far terminal). No times at all -> one
+                # representative trip + a headway.
+                if is_return and ret_departures:
+                    exact = [(d, 0) for d in ret_departures]
+                elif departures:
+                    exact = [(d, run if is_return else 0) for d in departures]
+                else:
+                    exact = None
+
+                if exact is not None:
                     trip_starts = [
-                        (f"{base}_{i + 1}", _hhmmss_to_secs(d) + offset)
-                        for i, d in enumerate(departures)
+                        (f"{base}_{i + 1}", _hhmmss_to_secs(d) + off)
+                        for i, (d, off) in enumerate(exact)
                     ]
                 else:
+                    offset = run if is_return else 0
                     trip_starts = [(base, _hhmmss_to_secs(start_time) + offset)]
 
                 for trip_id, dep_secs in trip_starts:
@@ -605,12 +695,16 @@ def build_feed(routes, agencies, params):
                             "stop_sequence": seq,
                             # Only the first stop of a transcribed-departure
                             # trip is an exact time; everything else here is
-                            # interpolated (an estimate, per the spec).
-                            "timepoint": 1 if (departures and seq == 1) else 0,
+                            # interpolated (an estimate, per the spec). The
+                            # derived return direction is all estimates.
+                            "timepoint": 1 if (
+                                exact is not None and seq == 1
+                                and not (is_return and not ret_departures)
+                            ) else 0,
                             "shape_dist_traveled": f"{dist:.1f}" if has_shape else "",
                         })
 
-                if not departures:
+                if exact is None:
                     # One frequencies.txt row per time-of-day band, all
                     # against the same representative trip.
                     for band in bands:
@@ -688,7 +782,8 @@ def build_feed(routes, agencies, params):
             pool.rows()),
         "routes.txt": _csv(
             ["route_id", "agency_id", "route_short_name", "route_long_name",
-             "route_type", "route_color"], routes_rows),
+             "route_desc", "route_type", "route_color", "continuous_pickup",
+             "continuous_drop_off"], routes_rows),
         "trips.txt": _csv(
             ["route_id", "service_id", "trip_id", "trip_headsign",
              "direction_id", "shape_id"], trips_rows),
@@ -718,6 +813,20 @@ def build_feed(routes, agencies, params):
     if calendar_dates_rows:
         tables["calendar_dates.txt"] = _csv(
             ["service_id", "date", "exception_type"], calendar_dates_rows)
+
+    # Walking transfers between distinct nearby stops (both directions).
+    # transfer_type 2 = minimum time required: walk at ~1 m/s + a buffer.
+    transfer_rows = []
+    for a, b, dist in pool.transfer_pairs(TRANSFER_RADIUS_M):
+        t = int(dist) + 60
+        transfer_rows.append({"from_stop_id": a, "to_stop_id": b,
+                              "transfer_type": 2, "min_transfer_time": t})
+        transfer_rows.append({"from_stop_id": b, "to_stop_id": a,
+                              "transfer_type": 2, "min_transfer_time": t})
+    if transfer_rows:
+        tables["transfers.txt"] = _csv(
+            ["from_stop_id", "to_stop_id", "transfer_type",
+             "min_transfer_time"], transfer_rows)
 
     # Optional flat fare (e.g. Brunei's B$1): payment on board, no transfers info.
     fare = params.get("fare") or {}

--- a/gtfs.py
+++ b/gtfs.py
@@ -111,19 +111,27 @@ class _StopPool:
         self.merges = 0
 
     def resolve(self, stop):
-        """Return a stop_id for `stop` ({name, lon, lat}), merging when possible."""
+        """Return a stop_id for `stop` ({name, lon, lat, code?}), merging when
+        possible. Stops with two DIFFERENT public codes never merge; a merge
+        backfills a code the first occurrence lacked."""
         key = _norm_name(stop.get("name"))
+        code = (stop.get("code") or "").strip()
         sp = [stop["lon"], stop["lat"]]
         if key:  # named stops merge by name + proximity
             for idx in self._by_name.get(key, []):
                 ex = self._entries[idx]
+                if code and ex["code"] and ex["code"] != code:
+                    continue  # same name but distinct signed stops
                 if _haversine(sp, [ex["lon"], ex["lat"]]) <= STOP_MERGE_RADIUS_M:
+                    if code and not ex["code"]:
+                        ex["code"] = code
                     self.merges += 1
                     return ex["stop_id"]
         stop_id = f"S{len(self._entries) + 1:04d}"
         self._entries.append({
             "stop_id": stop_id,
             "name": stop.get("name") or stop_id,
+            "code": code,
             "lon": stop["lon"],
             "lat": stop["lat"],
         })
@@ -135,6 +143,7 @@ class _StopPool:
         """stops.txt rows with coords formatted to 6 decimals."""
         return [{
             "stop_id": e["stop_id"],
+            "stop_code": e["code"],
             "stop_name": e["name"],
             "stop_lat": f"{e['lat']:.6f}",
             "stop_lon": f"{e['lon']:.6f}",
@@ -344,6 +353,10 @@ def build_feed(routes, agencies, params):
                             "departure_time": hhmm,
                             "stop_id": sid,
                             "stop_sequence": seq,
+                            # Only the first stop of a transcribed-departure
+                            # trip is an exact time; everything else here is
+                            # interpolated (an estimate, per the spec).
+                            "timepoint": 1 if (departures and seq == 1) else 0,
                             "shape_dist_traveled": f"{dist:.1f}" if has_shape else "",
                         })
 
@@ -390,7 +403,8 @@ def build_feed(routes, agencies, params):
             ["agency_id", "agency_name", "agency_url", "agency_timezone",
              "agency_lang", "agency_phone", "agency_email"], agency_rows),
         "stops.txt": _csv(
-            ["stop_id", "stop_name", "stop_lat", "stop_lon"], pool.rows()),
+            ["stop_id", "stop_code", "stop_name", "stop_lat", "stop_lon"],
+            pool.rows()),
         "routes.txt": _csv(
             ["route_id", "agency_id", "route_short_name", "route_long_name",
              "route_type", "route_color"], routes_rows),
@@ -399,7 +413,8 @@ def build_feed(routes, agencies, params):
              "direction_id", "shape_id"], trips_rows),
         "stop_times.txt": _csv(
             ["trip_id", "arrival_time", "departure_time", "stop_id",
-             "stop_sequence", "shape_dist_traveled"], stop_times_rows),
+             "stop_sequence", "timepoint", "shape_dist_traveled"],
+            stop_times_rows),
         "shapes.txt": _csv(
             ["shape_id", "shape_pt_lat", "shape_pt_lon", "shape_pt_sequence",
              "shape_dist_traveled"], shapes_rows),

--- a/gtfs.py
+++ b/gtfs.py
@@ -24,9 +24,11 @@ import zipfile
 STOP_MERGE_RADIUS_M = 40.0
 
 # GTFS files we emit, in a stable order (zip listing reads sensibly).
+# fare_attributes.txt is only present when a fare is configured.
 _FILE_ORDER = [
     "agency.txt", "stops.txt", "routes.txt", "trips.txt", "stop_times.txt",
-    "shapes.txt", "frequencies.txt", "calendar.txt", "feed_info.txt",
+    "shapes.txt", "frequencies.txt", "calendar.txt", "fare_attributes.txt",
+    "feed_info.txt",
 ]
 
 
@@ -134,25 +136,40 @@ def _csv(header, rows):
 
 
 # --- feed builder ------------------------------------------------------------
+def _hhmmss_to_secs(t):
+    h, m, s = (int(x) for x in t.split(":"))
+    return h * 3600 + m * 60 + s
+
+
 def build_feed(routes, agency, params):
     """Build a GTFS feed and return it as zip bytes.
 
-    routes: [{route_id, short_name, long_name, segments, stops}]
+    routes: [{route_id, short_name, long_name, segments, stops, color?,
+              schedule?}] where schedule overrides the feed defaults per route:
+             {headway_secs?, start_time?, end_time?, days?[7]}
     agency: {id, name, url, phone, timezone, lang, email?}
     params: {headway_secs, start_time, end_time, service_id, days[7],
              start_date, end_date, feed_version, publisher_name, publisher_url,
-             feed_lang}
+             feed_lang, fare?: {price, currency}}
     """
     agency_id = agency["id"]
-    service_id = params["service_id"]
-    headway = int(params["headway_secs"])
+    default_service_id = params["service_id"]
+    default_days = list(params["days"])
 
-    # Service window as seconds since midnight; trip stop_times span it from 0.
-    def _hhmmss_to_secs(t):
-        h, m, s = (int(x) for x in t.split(":"))
-        return h * 3600 + m * 60 + s
+    # Each distinct operating-days pattern becomes its own service_id; the
+    # feed-default pattern keeps the default id (e.g. DAILY).
+    services = {}  # tuple(days) -> service_id
 
-    win_start = _hhmmss_to_secs(params["start_time"])
+    def _service_for(days):
+        key = tuple(int(bool(d)) for d in days)
+        if key not in services:
+            if list(key) == default_days:
+                services[key] = default_service_id
+            else:
+                services[key] = "SVC_" + "".join(str(d) for d in key)
+        return services[key]
+
+    _service_for(default_days)  # always emit the default service
 
     pool = _StopPool()
     routes_rows, trips_rows, shapes_rows, stop_times_rows, freq_rows = [], [], [], [], []
@@ -161,6 +178,15 @@ def build_feed(routes, agency, params):
         rid = r["route_id"]
         shape_id = f"shp_{rid}"
         trip_id = f"trip_{rid}"
+
+        # Per-route schedule overrides, falling back to the feed defaults.
+        sched = r.get("schedule") or {}
+        headway = int(sched.get("headway_secs") or params["headway_secs"])
+        start_time = sched.get("start_time") or params["start_time"]
+        end_time = sched.get("end_time") or params["end_time"]
+        days = sched.get("days") or default_days
+        service_id = _service_for(days)
+        win_start = _hhmmss_to_secs(start_time)
 
         points = _flatten_segments(r.get("segments", []))
         cum = _cumulative_dist(points)
@@ -172,6 +198,7 @@ def build_feed(routes, agency, params):
             "route_short_name": r.get("short_name", "") or "",
             "route_long_name": r.get("long_name", "") or "",
             "route_type": 3,  # 3 = bus
+            "route_color": (r.get("color") or "").lstrip("#").upper(),
         })
 
         for i, p in enumerate(points):
@@ -221,21 +248,23 @@ def build_feed(routes, agency, params):
 
         freq_rows.append({
             "trip_id": trip_id,
-            "start_time": params["start_time"],
-            "end_time": params["end_time"],
+            "start_time": start_time,
+            "end_time": end_time,
             "headway_secs": headway,
             "exact_times": 0,
         })
 
-    days = params["days"]
-    calendar_rows = [{
-        "service_id": service_id,
-        "monday": days[0], "tuesday": days[1], "wednesday": days[2],
-        "thursday": days[3], "friday": days[4], "saturday": days[5],
-        "sunday": days[6],
-        "start_date": params["start_date"],
-        "end_date": params["end_date"],
-    }]
+    calendar_rows = [
+        {
+            "service_id": sid,
+            "monday": key[0], "tuesday": key[1], "wednesday": key[2],
+            "thursday": key[3], "friday": key[4], "saturday": key[5],
+            "sunday": key[6],
+            "start_date": params["start_date"],
+            "end_date": params["end_date"],
+        }
+        for key, sid in sorted(services.items(), key=lambda kv: kv[1])
+    ]
 
     agency_rows = [{
         "agency_id": agency_id,
@@ -262,7 +291,7 @@ def build_feed(routes, agency, params):
             ["stop_id", "stop_name", "stop_lat", "stop_lon"], pool.rows()),
         "routes.txt": _csv(
             ["route_id", "agency_id", "route_short_name", "route_long_name",
-             "route_type"], routes_rows),
+             "route_type", "route_color"], routes_rows),
         "trips.txt": _csv(
             ["route_id", "service_id", "trip_id", "shape_id"], trips_rows),
         "stop_times.txt": _csv(
@@ -283,10 +312,24 @@ def build_feed(routes, agency, params):
              "feed_version"], feed_info_rows),
     }
 
+    # Optional flat fare (e.g. Brunei's B$1): payment on board, no transfers info.
+    fare = params.get("fare") or {}
+    if fare.get("price"):
+        tables["fare_attributes.txt"] = _csv(
+            ["fare_id", "price", "currency_type", "payment_method", "transfers"],
+            [{
+                "fare_id": "FLAT",
+                "price": f"{float(fare['price']):.2f}",
+                "currency_type": fare.get("currency", "BND"),
+                "payment_method": 0,  # paid on board
+                "transfers": "",      # unlimited / unknown
+            }])
+
     out = io.BytesIO()
     with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zf:
         for name in _FILE_ORDER:
-            zf.writestr(name, tables[name])
+            if name in tables:
+                zf.writestr(name, tables[name])
 
     return out.getvalue(), {
         "routes": len(routes_rows),

--- a/scripts/build_gtfs.py
+++ b/scripts/build_gtfs.py
@@ -26,11 +26,10 @@ def main():
     args = ap.parse_args()
 
     year = appmod._resolve_year(args.year)
-    routes = appmod.gather_gtfs_routes(year)
+    routes, agency, params = appmod.gtfs_feed_inputs(year)
     if not routes:
         sys.exit(f"No exportable routes found for year {year}.")
 
-    params = dict(appmod.GTFS_PARAMS, feed_version=f"{year}.1")
     if args.headway:
         params["headway_secs"] = args.headway
     if args.start_time:
@@ -38,7 +37,7 @@ def main():
     if args.end_time:
         params["end_time"] = args.end_time
 
-    data, stats = gtfs.build_feed(routes, appmod.GTFS_AGENCY, params)
+    data, stats = gtfs.build_feed(routes, agency, params)
     with open(args.out, "wb") as f:
         f.write(data)
 

--- a/scripts/build_gtfs.py
+++ b/scripts/build_gtfs.py
@@ -23,6 +23,8 @@ def main():
     ap.add_argument("--headway", type=int, help="headway seconds (overrides default)")
     ap.add_argument("--start-time", help="service window start HH:MM:SS")
     ap.add_argument("--end-time", help="service window end HH:MM:SS")
+    ap.add_argument("--validate", action="store_true",
+                    help="run the structural validator on the built feed")
     args = ap.parse_args()
 
     year = appmod._resolve_year(args.year)
@@ -48,6 +50,16 @@ def main():
     print(f"  stops:       {stats['stops']} ({stats['merged_stops']} merges)")
     print(f"  stop_times:  {stats['stop_times']}")
     print(f"  shape_points:{stats['shape_points']}")
+
+    if args.validate:
+        findings = gtfs.validate_feed(data)
+        errors = sum(1 for f in findings if f["severity"] == "error")
+        print(f"\nValidation: {errors} errors, {len(findings) - errors} warnings")
+        for f in findings:
+            ex = f" — {', '.join(f['examples'])}" if f["examples"] else ""
+            print(f"  [{f['severity'].upper():7}] {f['message']} (x{f['count']}){ex}")
+        if errors:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/build_gtfs.py
+++ b/scripts/build_gtfs.py
@@ -42,7 +42,9 @@ def main():
         f.write(data)
 
     print(f"Wrote {args.out} ({len(data):,} bytes)")
-    print(f"  routes:      {stats['routes']}")
+    print(f"  routes:      {stats['routes']} "
+          f"({stats['scheduled_routes']} with transcribed departures)")
+    print(f"  trips:       {stats['trips']}")
     print(f"  stops:       {stats['stops']} ({stats['merged_stops']} merges)")
     print(f"  stop_times:  {stats['stop_times']}")
     print(f"  shape_points:{stats['shape_points']}")

--- a/static/css/offcanvas.css
+++ b/static/css/offcanvas.css
@@ -1,59 +1,8 @@
-/*
- * Style tweaks
- * --------------------------------------------------
- */
+/* The mobile sidebar collapse is #sidebar.collapsed (styles.css) toggled by
+ * offcanvas.js. The slide-out transform pushes past the viewport edge — this
+ * keeps that from creating a horizontal scrollbar. (The Bootstrap offcanvas
+ * boilerplate that used to live here targeted markup this app never had.) */
 html,
 body {
-  overflow-x: hidden; /* Prevent scroll on narrow devices */
-}
-body {
-  padding-top: 70px;
-}
-footer {
-  padding: 30px 0;
-}
-
-/*
- * Off Canvas
- * --------------------------------------------------
- */
-@media screen and (max-width: 767px) {
-  .row-offcanvas {
-    position: relative;
-    -webkit-transition: all .25s ease-out;
-         -o-transition: all .25s ease-out;
-            transition: all .25s ease-out;
-  }
-
-  .row-offcanvas-right {
-    right: 0;
-  }
-
-  .row-offcanvas-left {
-    left: 0;
-  }
-
-  .row-offcanvas-right
-  .sidebar-offcanvas {
-    right: -75%; /* roomier for long route names */
-  }
-
-  .row-offcanvas-left
-  .sidebar-offcanvas {
-    left: -75%;
-  }
-
-  .row-offcanvas-right.active {
-    right: 75%;
-  }
-
-  .row-offcanvas-left.active {
-    left: 75%;
-  }
-
-  .sidebar-offcanvas {
-    position: absolute;
-    top: 0;
-    width: 75%;
-  }
+  overflow-x: hidden;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -538,3 +538,62 @@ details.gep-section summary {
   cursor: nwse-resize;
   background: linear-gradient(135deg, transparent 50%, #b0b0b0 50%);
 }
+
+/* --- GTFS workbench page (/gtfs): routes | map+editor | docked GTFS pane --- */
+body.gtfs-page {
+  height: 100%;
+  overflow: hidden;
+}
+.gtfs-layout {
+  display: flex;
+  height: calc(100vh - 50px); /* below the fixed navbar */
+}
+.gtfs-routes-col {
+  flex: 0 0 280px;
+  overflow-y: auto;
+  padding: 8px;
+  background: #fafafa;
+  border-right: 1px solid #ddd;
+}
+.gtfs-routes-col .sidebar-title {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+.gtfs-map-col {
+  flex: 1 1 auto;
+  position: relative;
+  min-width: 320px;
+}
+body.gtfs-page #map {
+  width: 100%;
+  height: 100%;
+}
+body.gtfs-page #routes {
+  max-height: none;
+}
+/* Docked variant of the GTFS editor: a permanent right column, not a
+   floating window. */
+#gtfsPanel.docked {
+  position: static;
+  flex: 0 0 400px;
+  width: 400px;
+  height: auto;
+  max-width: none;
+  max-height: none;
+  border: none;
+  border-left: 1px solid #ddd;
+  border-radius: 0;
+  box-shadow: none;
+}
+#gtfsPanel.docked #gtfsHeader {
+  cursor: default;
+}
+@media (max-width: 991px) {
+  .gtfs-routes-col {
+    flex-basis: 200px;
+  }
+  #gtfsPanel.docked {
+    flex-basis: 320px;
+    width: 320px;
+  }
+}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -375,190 +375,149 @@ body.editing #sidebar {
   background: linear-gradient(135deg, transparent 50%, #b0b0b0 50%);
 }
 
-/* --- GTFS editor panel (mirrors the stop-image panel patterns) --- */
-#gtfsPanel {
-  position: absolute;
-  top: 120px;
-  right: 320px;
-  width: 380px;
-  height: 540px;
-  min-width: 280px;
-  min-height: 260px;
-  max-width: calc(100% - 24px);
-  max-height: calc(100% - 80px);
-  z-index: 1100;
-  display: flex;
-  flex-direction: column;
-  background: #fff;
-  border: 1px solid #aaa;
-  border-radius: 6px;
-  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
-  overflow: hidden;
-}
-#gtfsHeader {
-  flex: 0 0 auto;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 4px;
-  padding: 5px 6px;
-  background: #2c3e50;
-  color: #fff;
-  cursor: move;
-  user-select: none;
-}
-#gtfsHeader .gep-title {
-  font-weight: 600;
-  font-size: 12px;
-  margin-right: 2px;
-}
-#gtfsHeader select {
-  width: auto;
-  max-width: 160px;
-  height: 24px;
-  padding: 1px 4px;
-  font-size: 12px;
-  color: #333;
-}
-#gtfsHeader .gep-tools {
-  margin-left: auto;
-  white-space: nowrap;
-}
-#gtfsBody {
-  flex: 1 1 auto;
-  overflow: auto;
-  padding: 6px 8px;
-}
-.gep-section {
-  margin-bottom: 8px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  padding: 6px 8px;
-}
-.gep-section-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 4px;
-  font-size: 12px;
-  font-weight: 600;
-  color: #444;
-  margin-bottom: 4px;
-}
-.gep-section-head .gep-tools select {
-  display: inline-block;
-  width: auto;
-  max-width: 150px;
-  height: 22px;
-  padding: 1px 4px;
-  font-size: 11px;
-}
-details.gep-section summary {
-  cursor: pointer;
-  outline: none;
-}
-.gep-status {
-  font-weight: 400;
-  font-size: 11px;
-  color: #2e7d32;
-}
-.gep-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
-  margin-bottom: 4px;
-  font-size: 12px;
-}
-.gep-row label {
-  display: flex;
-  align-items: center;
-  gap: 3px;
-  margin: 0;
-  font-weight: 400;
-}
-.gep-row input[type="number"] {
-  width: 54px;
-}
-.gep-row input[type="text"],
-.gep-row input[type="number"],
-.gep-row input[type="time"] {
-  font-size: 12px;
-  padding: 2px 4px;
-  border: 1px solid #ccc;
-  border-radius: 3px;
-  height: 24px;
-}
-.gep-row #gepLong {
-  flex: 1 1 120px;
-}
-.gep-days label {
-  gap: 2px;
-}
-.gep-row .gep-block {
-  display: block;
-  flex: 1 1 100%;
-  font-size: 11px;
-  color: #666;
-}
-.gep-row .gep-block textarea {
-  display: block;
-  width: 100%;
-  margin-top: 2px;
-  resize: vertical;
-  font-size: 12px;
-  color: #333;
-  padding: 3px 5px;
-  border: 1px solid #ccc;
-  border-radius: 3px;
-}
-#gtfsTimingBody {
-  max-height: 220px;
-  overflow: auto;
-  background: #f2f2f2;
-  text-align: center;
-  border-radius: 3px;
-}
-#gtfsTimingImg {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-.gep-empty {
-  padding: 16px;
-  color: #888;
-  font-size: 12px;
-}
-#gtfsResize {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 16px;
-  height: 16px;
-  cursor: nwse-resize;
-  background: linear-gradient(135deg, transparent 50%, #b0b0b0 50%);
-}
-
-/* --- GTFS workbench page (/gtfs): routes | map+editor | docked GTFS pane --- */
+/* ====================================================================
+   GTFS workbench (/gtfs) — transit-signage design language.
+   Ink slate + warm paper surfaces, one signage-yellow accent, Barlow
+   Condensed display type and IBM Plex Mono for anything that is a time
+   or a route code. The departures field reads like a departure board.
+   ==================================================================== */
 body.gtfs-page {
+  --gtfs-ink: #1d2a33;        /* dark slate, like the signboard frames */
+  --gtfs-ink-soft: #46555f;
+  --gtfs-paper: #f6f4ee;      /* warm paper */
+  --gtfs-card: #ffffff;
+  --gtfs-line: #ddd6c8;
+  --gtfs-accent: #ffd166;     /* signage yellow (matches the stop markers) */
+  --gtfs-accent-ink: #6b5200;
+  --gtfs-go: #2e7d32;
+  --gtfs-display: "Barlow Condensed", "Arial Narrow", sans-serif;
+  --gtfs-mono: "IBM Plex Mono", Consolas, monospace;
   height: 100%;
   overflow: hidden;
+  background: var(--gtfs-paper);
 }
+body.gtfs-page .navbar-inverse {
+  background: var(--gtfs-ink);
+  border-color: var(--gtfs-ink);
+}
+body.gtfs-page .navbar-brand {
+  font-family: var(--gtfs-display);
+  font-weight: 700;
+  font-size: 20px;
+  letter-spacing: 0.02em;
+}
+.gtfs-brand-tag {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 8px 2px;
+  background: var(--gtfs-accent);
+  color: var(--gtfs-accent-ink);
+  border-radius: 3px;
+  font-family: var(--gtfs-display);
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: 0.08em;
+  vertical-align: 2px;
+}
+.gtfs-download-btn {
+  background: var(--gtfs-accent);
+  border: 1px solid #e6b94f;
+  color: var(--gtfs-accent-ink);
+  font-weight: 600;
+}
+.gtfs-download-btn:hover {
+  background: #ffdd85;
+  color: var(--gtfs-accent-ink);
+}
+body.gtfs-page .navbar .navbar-btn {
+  margin-left: 6px;
+}
+
 .gtfs-layout {
   display: flex;
   height: calc(100vh - 50px); /* below the fixed navbar */
 }
+
+/* --- Route list ------------------------------------------------------ */
 .gtfs-routes-col {
-  flex: 0 0 280px;
+  flex: 0 0 264px;
   overflow-y: auto;
-  padding: 8px;
-  background: #fafafa;
-  border-right: 1px solid #ddd;
+  padding: 10px 0 10px 10px;
+  background: var(--gtfs-paper);
+  border-right: 1px solid var(--gtfs-line);
 }
-.gtfs-routes-col .sidebar-title {
+.gtfs-list-head {
+  font-family: var(--gtfs-display);
   font-weight: 600;
-  margin-bottom: 6px;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--gtfs-ink-soft);
+  margin: 14px 10px 4px 2px;
+  padding-bottom: 3px;
+  border-bottom: 2px solid var(--gtfs-line);
 }
+.gtfs-list-head:first-child {
+  margin-top: 0;
+}
+.gtfs-route-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px 5px 6px;
+  margin: 1px 10px 1px 0;
+  border-left: 3px solid transparent;
+  border-radius: 0 4px 4px 0;
+  cursor: pointer;
+  user-select: none;
+}
+.gtfs-route-row:hover {
+  background: rgba(255, 209, 102, 0.18);
+}
+.gtfs-route-row.selected {
+  background: var(--gtfs-card);
+  border-left-color: var(--gtfs-accent);
+  box-shadow: 0 1px 4px rgba(29, 42, 51, 0.12);
+}
+.gtfs-route-chip {
+  flex: 0 0 34px;
+  text-align: center;
+  padding: 1px 0 2px;
+  background: var(--gtfs-ink);
+  color: var(--gtfs-accent);
+  border-radius: 4px;
+  font-family: var(--gtfs-mono);
+  font-weight: 600;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.gtfs-route-row.selected .gtfs-route-chip {
+  background: var(--gtfs-accent);
+  color: var(--gtfs-ink);
+}
+.gtfs-route-label {
+  flex: 1 1 auto;
+  font-size: 13px;
+  color: var(--gtfs-ink);
+  word-break: break-word;
+}
+.gtfs-route-row.user .gtfs-route-label {
+  font-style: italic;
+}
+.gtfs-route-del {
+  flex: 0 0 auto;
+  color: #c0392b;
+  opacity: 0.45;
+  text-decoration: none;
+  font-size: 13px;
+}
+.gtfs-route-del:hover {
+  opacity: 1;
+  color: #c0392b;
+  text-decoration: none;
+}
+
+/* --- Map column ------------------------------------------------------- */
 .gtfs-map-col {
   flex: 1 1 auto;
   position: relative;
@@ -568,32 +527,244 @@ body.gtfs-page #map {
   width: 100%;
   height: 100%;
 }
-body.gtfs-page #routes {
-  max-height: none;
-}
-/* Docked variant of the GTFS editor: a permanent right column, not a
-   floating window. */
-#gtfsPanel.docked {
-  position: static;
-  flex: 0 0 400px;
-  width: 400px;
-  height: auto;
-  max-width: none;
-  max-height: none;
+#gtfsEditBtn {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 900;
+  padding: 7px 16px 8px;
+  background: var(--gtfs-ink);
+  color: #fff;
   border: none;
-  border-left: 1px solid #ddd;
-  border-radius: 0;
-  box-shadow: none;
+  border-radius: 999px;
+  font-family: var(--gtfs-display);
+  font-weight: 600;
+  font-size: 16px;
+  letter-spacing: 0.04em;
+  box-shadow: 0 2px 10px rgba(29, 42, 51, 0.4);
+  transition: transform 0.12s ease, background 0.12s ease;
 }
-#gtfsPanel.docked #gtfsHeader {
-  cursor: default;
+#gtfsEditBtn:hover {
+  background: #2d4250;
+  transform: translateY(-1px);
 }
+body.editing #gtfsEditBtn {
+  display: none !important; /* the editor toolbar takes over */
+}
+
+/* --- GTFS pane --------------------------------------------------------- */
+#gtfsPanel {
+  flex: 0 0 400px;
+  display: flex;
+  flex-direction: column;
+  background: var(--gtfs-paper);
+  border-left: 1px solid var(--gtfs-line);
+  overflow: hidden;
+}
+#gtfsHeader {
+  flex: 0 0 auto;
+  padding: 8px 12px;
+  background: var(--gtfs-ink);
+  color: #fff;
+}
+#gtfsHeader .gep-title {
+  font-family: var(--gtfs-display);
+  font-weight: 600;
+  font-size: 19px;
+  letter-spacing: 0.03em;
+}
+#gtfsBody {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 10px;
+  gap: 10px;
+}
+.gep-section {
+  background: var(--gtfs-card);
+  border: 1px solid var(--gtfs-line);
+  border-radius: 6px;
+  padding: 8px 10px 10px;
+}
+.gep-section-grow {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 180px;
+}
+.gep-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  font-family: var(--gtfs-display);
+  font-weight: 600;
+  font-size: 16px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--gtfs-ink);
+  margin-bottom: 6px;
+  padding-bottom: 4px;
+  border-bottom: 2px solid var(--gtfs-accent);
+}
+.gep-section-head .gep-tools {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+.gep-section-head .gep-tools select {
+  width: auto;
+  max-width: 150px;
+  height: 22px;
+  padding: 1px 4px;
+  font-size: 11px;
+  font-family: inherit;
+  letter-spacing: normal;
+  text-transform: none;
+  font-weight: 400;
+}
+.gep-status {
+  font-family: var(--gtfs-mono);
+  font-weight: 400;
+  font-size: 11px;
+  letter-spacing: normal;
+  text-transform: none;
+  color: var(--gtfs-go);
+}
+.gep-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 10px;
+  margin-bottom: 6px;
+  font-size: 12px;
+  color: var(--gtfs-ink-soft);
+}
+.gep-row:last-child {
+  margin-bottom: 0;
+}
+.gep-row label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: 0;
+  font-weight: 400;
+}
+.gep-row input[type="text"],
+.gep-row input[type="number"],
+.gep-row input[type="time"] {
+  font-size: 12px;
+  padding: 2px 5px;
+  border: 1px solid #cfc8b8;
+  border-radius: 3px;
+  height: 24px;
+  background: #fffdf8;
+  color: var(--gtfs-ink);
+}
+.gep-row input[type="number"] {
+  width: 56px;
+}
+.gep-row input[type="time"],
+.gep-row input[type="number"] {
+  font-family: var(--gtfs-mono);
+}
+.gep-row #gepLong {
+  flex: 1 1 120px;
+}
+.gep-row input:focus,
+.gep-row textarea:focus {
+  outline: none;
+  border-color: var(--gtfs-accent);
+  box-shadow: 0 0 0 2px rgba(255, 209, 102, 0.35);
+}
+.gep-days label {
+  gap: 3px;
+  font-family: var(--gtfs-mono);
+  font-size: 11px;
+}
+.gep-row .gep-block {
+  display: block;
+  flex: 1 1 100%;
+  font-size: 11px;
+  color: var(--gtfs-ink-soft);
+}
+.gep-row .gep-block input {
+  display: block;
+  width: 100%;
+  margin-top: 2px;
+  font-size: 12px;
+  padding: 3px 6px;
+  border: 1px solid #cfc8b8;
+  border-radius: 3px;
+  height: 26px;
+}
+/* The departures field is the heart of the transcription job — style it as
+   a departure board: dark, mono, signage yellow. */
+.gep-row .gep-block textarea {
+  display: block;
+  width: 100%;
+  margin-top: 3px;
+  resize: vertical;
+  font-family: var(--gtfs-mono);
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  line-height: 1.7;
+  color: var(--gtfs-accent);
+  background: #14191d;
+  caret-color: var(--gtfs-accent);
+  padding: 6px 9px;
+  border: 1px solid #000;
+  border-radius: 4px;
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.6);
+}
+.gep-row .gep-block textarea::placeholder {
+  color: rgba(255, 209, 102, 0.35);
+}
+.gep-row .gep-block textarea:disabled,
+.gep-row input:disabled {
+  opacity: 0.45;
+}
+#gtfsTimingBody {
+  flex: 1 1 auto;
+  min-height: 140px;
+  overflow: auto;
+  background: #e9e5da;
+  text-align: center;
+  border-radius: 4px;
+}
+#gtfsTimingImg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.gep-empty {
+  padding: 18px;
+  color: #97917f;
+  font-size: 12px;
+}
+/* Feed settings modal */
+.gep-feed-form .gep-row {
+  margin-bottom: 8px;
+}
+.gep-feed-form .gep-block {
+  flex: 1 1 40%;
+}
+.gep-hint {
+  margin: 4px 0 0;
+  font-size: 11px;
+  color: #97917f;
+}
+#feedSettingsModal .modal-title .gep-status {
+  margin-left: 8px;
+}
+
 @media (max-width: 991px) {
   .gtfs-routes-col {
-    flex-basis: 200px;
+    flex-basis: 190px;
   }
-  #gtfsPanel.docked {
+  #gtfsPanel {
     flex-basis: 320px;
-    width: 320px;
   }
 }
+

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -504,6 +504,20 @@ body.gtfs-page .navbar .navbar-btn {
 .gtfs-route-row.user .gtfs-route-label {
   font-style: italic;
 }
+/* GeoJSON path tracings: outlined chip, echoing their dashed map line. */
+.gtfs-route-row.path .gtfs-route-chip {
+  background: transparent;
+  color: var(--gtfs-ink-soft);
+  border: 1px dashed var(--gtfs-ink-soft);
+  padding-top: 0;
+  padding-bottom: 1px;
+}
+.gtfs-route-row.path.selected .gtfs-route-chip {
+  background: var(--gtfs-accent);
+  color: var(--gtfs-ink);
+  border-style: solid;
+  border-color: var(--gtfs-accent);
+}
 .gtfs-route-del {
   flex: 0 0 auto;
   color: #c0392b;
@@ -631,6 +645,9 @@ body.editing #gtfsEditBtn {
   letter-spacing: normal;
   text-transform: none;
   color: var(--gtfs-go);
+}
+.gep-status.hint {
+  color: #97917f;
 }
 .gep-row {
   display: flex;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -10,13 +10,14 @@
   --gtfs-accent: #ffd166;     /* signage yellow (matches the stop markers) */
   --gtfs-accent-ink: #6b5200;
   --gtfs-go: #2e7d32;
+  --gtfs-danger: #c0392b;
   --gtfs-display: "Barlow Condensed", "Arial Narrow", sans-serif;
   --gtfs-mono: "IBM Plex Mono", Consolas, monospace;
 }
 
 html,
 body {
-  height: 99%;
+  height: 100%;
 }
 
 /* --- Shared chrome: slate navbar with signage type --- */
@@ -73,7 +74,7 @@ body {
   border-radius: 999px;
   box-shadow: 0 2px 10px rgba(29, 42, 51, 0.4);
   display: none;
-  top: 1.5em;
+  top: 60px; /* clear of the fixed navbar (its parent isn't positioned) */
   left: 0;
   right: 0;
   margin-left: auto;
@@ -81,7 +82,20 @@ body {
   width: 12em;
   text-align: center;
   position: absolute;
-  z-index: 1050;
+  z-index: 1020; /* over the map, under navbar (1030) and modals (1050) */
+  cursor: pointer; /* the whole pill cancels loading */
+}
+/* The cancel "X" inside the pill: a small accent glyph, not a full
+   Bootstrap danger button straddling the pill's edge. */
+#loading .btn {
+  padding: 0 6px;
+  font-size: 11px;
+  line-height: 1.4;
+  background: transparent;
+  border: 1px solid var(--gtfs-accent);
+  color: var(--gtfs-accent);
+  border-radius: 3px;
+  margin-left: 6px;
 }
 
 #info {
@@ -124,11 +138,6 @@ body {
 }
 
 #map {
-  width: 100%;
-  height: 98%;
-}
-
-.fill {
   width: 100%;
   height: 100%;
 }
@@ -183,8 +192,41 @@ body {
   margin-bottom: 6px;
 }
 
-nav {
-  height: 50px;
+/* The navbar lays out as a wrapping flex row (Bootstrap 3's float-based
+   navbar breaks below 768px without a collapse, and a fixed height clipped
+   the background when buttons wrapped). The brand + map-style group sits
+   left, action buttons right; extra rows keep the slate background. */
+nav.navbar {
+  min-height: 50px;
+  height: auto;
+}
+.navbar > .container,
+.navbar > .container-fluid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2px 8px;
+  padding-top: 2px;
+  padding-bottom: 2px;
+}
+.navbar .navbar-header {
+  float: none;
+}
+.navbar .navbar-nav {
+  float: none;
+  margin-right: auto; /* push the action buttons to the right edge */
+}
+.navbar .navbar-nav > li {
+  float: none;
+}
+.navbar .navbar-btn,
+.navbar a.navbar-btn {
+  float: none !important;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.navbar select.form-control {
+  width: auto;
 }
 
 body {
@@ -206,8 +248,19 @@ body:not(.guide-page) footer {
   pointer-events: none;
 }
 
-[class*="col-"] {
+/* Map page only — the GTFS modals may legitimately use grid gutters. */
+body:not(.gtfs-page):not(.guide-page) [class*="col-"] {
   padding: 0;
+}
+
+/* Keyboard users get a visible accent ring on everything interactive. */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--gtfs-accent);
+  outline-offset: 1px;
 }
 
 @media (max-width: 767px) {
@@ -221,23 +274,6 @@ body:not(.guide-page) footer {
 
 .navbar-nav {
   margin: 0;
-}
-
-.navbar-nav > li > a {
-  padding-top: 15px;
-  padding-bottom: 15px;
-}
-
-#mapStyle,
-#dataYear {
-  margin-top: 8px;
-}
-
-/* Year picker only holds "2016"/"2026" — keep it compact, not full-width */
-#dataYear {
-  width: auto;
-  display: inline-block;
-  margin-right: 6px;
 }
 
 /* --- Floating routes sidebar --- */
@@ -277,11 +313,6 @@ body.editing #sidebar {
   padding-bottom: 4px;
   border-bottom: 2px solid var(--gtfs-accent);
 }
-.sidebar-subtitle {
-  font-weight: 600;
-  font-size: 13px;
-  margin: 10px 0 6px;
-}
 /* The whole panel scrolls, so don't nest a second scroll area in the lists. */
 #sidebar #routes {
   max-height: none;
@@ -307,12 +338,6 @@ body.editing #sidebar {
 }
 
 /* --- Route editor --- */
-#routes .route-item,
-#geojsonRoutes .route-item {
-  display: flex;
-  align-items: center;
-}
-
 .route-edit-btn,
 .route-ride-btn,
 .route-del-btn,
@@ -331,7 +356,7 @@ body.editing #sidebar {
   opacity: 1;
 }
 .route-del-btn {
-  color: #c0392b;
+  color: var(--gtfs-danger);
 }
 
 #editorToolbar {
@@ -360,12 +385,12 @@ body.editing #sidebar {
   margin-right: 4px;
 }
 #editorToolbar .ed-tool.active {
-  background-color: #ffd166;
+  background-color: var(--gtfs-accent);
   border-color: #e0a800;
   font-weight: 600;
 }
 #editorToolbar .ed-status {
-  color: #2e7d32;
+  color: var(--gtfs-go);
   font-size: 12px;
 }
 
@@ -396,13 +421,13 @@ body.editing #sidebar {
   min-height: 200px;
   max-width: calc(100% - 24px);
   max-height: calc(100% - 80px);
-  z-index: 1100;
+  z-index: 1010; /* above the sidebar (1000), below modals (1050) */
   display: flex;
   flex-direction: column;
-  background: #fff;
-  border: 1px solid #aaa;
+  background: var(--gtfs-card);
+  border: 1px solid var(--gtfs-line);
   border-radius: 6px;
-  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 4px 18px rgba(29, 42, 51, 0.35);
   overflow: hidden;
 }
 #stopImageHeader {
@@ -439,7 +464,7 @@ body.editing #sidebar {
 #stopImageBody {
   flex: 1 1 auto;
   overflow: auto;
-  background: #f2f2f2;
+  background: #e9e5da; /* matches the timing panel's photo well */
   text-align: center;
 }
 #stopImageImg {
@@ -449,14 +474,14 @@ body.editing #sidebar {
 }
 .sip-empty {
   padding: 24px 16px;
-  color: #888;
+  color: var(--gtfs-ink-soft);
   font-size: 13px;
 }
 #stopImageNotes {
   flex: 0 0 auto;
   padding: 6px 8px 8px;
-  background: #fff;
-  border-top: 1px solid #ddd;
+  background: var(--gtfs-card);
+  border-top: 1px solid var(--gtfs-line);
 }
 .sip-notes-head {
   display: flex;
@@ -464,13 +489,13 @@ body.editing #sidebar {
   justify-content: space-between;
   font-size: 12px;
   font-weight: 600;
-  color: #444;
+  color: var(--gtfs-ink);
   margin-bottom: 4px;
 }
 .sip-notes-status {
   font-weight: 400;
   font-size: 11px;
-  color: #2e7d32;
+  color: var(--gtfs-go);
 }
 #stopImageNotesText {
   width: 100%;
@@ -631,14 +656,14 @@ body.gtfs-page .navbar .navbar-btn {
 }
 .gtfs-route-del {
   flex: 0 0 auto;
-  color: #c0392b;
-  opacity: 0.45;
+  color: var(--gtfs-danger);
+  opacity: 0.7;
   text-decoration: none;
   font-size: 13px;
 }
 .gtfs-route-del:hover {
   opacity: 1;
-  color: #c0392b;
+  color: var(--gtfs-danger);
   text-decoration: none;
 }
 
@@ -749,6 +774,14 @@ body.editing #gtfsEditBtn {
   text-transform: none;
   font-weight: 400;
 }
+/* Buttons in the head would otherwise inherit the display-type styling
+   ("FIT" in tracked uppercase Barlow). */
+.gep-section-head .gep-tools .btn {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 400;
+}
 .gep-status {
   font-family: var(--gtfs-mono);
   font-weight: 400;
@@ -758,7 +791,7 @@ body.editing #gtfsEditBtn {
   color: var(--gtfs-go);
 }
 .gep-status.hint {
-  color: #97917f;
+  color: var(--gtfs-ink-soft);
 }
 .gep-row {
   display: flex;
@@ -778,6 +811,15 @@ body.editing #gtfsEditBtn {
   gap: 4px;
   margin: 0;
   font-weight: 400;
+}
+/* Labels are flex items themselves, so growing the field means growing its
+   label — these two should fill the remaining row width. */
+.gep-row label:has(> #gepLong),
+.gep-row label:has(> #gepOperator) {
+  flex: 1 1 auto;
+}
+.gep-row input[type="checkbox"] {
+  margin: 0; /* Bootstrap's 4px top margin misaligns in centered flex rows */
 }
 .gep-row input[type="text"],
 .gep-row input[type="number"],
@@ -914,7 +956,8 @@ body.editing #gtfsEditBtn {
   min-width: 60px;
 }
 .gep-stop-coord {
-  flex: 0 0 72px;
+  flex: 0 1 72px; /* shrinkable, or rows overflow the narrow-pane basis */
+  min-width: 56px;
   font-family: var(--gtfs-mono);
   font-size: 10px !important;
   color: var(--gtfs-ink-soft) !important;
@@ -936,7 +979,7 @@ body.editing #gtfsEditBtn {
   text-decoration: none;
 }
 .gep-stop-tools .gep-stop-del {
-  color: #c0392b;
+  color: var(--gtfs-danger);
 }
 
 #gtfsTimingBody {
@@ -954,8 +997,12 @@ body.editing #gtfsEditBtn {
 }
 .gep-empty {
   padding: 18px;
-  color: #97917f;
+  color: var(--gtfs-ink-soft);
   font-size: 12px;
+}
+/* The stops hint is a one-line status note, not an empty-state well. */
+#gepStopsHint {
+  padding: 4px 0;
 }
 /* Day-type schedule blocks (weekday/weekend…) */
 .gep-sched-block {
@@ -978,14 +1025,16 @@ body.editing #gtfsEditBtn {
   letter-spacing: 0.08em;
   color: var(--gtfs-ink-soft);
 }
-.gep-sched-del {
-  color: #c0392b;
+.gep-sched-del,
+.gep-band-del {
+  color: var(--gtfs-danger);
   opacity: 0.5;
   cursor: pointer;
   text-decoration: none;
   font-size: 12px;
 }
-.gep-sched-del:hover {
+.gep-sched-del:hover,
+.gep-band-del:hover {
   opacity: 1;
   text-decoration: none;
 }
@@ -993,17 +1042,6 @@ body.editing #gtfsEditBtn {
   margin-bottom: 8px;
 }
 /* Time-of-day frequency bands within a block */
-.gep-band-del {
-  color: #c0392b;
-  opacity: 0.5;
-  cursor: pointer;
-  text-decoration: none;
-  font-size: 12px;
-}
-.gep-band-del:hover {
-  opacity: 1;
-  text-decoration: none;
-}
 .gep-band:only-child .gep-band-del {
   display: none; /* a block always keeps at least one band */
 }
@@ -1047,7 +1085,7 @@ body.editing #gtfsEditBtn {
 }
 .gep-holiday-del {
   flex: 0 0 16px;
-  color: #c0392b;
+  color: var(--gtfs-danger);
   opacity: 0.5;
   cursor: pointer;
   text-decoration: none;
@@ -1082,9 +1120,6 @@ body.editing #gtfsEditBtn {
 .gep-feed-form .gep-row {
   margin-bottom: 8px;
 }
-.gep-feed-form .gep-block {
-  flex: 1 1 40%;
-}
 .gep-feed-subhead {
   font-family: var(--gtfs-display);
   font-weight: 600;
@@ -1105,7 +1140,7 @@ body.editing #gtfsEditBtn {
   font-size: 11px;
   text-transform: none;
   letter-spacing: normal;
-  color: #97917f;
+  color: var(--gtfs-ink-soft);
   margin-left: 8px;
 }
 .gep-agency-head,
@@ -1134,7 +1169,7 @@ body.editing #gtfsEditBtn {
 }
 .gep-agency-del {
   flex: 0 0 16px;
-  color: #c0392b;
+  color: var(--gtfs-danger);
   opacity: 0.5;
   cursor: pointer;
   text-decoration: none;
@@ -1149,7 +1184,7 @@ body.editing #gtfsEditBtn {
 .gep-hint {
   margin: 4px 0 0;
   font-size: 11px;
-  color: #97917f;
+  color: var(--gtfs-ink-soft);
 }
 #feedSettingsModal .modal-title .gep-status {
   margin-left: 8px;
@@ -1175,7 +1210,7 @@ body.editing #gtfsEditBtn {
 }
 .gep-validate-summary.err {
   background: #fae3e0;
-  color: #c0392b;
+  color: var(--gtfs-danger);
 }
 .gep-validate-row {
   display: flex;
@@ -1195,7 +1230,7 @@ body.editing #gtfsEditBtn {
   padding: 1px 0;
 }
 .gep-validate-badge.error {
-  background: #c0392b;
+  background: var(--gtfs-danger);
   color: #fff;
 }
 .gep-validate-badge.warning {
@@ -1217,6 +1252,37 @@ body.editing #gtfsEditBtn {
   }
   #gtfsPanel {
     flex-basis: 320px;
+  }
+}
+/* Below ~820px the three non-shrinking columns can't fit side by side and
+   the GTFS pane would be clipped off-screen — stack them instead. */
+@media (max-width: 820px) {
+  body.gtfs-page {
+    overflow: auto;
+  }
+  .gtfs-layout {
+    flex-direction: column;
+    height: auto;
+  }
+  .gtfs-routes-col {
+    flex: none;
+    max-height: 30vh;
+    border-right: none;
+    border-bottom: 1px solid var(--gtfs-line);
+  }
+  .gtfs-map-col {
+    flex: none;
+    height: 55vh;
+    min-width: 0;
+  }
+  #gtfsPanel {
+    flex: none;
+    width: auto;
+    border-left: none;
+    border-top: 1px solid var(--gtfs-line);
+  }
+  #gtfsBody {
+    overflow-y: visible;
   }
 }
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -886,6 +886,11 @@ body.editing #gtfsEditBtn {
   border-color: #cfc8b8;
   background: #fffdf8;
 }
+.gep-stop-code {
+  flex: 0 0 48px;
+  font-family: var(--gtfs-mono);
+  font-size: 10px !important;
+}
 .gep-stop-name {
   flex: 1 1 auto;
   min-width: 60px;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -495,6 +495,23 @@ details.gep-section summary {
 .gep-days label {
   gap: 2px;
 }
+.gep-row .gep-block {
+  display: block;
+  flex: 1 1 100%;
+  font-size: 11px;
+  color: #666;
+}
+.gep-row .gep-block textarea {
+  display: block;
+  width: 100%;
+  margin-top: 2px;
+  resize: vertical;
+  font-size: 12px;
+  color: #333;
+  padding: 3px 5px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+}
 #gtfsTimingBody {
   max-height: 220px;
   overflow: auto;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,35 +1,118 @@
+/* Transit-signage design tokens, shared by the map page and the GTFS
+   workbench: ink slate + warm paper, one signage-yellow accent, Barlow
+   Condensed display type and IBM Plex Mono for times and route codes. */
+:root {
+  --gtfs-ink: #1d2a33;        /* dark slate, like the signboard frames */
+  --gtfs-ink-soft: #46555f;
+  --gtfs-paper: #f6f4ee;      /* warm paper */
+  --gtfs-card: #ffffff;
+  --gtfs-line: #ddd6c8;
+  --gtfs-accent: #ffd166;     /* signage yellow (matches the stop markers) */
+  --gtfs-accent-ink: #6b5200;
+  --gtfs-go: #2e7d32;
+  --gtfs-display: "Barlow Condensed", "Arial Narrow", sans-serif;
+  --gtfs-mono: "IBM Plex Mono", Consolas, monospace;
+}
+
 html,
 body {
   height: 99%;
 }
 
+/* --- Shared chrome: slate navbar with signage type --- */
+.navbar-inverse {
+  background: var(--gtfs-ink);
+  border-color: var(--gtfs-ink);
+}
+.navbar-inverse .navbar-brand {
+  font-family: var(--gtfs-display);
+  font-weight: 700;
+  font-size: 20px;
+  letter-spacing: 0.02em;
+  color: #fff;
+}
+.navbar-inverse .navbar-brand:hover {
+  color: var(--gtfs-accent);
+}
+.navbar .btn-default.navbar-btn,
+.navbar a.btn-default.navbar-btn {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+.navbar .btn-default.navbar-btn:hover,
+.navbar a.btn-default.navbar-btn:hover {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+.navbar .btn-primary.navbar-btn {
+  background: var(--gtfs-accent);
+  border-color: #e6b94f;
+  color: var(--gtfs-accent-ink);
+  font-weight: 600;
+}
+.navbar .btn-primary.navbar-btn:hover {
+  background: #ffdd85;
+  color: var(--gtfs-accent-ink);
+}
+.navbar select.form-control {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+.navbar select.form-control option {
+  color: #333;
+}
+
 #loading {
-  padding: 5px;
-  background-color: rgba(255, 255, 255, 0.8);
+  padding: 6px 16px;
+  background: var(--gtfs-ink);
+  color: var(--gtfs-accent);
+  font-family: var(--gtfs-mono);
+  font-size: 12px;
+  border-radius: 999px;
+  box-shadow: 0 2px 10px rgba(29, 42, 51, 0.4);
   display: none;
   top: 1.5em;
   left: 0;
   right: 0;
   margin-left: auto;
   margin-right: auto;
-  width: 10em;
+  width: 12em;
   text-align: center;
   position: absolute;
   z-index: 1050;
 }
 
 #info {
-  background-color: rgba(255, 255, 255, 0.5);
+  background: var(--gtfs-card);
+  border: 1px solid var(--gtfs-line);
+  border-top: 3px solid var(--gtfs-accent);
+  border-radius: 8px 8px 0 0;
+  box-shadow: 0 -2px 14px rgba(29, 42, 51, 0.18);
   display: none;
   text-align: center;
   position: absolute;
-  width: 90%;
+  width: auto;
+  max-width: 90%;
+  min-width: 280px;
   margin: 0 auto;
   left: 0;
   right: 0;
-  padding: 5px;
+  padding: 10px 14px;
   top: auto;
   bottom: 0;
+}
+#info .name {
+  font-family: var(--gtfs-display);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--gtfs-ink);
+}
+#info .location {
+  font-family: var(--gtfs-mono);
+  font-size: 11px;
+  color: var(--gtfs-ink-soft);
 }
 
 #info h3 {
@@ -56,11 +139,20 @@ body {
 }
 
 #routes .list-group-item {
-  padding: 5px;
+  padding: 5px 6px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  margin-bottom: 0;
+}
+
+#routes .list-group-item:hover {
+  background: rgba(255, 209, 102, 0.18);
 }
 
 #routes input {
   margin-right: 7px;
+  accent-color: var(--gtfs-ink);
 }
 
 #routes .route-item {
@@ -78,11 +170,13 @@ body {
   height: 14px;
   border-radius: 3px;
   margin-right: 7px;
-  border: 1px solid rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(29, 42, 51, 0.3);
 }
 
 .route-name {
   flex: 1 1 auto;
+  font-size: 13px;
+  color: var(--gtfs-ink);
 }
 
 #routeBulkControls {
@@ -98,12 +192,16 @@ body {
 }
 
 footer {
-  padding: 0;
+  padding: 2px 0;
   position: absolute;
   bottom: 0;
   left: 0;
   width: 100%;
   text-align: center;
+  font-size: 11px;
+  color: var(--gtfs-ink-soft);
+  text-shadow: 0 0 4px #fff, 0 0 8px #fff;
+  pointer-events: none;
 }
 
 [class*="col-"] {
@@ -149,11 +247,11 @@ footer {
   width: 300px;
   max-width: calc(100% - 20px);
   z-index: 1000;
-  padding: 10px;
-  background: rgba(255, 255, 255, 0.97);
-  border: 1px solid #ccc;
+  padding: 10px 12px;
+  background: rgba(246, 244, 238, 0.97); /* warm paper over the map */
+  border: 1px solid var(--gtfs-line);
   border-radius: 8px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 18px rgba(29, 42, 51, 0.3);
   overflow-y: auto;
   transition: transform 0.2s ease, opacity 0.2s ease;
 }
@@ -167,8 +265,15 @@ body.editing #sidebar {
   top: 108px;
 }
 .sidebar-title {
+  font-family: var(--gtfs-display);
   font-weight: 600;
+  font-size: 17px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--gtfs-ink);
   margin-bottom: 8px;
+  padding-bottom: 4px;
+  border-bottom: 2px solid var(--gtfs-accent);
 }
 .sidebar-subtitle {
   font-weight: 600;
@@ -185,14 +290,15 @@ body.editing #sidebar {
 }
 /* Year/type group headers in the combined routes list. */
 .route-group {
+  font-family: var(--gtfs-display);
   font-weight: 600;
-  font-size: 12px;
+  font-size: 14px;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: #555;
+  letter-spacing: 0.14em;
+  color: var(--gtfs-ink-soft);
   margin: 12px 0 4px;
-  padding-bottom: 2px;
-  border-bottom: 1px solid #ddd;
+  padding-bottom: 3px;
+  border-bottom: 2px solid var(--gtfs-line);
 }
 .route-group:first-child {
   margin-top: 0;
@@ -237,13 +343,18 @@ body.editing #sidebar {
   align-items: center;
   gap: 6px;
   padding: 6px 10px;
-  background: rgba(255, 255, 255, 0.96);
-  border: 1px solid #ccc;
+  background: rgba(246, 244, 238, 0.97);
+  border: 1px solid var(--gtfs-line);
+  border-left: 4px solid var(--gtfs-accent);
   border-radius: 6px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 2px 10px rgba(29, 42, 51, 0.3);
 }
 #editorToolbar .ed-title {
+  font-family: var(--gtfs-display);
   font-weight: 600;
+  font-size: 16px;
+  letter-spacing: 0.03em;
+  color: var(--gtfs-ink);
   margin-right: 4px;
 }
 #editorToolbar .ed-tool.active {
@@ -299,14 +410,16 @@ body.editing #sidebar {
   align-items: center;
   gap: 4px;
   padding: 5px 6px;
-  background: #2c3e50;
+  background: var(--gtfs-ink);
   color: #fff;
   cursor: move;
   user-select: none;
 }
 #stopImageHeader .sip-title {
+  font-family: var(--gtfs-display);
   font-weight: 600;
-  font-size: 12px;
+  font-size: 14px;
+  letter-spacing: 0.04em;
   margin-right: 2px;
 }
 #stopImageHeader select {
@@ -382,29 +495,9 @@ body.editing #sidebar {
    or a route code. The departures field reads like a departure board.
    ==================================================================== */
 body.gtfs-page {
-  --gtfs-ink: #1d2a33;        /* dark slate, like the signboard frames */
-  --gtfs-ink-soft: #46555f;
-  --gtfs-paper: #f6f4ee;      /* warm paper */
-  --gtfs-card: #ffffff;
-  --gtfs-line: #ddd6c8;
-  --gtfs-accent: #ffd166;     /* signage yellow (matches the stop markers) */
-  --gtfs-accent-ink: #6b5200;
-  --gtfs-go: #2e7d32;
-  --gtfs-display: "Barlow Condensed", "Arial Narrow", sans-serif;
-  --gtfs-mono: "IBM Plex Mono", Consolas, monospace;
   height: 100%;
   overflow: hidden;
   background: var(--gtfs-paper);
-}
-body.gtfs-page .navbar-inverse {
-  background: var(--gtfs-ink);
-  border-color: var(--gtfs-ink);
-}
-body.gtfs-page .navbar-brand {
-  font-family: var(--gtfs-display);
-  font-weight: 700;
-  font-size: 20px;
-  letter-spacing: 0.02em;
 }
 .gtfs-brand-tag {
   display: inline-block;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -835,6 +835,87 @@ body.editing #gtfsEditBtn {
 .gep-row input:disabled {
   opacity: 0.45;
 }
+/* Stops list: sequence chip | name | lat | lon | tools, scrolling past ~8 rows */
+.gep-count {
+  font-family: var(--gtfs-mono);
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: normal;
+  color: var(--gtfs-ink-soft);
+}
+#gepStopsList {
+  max-height: 230px;
+  overflow-y: auto;
+}
+.gep-stop-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 0;
+}
+.gep-stop-row + .gep-stop-row {
+  border-top: 1px dotted var(--gtfs-line);
+}
+.gep-stop-seq {
+  flex: 0 0 26px;
+  padding: 1px 0 2px;
+  text-align: center;
+  background: var(--gtfs-ink);
+  color: var(--gtfs-accent);
+  border: none;
+  border-radius: 3px;
+  font-family: var(--gtfs-mono);
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.gep-stop-seq:hover {
+  background: #2d4250;
+}
+.gep-stop-row input {
+  font-size: 11px;
+  padding: 1px 4px;
+  height: 22px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--gtfs-ink);
+}
+.gep-stop-row input:hover:not(:disabled),
+.gep-stop-row input:focus {
+  border-color: #cfc8b8;
+  background: #fffdf8;
+}
+.gep-stop-name {
+  flex: 1 1 auto;
+  min-width: 60px;
+}
+.gep-stop-coord {
+  flex: 0 0 72px;
+  font-family: var(--gtfs-mono);
+  font-size: 10px !important;
+  color: var(--gtfs-ink-soft) !important;
+}
+.gep-stop-tools {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+.gep-stop-tools a {
+  cursor: pointer;
+  padding: 0 2px;
+  color: var(--gtfs-ink-soft);
+  opacity: 0.55;
+  text-decoration: none;
+  font-size: 12px;
+}
+.gep-stop-tools a:hover {
+  opacity: 1;
+  text-decoration: none;
+}
+.gep-stop-tools .gep-stop-del {
+  color: #c0392b;
+}
+
 #gtfsTimingBody {
   flex: 1 1 auto;
   min-height: 140px;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -374,3 +374,150 @@ body.editing #sidebar {
   cursor: nwse-resize;
   background: linear-gradient(135deg, transparent 50%, #b0b0b0 50%);
 }
+
+/* --- GTFS editor panel (mirrors the stop-image panel patterns) --- */
+#gtfsPanel {
+  position: absolute;
+  top: 120px;
+  right: 320px;
+  width: 380px;
+  height: 540px;
+  min-width: 280px;
+  min-height: 260px;
+  max-width: calc(100% - 24px);
+  max-height: calc(100% - 80px);
+  z-index: 1100;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border: 1px solid #aaa;
+  border-radius: 6px;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+}
+#gtfsHeader {
+  flex: 0 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 6px;
+  background: #2c3e50;
+  color: #fff;
+  cursor: move;
+  user-select: none;
+}
+#gtfsHeader .gep-title {
+  font-weight: 600;
+  font-size: 12px;
+  margin-right: 2px;
+}
+#gtfsHeader select {
+  width: auto;
+  max-width: 160px;
+  height: 24px;
+  padding: 1px 4px;
+  font-size: 12px;
+  color: #333;
+}
+#gtfsHeader .gep-tools {
+  margin-left: auto;
+  white-space: nowrap;
+}
+#gtfsBody {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 6px 8px;
+}
+.gep-section {
+  margin-bottom: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 6px 8px;
+}
+.gep-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #444;
+  margin-bottom: 4px;
+}
+.gep-section-head .gep-tools select {
+  display: inline-block;
+  width: auto;
+  max-width: 150px;
+  height: 22px;
+  padding: 1px 4px;
+  font-size: 11px;
+}
+details.gep-section summary {
+  cursor: pointer;
+  outline: none;
+}
+.gep-status {
+  font-weight: 400;
+  font-size: 11px;
+  color: #2e7d32;
+}
+.gep-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+  font-size: 12px;
+}
+.gep-row label {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  margin: 0;
+  font-weight: 400;
+}
+.gep-row input[type="number"] {
+  width: 54px;
+}
+.gep-row input[type="text"],
+.gep-row input[type="number"],
+.gep-row input[type="time"] {
+  font-size: 12px;
+  padding: 2px 4px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  height: 24px;
+}
+.gep-row #gepLong {
+  flex: 1 1 120px;
+}
+.gep-days label {
+  gap: 2px;
+}
+#gtfsTimingBody {
+  max-height: 220px;
+  overflow: auto;
+  background: #f2f2f2;
+  text-align: center;
+  border-radius: 3px;
+}
+#gtfsTimingImg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.gep-empty {
+  padding: 16px;
+  color: #888;
+  font-size: 12px;
+}
+#gtfsResize {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 16px;
+  height: 16px;
+  cursor: nwse-resize;
+  background: linear-gradient(135deg, transparent 50%, #b0b0b0 50%);
+}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -934,9 +934,8 @@ body.editing #gtfsEditBtn {
   color: #97917f;
   font-size: 12px;
 }
-/* Route pane operator picker */
-.gep-row select#gepOperator {
-  flex: 1 1 auto;
+/* Route pane selects (operator, direction type) */
+.gep-row select {
   font-size: 12px;
   height: 24px;
   padding: 2px 4px;
@@ -944,6 +943,13 @@ body.editing #gtfsEditBtn {
   border-radius: 3px;
   background: #fffdf8;
   color: var(--gtfs-ink);
+}
+.gep-row select#gepOperator {
+  flex: 1 1 auto;
+}
+.gep-row #gepHeadsign,
+.gep-row #gepReturnHeadsign {
+  width: 110px;
 }
 
 /* Feed settings modal */

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -611,6 +611,22 @@ body.gtfs-page .navbar .navbar-btn {
   border-style: solid;
   border-color: var(--gtfs-accent);
 }
+/* Transcription-progress meter: schedule | departures | operator | headsign */
+.gtfs-route-meter {
+  flex: 0 0 auto;
+  display: inline-flex;
+  gap: 2px;
+  align-self: center;
+}
+.gtfs-route-meter i {
+  width: 4px;
+  height: 11px;
+  border-radius: 1px;
+  background: var(--gtfs-line);
+}
+.gtfs-route-meter i.on {
+  background: var(--gtfs-go);
+}
 .gtfs-route-del {
   flex: 0 0 auto;
   color: #c0392b;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -934,12 +934,85 @@ body.editing #gtfsEditBtn {
   color: #97917f;
   font-size: 12px;
 }
+/* Route pane operator picker */
+.gep-row select#gepOperator {
+  flex: 1 1 auto;
+  font-size: 12px;
+  height: 24px;
+  padding: 2px 4px;
+  border: 1px solid #cfc8b8;
+  border-radius: 3px;
+  background: #fffdf8;
+  color: var(--gtfs-ink);
+}
+
 /* Feed settings modal */
 .gep-feed-form .gep-row {
   margin-bottom: 8px;
 }
 .gep-feed-form .gep-block {
   flex: 1 1 40%;
+}
+.gep-feed-subhead {
+  font-family: var(--gtfs-display);
+  font-weight: 600;
+  font-size: 15px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--gtfs-ink);
+  margin: 12px 0 6px;
+  padding-bottom: 3px;
+  border-bottom: 2px solid var(--gtfs-accent);
+}
+.gep-feed-subhead:first-child {
+  margin-top: 0;
+}
+.gep-hint-inline {
+  font-family: inherit;
+  font-weight: 400;
+  font-size: 11px;
+  text-transform: none;
+  letter-spacing: normal;
+  color: #97917f;
+  margin-left: 8px;
+}
+.gep-agency-head,
+.gep-agency-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+.gep-agency-head {
+  font-size: 11px;
+  color: var(--gtfs-ink-soft);
+  margin-bottom: 2px;
+}
+.gep-agency-col-name, .gep-agency-row .gep-agency-name { flex: 2 1 120px; }
+.gep-agency-col-url, .gep-agency-row .gep-agency-url { flex: 2 1 100px; }
+.gep-agency-col-phone, .gep-agency-row .gep-agency-phone { flex: 1 1 70px; }
+.gep-agency-col-x { flex: 0 0 16px; }
+.gep-agency-row input {
+  font-size: 12px;
+  padding: 3px 6px;
+  height: 26px;
+  border: 1px solid #cfc8b8;
+  border-radius: 3px;
+  min-width: 0;
+}
+.gep-agency-del {
+  flex: 0 0 16px;
+  color: #c0392b;
+  opacity: 0.5;
+  cursor: pointer;
+  text-decoration: none;
+}
+.gep-agency-del:hover {
+  opacity: 1;
+  text-decoration: none;
+}
+#gepAgencyAdd {
+  margin-bottom: 4px;
 }
 .gep-hint {
   margin: 4px 0 0;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -974,6 +974,73 @@ body.editing #gtfsEditBtn {
 #gepSchedAdd {
   margin-bottom: 8px;
 }
+/* Time-of-day frequency bands within a block */
+.gep-band-del {
+  color: #c0392b;
+  opacity: 0.5;
+  cursor: pointer;
+  text-decoration: none;
+  font-size: 12px;
+}
+.gep-band-del:hover {
+  opacity: 1;
+  text-decoration: none;
+}
+.gep-band:only-child .gep-band-del {
+  display: none; /* a block always keeps at least one band */
+}
+.gep-band-add {
+  font-size: 11px;
+  color: var(--gtfs-ink-soft);
+  cursor: pointer;
+  text-decoration: none;
+  border-bottom: 1px dotted var(--gtfs-ink-soft);
+}
+.gep-band-add:hover {
+  color: var(--gtfs-ink);
+  text-decoration: none;
+}
+
+/* Holiday rows in feed settings */
+.gep-holiday-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+.gep-holiday-row input,
+.gep-holiday-row select {
+  font-size: 12px;
+  padding: 3px 6px;
+  height: 26px;
+  border: 1px solid #cfc8b8;
+  border-radius: 3px;
+  min-width: 0;
+}
+.gep-holiday-date {
+  flex: 0 0 130px;
+  font-family: var(--gtfs-mono);
+}
+.gep-holiday-mode {
+  flex: 0 0 140px;
+}
+.gep-holiday-name {
+  flex: 1 1 90px;
+}
+.gep-holiday-del {
+  flex: 0 0 16px;
+  color: #c0392b;
+  opacity: 0.5;
+  cursor: pointer;
+  text-decoration: none;
+}
+.gep-holiday-del:hover {
+  opacity: 1;
+  text-decoration: none;
+}
+#gepHolidayAdd {
+  margin-bottom: 4px;
+}
 
 /* Route pane selects (operator, direction type) */
 .gep-row select {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -934,6 +934,42 @@ body.editing #gtfsEditBtn {
   color: #97917f;
   font-size: 12px;
 }
+/* Day-type schedule blocks (weekday/weekend…) */
+.gep-sched-block {
+  border: 1px dashed var(--gtfs-line);
+  border-radius: 4px;
+  padding: 6px 8px 8px;
+  margin-bottom: 6px;
+}
+.gep-sched-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+.gep-sched-title {
+  font-family: var(--gtfs-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--gtfs-ink-soft);
+}
+.gep-sched-del {
+  color: #c0392b;
+  opacity: 0.5;
+  cursor: pointer;
+  text-decoration: none;
+  font-size: 12px;
+}
+.gep-sched-del:hover {
+  opacity: 1;
+  text-decoration: none;
+}
+#gepSchedAdd {
+  margin-bottom: 8px;
+}
+
 /* Route pane selects (operator, direction type) */
 .gep-row select {
   font-size: 12px;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1070,6 +1070,62 @@ body.editing #gtfsEditBtn {
   margin-left: 8px;
 }
 
+/* Validation results */
+.gep-validate-summary {
+  font-family: var(--gtfs-mono);
+  font-size: 12px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+  background: #f0ede5;
+  color: var(--gtfs-ink);
+}
+.gep-validate-summary.ok {
+  background: #e6f2e6;
+  color: var(--gtfs-go);
+}
+.gep-validate-summary.warn {
+  background: #fdf3d7;
+  color: #8a6d00;
+}
+.gep-validate-summary.err {
+  background: #fae3e0;
+  color: #c0392b;
+}
+.gep-validate-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 0;
+  border-bottom: 1px dotted var(--gtfs-line);
+  font-size: 12px;
+}
+.gep-validate-badge {
+  flex: 0 0 50px;
+  text-align: center;
+  font-family: var(--gtfs-mono);
+  font-size: 10px;
+  font-weight: 600;
+  border-radius: 3px;
+  padding: 1px 0;
+}
+.gep-validate-badge.error {
+  background: #c0392b;
+  color: #fff;
+}
+.gep-validate-badge.warning {
+  background: var(--gtfs-accent);
+  color: var(--gtfs-accent-ink);
+}
+.gep-validate-msg {
+  color: var(--gtfs-ink);
+}
+.gep-validate-ex {
+  font-family: var(--gtfs-mono);
+  font-size: 11px;
+  color: var(--gtfs-ink-soft);
+}
+
 @media (max-width: 991px) {
   .gtfs-routes-col {
     flex-basis: 190px;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -191,7 +191,9 @@ body {
   padding-top: 50px;
 }
 
-footer {
+/* Map-page footer only: overlays the bottom edge of the map. (Scoped so it
+   doesn't hijack other pages' footers, e.g. the guide's.) */
+body:not(.guide-page) footer {
   padding: 2px 0;
   position: absolute;
   bottom: 0;
@@ -209,7 +211,7 @@ footer {
 }
 
 @media (max-width: 767px) {
-  footer {
+  body:not(.guide-page) footer {
     position: relative;
   }
   #map {
@@ -1224,6 +1226,18 @@ body.guide-page {
   padding: 0;
   background: var(--gtfs-paper);
   color: var(--gtfs-ink);
+  /* No Bootstrap on this page — supply the body face it would have given. */
+  font-family: "Helvetica Neue", Arial, "Segoe UI", sans-serif;
+}
+.guide a {
+  color: var(--gtfs-ink);
+  text-decoration-color: var(--gtfs-accent);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
+}
+.guide a:hover {
+  background: var(--gtfs-accent);
+  text-decoration: none;
 }
 .guide {
   max-width: 780px;
@@ -1284,7 +1298,6 @@ body.guide-page {
   border-collapse: collapse;
   background: var(--gtfs-card);
   border: 1px solid var(--gtfs-line);
-  border-radius: 6px;
   margin: 8px 0 14px;
 }
 .guide-table th,
@@ -1344,14 +1357,40 @@ body.guide-page {
   color: var(--gtfs-ink-soft);
 }
 .guide-footer .btn {
+  display: inline-block;
+  padding: 8px 18px;
+  border-radius: 6px;
+  text-decoration: none;
+  font-family: var(--gtfs-display);
+  font-size: 16px;
+  letter-spacing: 0.03em;
   background: var(--gtfs-accent);
   border: 1px solid #e6b94f;
   color: var(--gtfs-accent-ink);
   font-weight: 600;
 }
+.guide-footer .btn:hover {
+  background: #ffdd85;
+  color: var(--gtfs-accent-ink);
+}
+@media (max-width: 600px) {
+  /* Long row headers would otherwise force the tables wider than the
+     viewport (nowrap min-content). */
+  .guide-table th {
+    width: 110px;
+    white-space: normal;
+  }
+}
 @media print {
   .guide-footer .btn {
     display: none;
+  }
+  /* Printers drop backgrounds; keep the chips legible on paper. */
+  .guide-kicker,
+  .guide code {
+    background: none;
+    color: var(--gtfs-ink);
+    border: 1px solid var(--gtfs-ink);
   }
 }
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1218,3 +1218,140 @@ body.editing #gtfsEditBtn {
   }
 }
 
+/* --- Data entry guide (/gtfs/guide) --- */
+body.guide-page {
+  height: auto;
+  padding: 0;
+  background: var(--gtfs-paper);
+  color: var(--gtfs-ink);
+}
+.guide {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 36px 24px 60px;
+  font-size: 14px;
+  line-height: 1.55;
+}
+.guide-masthead {
+  border-bottom: 4px solid var(--gtfs-ink);
+  margin-bottom: 28px;
+  padding-bottom: 18px;
+}
+.guide-kicker {
+  display: inline-block;
+  font-family: var(--gtfs-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  background: var(--gtfs-ink);
+  color: var(--gtfs-accent);
+  padding: 3px 10px;
+  border-radius: 3px;
+  margin-bottom: 12px;
+}
+.guide h1 {
+  font-family: var(--gtfs-display);
+  font-weight: 700;
+  font-size: 44px;
+  letter-spacing: 0.02em;
+  margin: 0 0 10px;
+}
+.guide-lede {
+  font-size: 16px;
+  color: var(--gtfs-ink-soft);
+  max-width: 640px;
+}
+.guide h2 {
+  font-family: var(--gtfs-display);
+  font-weight: 600;
+  font-size: 26px;
+  letter-spacing: 0.03em;
+  margin: 34px 0 10px;
+  padding-bottom: 4px;
+  border-bottom: 3px solid var(--gtfs-accent);
+}
+.guide h3 {
+  font-family: var(--gtfs-display);
+  font-weight: 600;
+  font-size: 18px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--gtfs-ink-soft);
+  margin: 20px 0 6px;
+}
+.guide-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--gtfs-card);
+  border: 1px solid var(--gtfs-line);
+  border-radius: 6px;
+  margin: 8px 0 14px;
+}
+.guide-table th,
+.guide-table td {
+  text-align: left;
+  vertical-align: top;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--gtfs-line);
+}
+.guide-table tr:last-child th,
+.guide-table tr:last-child td {
+  border-bottom: none;
+}
+.guide-table th {
+  width: 170px;
+  font-family: var(--gtfs-display);
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.03em;
+  color: var(--gtfs-ink);
+  white-space: nowrap;
+}
+.guide-mono td,
+.guide-mono th {
+  font-family: var(--gtfs-mono);
+  font-size: 12px;
+  width: auto;
+  white-space: normal;
+}
+.guide code {
+  font-family: var(--gtfs-mono);
+  font-size: 12px;
+  background: #14191d;
+  color: var(--gtfs-accent);
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+.guide-note {
+  background: #fdf3d7;
+  border-left: 4px solid var(--gtfs-accent);
+  padding: 8px 12px;
+  border-radius: 0 4px 4px 0;
+  color: #6b5200;
+}
+.guide-rules li {
+  margin-bottom: 6px;
+}
+.guide-footer {
+  margin-top: 40px;
+  padding-top: 16px;
+  border-top: 1px solid var(--gtfs-line);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--gtfs-ink-soft);
+}
+.guide-footer .btn {
+  background: var(--gtfs-accent);
+  border: 1px solid #e6b94f;
+  color: var(--gtfs-accent-ink);
+  font-weight: 600;
+}
+@media print {
+  .guide-footer .btn {
+    display: none;
+  }
+}
+

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -35,12 +35,6 @@ APP.BusMap = class {
     this.infoManager.init();
     this.editorManager.init();
     this.stopImageManager.init();
-
-    // The GTFS editor lives on the /gtfs page only (docked panel).
-    if (APP.GtfsEditorManager && document.getElementById("gtfsPanel")) {
-      this.gtfsEditorManager = new APP.GtfsEditorManager();
-      this.gtfsEditorManager.init();
-    }
   }
 
   /**

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -29,14 +29,18 @@ APP.BusMap = class {
       this.infoManager
     );
     this.stopImageManager = new APP.StopImageManager(this.editorManager);
-    this.gtfsEditorManager = new APP.GtfsEditorManager();
 
     this.locationTracker.init();
     this.routeManager.init();
     this.infoManager.init();
     this.editorManager.init();
     this.stopImageManager.init();
-    this.gtfsEditorManager.init();
+
+    // The GTFS editor lives on the /gtfs page only (docked panel).
+    if (APP.GtfsEditorManager && document.getElementById("gtfsPanel")) {
+      this.gtfsEditorManager = new APP.GtfsEditorManager();
+      this.gtfsEditorManager.init();
+    }
   }
 
   /**

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -29,12 +29,14 @@ APP.BusMap = class {
       this.infoManager
     );
     this.stopImageManager = new APP.StopImageManager(this.editorManager);
+    this.gtfsEditorManager = new APP.GtfsEditorManager();
 
     this.locationTracker.init();
     this.routeManager.init();
     this.infoManager.init();
     this.editorManager.init();
     this.stopImageManager.init();
+    this.gtfsEditorManager.init();
   }
 
   /**

--- a/static/js/editor-manager.js
+++ b/static/js/editor-manager.js
@@ -256,6 +256,7 @@ APP.EditorManager = class {
         const f = new ol.Feature(new ol.geom.Point(APP.MapUtils.toOL([s.lon, s.lat])));
         f.set("kind", "stop");
         f.set("name", s.name || "");
+        f.set("code", s.code || ""); // public stop number (GTFS stop_code)
         this.source.addFeature(f);
       });
     }
@@ -275,7 +276,9 @@ APP.EditorManager = class {
         );
       } else if (f.get("kind") === "stop") {
         const ll = APP.MapUtils.toNormal(geom.getCoordinates());
-        stops.push({ name: f.get("name") || "", lon: round7(ll[0]), lat: round7(ll[1]) });
+        const stop = { name: f.get("name") || "", lon: round7(ll[0]), lat: round7(ll[1]) };
+        if (f.get("code")) stop.code = f.get("code");
+        stops.push(stop);
       }
     });
     return { segments, stops, name: this.routeName };

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -94,6 +94,86 @@ APP.GtfsEditorManager = class {
     if (this.current) this._loadStops();
   }
 
+  // --- Live mode: mirror the map editor's working stops ---------------------------
+  // While the editor is open, the list reflects its in-session features as they
+  // are dragged/placed/renamed, and list edits write back into those features.
+  // Nothing touches the server until the toolbar Save — exiting without saving
+  // discards both map and list changes together.
+
+  enterLive() {
+    const em = this.page && this.page.editorManager;
+    if (!em || !em.active || !em.source) {
+      this._renderStops();
+      return;
+    }
+    if (this._liveSource === em.source) {
+      this._renderStops(); // re-entered after an editor Save — just refresh
+      return;
+    }
+    this._flushStopsSave(); // pending non-live autosave from before
+    this._liveSource = em.source;
+    this._squelch = false;
+    this._onLiveCoord = (e) => this._updateLiveRow(e.feature);
+    this._onLiveStruct = () => {
+      if (this._squelch) return;
+      // Coalesce bursts (loads, undo/redo rebuilds); never steal typing focus.
+      clearTimeout(this._liveRenderTimer);
+      this._liveRenderTimer = setTimeout(() => {
+        if (!$("#gepStopsList").find(":focus").length) this._renderStops();
+      }, 200);
+    };
+    this._liveSource.on("changefeature", this._onLiveCoord);
+    this._liveSource.on("addfeature", this._onLiveStruct);
+    this._liveSource.on("removefeature", this._onLiveStruct);
+    this._liveSource.on("clear", this._onLiveStruct);
+    this._renderStops();
+  }
+
+  exitLive() {
+    if (this._liveSource) {
+      this._liveSource.un("changefeature", this._onLiveCoord);
+      this._liveSource.un("addfeature", this._onLiveStruct);
+      this._liveSource.un("removefeature", this._onLiveStruct);
+      this._liveSource.un("clear", this._onLiveStruct);
+      this._liveSource = null;
+      clearTimeout(this._liveRenderTimer);
+    }
+    this.refreshStops(); // back to the last saved version
+  }
+
+  _liveStopFeatures() {
+    if (!this._liveSource) return [];
+    return this._liveSource.getFeatures().filter((f) => f.get("kind") === "stop");
+  }
+
+  /** Update one row's inputs in place during a drag (no re-render, no focus loss). */
+  _updateLiveRow(feature) {
+    if (feature.get("kind") !== "stop") return;
+    const i = this._liveStopFeatures().indexOf(feature);
+    if (i < 0) return;
+    const row = $("#gepStopsList .gep-stop-row").eq(i);
+    if (!row.length) return;
+    const ll = APP.MapUtils.toNormal(feature.getGeometry().getCoordinates());
+    const set = (sel, val) => {
+      const el = row.find(sel)[0];
+      if (el && document.activeElement !== el) el.value = val;
+    };
+    set(".gep-stop-lat", ll[1].toFixed(6));
+    set(".gep-stop-lon", ll[0].toFixed(6));
+    set(".gep-stop-name", feature.get("name") || "");
+  }
+
+  /** Stops as plain data, from the live editor session or saved geometry. */
+  _stopsData() {
+    if (this._liveSource) {
+      return this._liveStopFeatures().map((f) => {
+        const ll = APP.MapUtils.toNormal(f.getGeometry().getCoordinates());
+        return { name: f.get("name") || "", lon: ll[0], lat: ll[1] };
+      });
+    }
+    return (this.geom && this.geom.stops) || [];
+  }
+
   /** Update the displayed name (e.g. after a rename in the editor). */
   setLabel(label) {
     if (!this.current) return;
@@ -150,9 +230,10 @@ APP.GtfsEditorManager = class {
       });
   }
 
-  /** Stops are saved as a new geometry version, which only user routes
-   * accept; the map editor being active also pauses list editing. */
+  /** Outside live mode, list edits save as a new geometry version, which only
+   * user routes accept. In live mode the editor session is always editable. */
   _stopsEditable() {
+    if (this._liveSource) return true;
     return !!(
       this.current &&
       this.current.isUser &&
@@ -165,25 +246,30 @@ APP.GtfsEditorManager = class {
     const list = $("#gepStopsList").empty();
     const hint = $("#gepStopsHint");
     const count = $("#gepStopCount");
-    const stops = (this.geom && this.geom.stops) || [];
+    const live = !!this._liveSource;
+    const stops = this._stopsData();
     count.text(stops.length ? `· ${stops.length}` : "");
-    if (!this.geom) {
+    if (!live && !this.geom) {
       hint.hide();
       return;
     }
     if (!stops.length) {
       hint
         .text(
-          this.current && this.current.isUser
-            ? "No stops yet — ✎ Edit the route and use + Stop to place them."
-            : "No stops on this route."
+          live
+            ? "No stops yet — use + Stop on the map; they appear here live."
+            : this.current && this.current.isUser
+              ? "No stops yet — ✎ Edit the route and use + Stop to place them."
+              : "No stops on this route."
         )
         .show();
       return;
     }
     let note = "";
-    if (this.page && this.page.editorManager.active) {
-      note = "Map editor open — stop edits happen there until you exit.";
+    if (live) {
+      note = "● live with the map editor — Save in the toolbar to keep changes";
+    } else if (this.page && this.page.editorManager.active) {
+      note = "Map editor open on another route.";
     } else if (this.current && !this.current.isUser) {
       note = "Official route — ✎ Edit copies it to make stops editable.";
     }
@@ -222,11 +308,28 @@ APP.GtfsEditorManager = class {
 
   _stopAt(el) {
     const i = parseInt($(el).closest(".gep-stop-row").attr("data-i"), 10);
-    const stops = (this.geom && this.geom.stops) || [];
-    return i >= 0 && i < stops.length ? i : null;
+    const n = this._liveSource
+      ? this._liveStopFeatures().length
+      : ((this.geom && this.geom.stops) || []).length;
+    return i >= 0 && i < n ? i : null;
+  }
+
+  /** Reorder the editor session's stop features (order = stop_sequence). */
+  _liveReorder(i, j) {
+    const src = this._liveSource;
+    const feats = this._liveStopFeatures();
+    if (j < 0 || j >= feats.length) return;
+    [feats[i], feats[j]] = [feats[j], feats[i]];
+    this._squelch = true; // one render at the end, not one per remove/add
+    feats.forEach((f) => src.removeFeature(f));
+    feats.forEach((f) => src.addFeature(f));
+    this._squelch = false;
+    this.page.editorManager._snapshot();
+    this._renderStops();
   }
 
   _queueStopsSave() {
+    if (this._liveSource) return; // live edits persist via the editor's Save
     if (!this._stopsEditable()) return;
     this.stopsStatus.textContent = "Saving…";
     if (this._stopsTimer) clearTimeout(this._stopsTimer);
@@ -525,20 +628,30 @@ APP.GtfsEditorManager = class {
         "#gepFarePrice, #gepFareCurrency"
     ).on("input change", () => this._queueFeedSave());
 
-    // Stops list (rows are rebuilt per route, so delegate).
+    // Stops list (rows are rebuilt per route, so delegate). Every edit
+    // branches: live mode writes into the editor's features (persisted only
+    // by the toolbar Save); otherwise it autosaves a new geometry version.
     const stopsList = $("#gepStopsList");
     stopsList.on("click", ".gep-stop-seq", (e) => {
       const i = this._stopAt(e.currentTarget);
-      if (i != null && this.page) {
-        const s = this.geom.stops[i];
-        this.page.focusStop(s.lon, s.lat);
-      }
+      if (i == null || !this.page) return;
+      const s = this._stopsData()[i];
+      if (s) this.page.focusStop(s.lon, s.lat);
     });
     stopsList.on("input", ".gep-stop-name", (e) => {
       const i = this._stopAt(e.currentTarget);
       if (i == null) return;
+      if (this._liveSource) {
+        const f = this._liveStopFeatures()[i];
+        if (f) f.set("name", e.currentTarget.value);
+        return;
+      }
       this.geom.stops[i].name = e.currentTarget.value;
       this._queueStopsSave();
+    });
+    // In live mode a rename becomes one undo step when the field is left.
+    stopsList.on("change", ".gep-stop-name", () => {
+      if (this._liveSource) this.page.editorManager._snapshot();
     });
     stopsList.on("change", ".gep-stop-coord", (e) => {
       const i = this._stopAt(e.currentTarget);
@@ -546,19 +659,32 @@ APP.GtfsEditorManager = class {
       const v = parseFloat(e.currentTarget.value);
       const isLat = $(e.currentTarget).hasClass("gep-stop-lat");
       const ok = isFinite(v) && (isLat ? Math.abs(v) <= 90 : Math.abs(v) <= 180);
-      const s = this.geom.stops[i];
+      const s = this._stopsData()[i];
       if (!ok) {
         e.currentTarget.value = (isLat ? s.lat : s.lon).toFixed(6); // revert
         return;
       }
-      if (isLat) s.lat = v;
-      else s.lon = v;
+      if (this._liveSource) {
+        const f = this._liveStopFeatures()[i];
+        if (!f) return;
+        const lon = isLat ? s.lon : v;
+        const lat = isLat ? v : s.lat;
+        f.setGeometry(new ol.geom.Point(APP.MapUtils.toOL([lon, lat])));
+        this.page.editorManager._snapshot();
+        return;
+      }
+      if (isLat) this.geom.stops[i].lat = v;
+      else this.geom.stops[i].lon = v;
       this._queueStopsSave();
     });
     stopsList.on("click", ".gep-stop-up, .gep-stop-down", (e) => {
       const i = this._stopAt(e.currentTarget);
       if (i == null) return;
       const j = $(e.currentTarget).hasClass("gep-stop-up") ? i - 1 : i + 1;
+      if (this._liveSource) {
+        this._liveReorder(i, j);
+        return;
+      }
       const stops = this.geom.stops;
       if (j < 0 || j >= stops.length) return;
       [stops[i], stops[j]] = [stops[j], stops[i]];
@@ -568,6 +694,14 @@ APP.GtfsEditorManager = class {
     stopsList.on("click", ".gep-stop-del", (e) => {
       const i = this._stopAt(e.currentTarget);
       if (i == null) return;
+      if (this._liveSource) {
+        const f = this._liveStopFeatures()[i];
+        if (f) {
+          this._liveSource.removeFeature(f);
+          this.page.editorManager._snapshot();
+        }
+        return;
+      }
       this.geom.stops.splice(i, 1);
       this._renderStops();
       this._queueStopsSave();

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -161,6 +161,7 @@ APP.GtfsEditorManager = class {
     set(".gep-stop-lat", ll[1].toFixed(6));
     set(".gep-stop-lon", ll[0].toFixed(6));
     set(".gep-stop-name", feature.get("name") || "");
+    set(".gep-stop-code", feature.get("code") || "");
   }
 
   /** Stops as plain data, from the live editor session or saved geometry. */
@@ -168,7 +169,12 @@ APP.GtfsEditorManager = class {
     if (this._liveSource) {
       return this._liveStopFeatures().map((f) => {
         const ll = APP.MapUtils.toNormal(f.getGeometry().getCoordinates());
-        return { name: f.get("name") || "", lon: ll[0], lat: ll[1] };
+        return {
+          name: f.get("name") || "",
+          code: f.get("code") || "",
+          lon: ll[0],
+          lat: ll[1],
+        };
       });
     }
     return (this.geom && this.geom.stops) || [];
@@ -279,6 +285,11 @@ APP.GtfsEditorManager = class {
       const row = $('<div class="gep-stop-row"></div>').attr("data-i", i);
       row.append(
         $('<button type="button" class="gep-stop-seq" title="Show on map"></button>').text(i + 1)
+      );
+      row.append(
+        $('<input type="text" class="gep-stop-code" placeholder="code" title="Public stop number (GTFS stop_code)" />')
+          .val(s.code || "")
+          .prop("disabled", !editable)
       );
       row.append(
         $('<input type="text" class="gep-stop-name" placeholder="(unnamed)" />')
@@ -813,8 +824,19 @@ APP.GtfsEditorManager = class {
       this.geom.stops[i].name = e.currentTarget.value;
       this._queueStopsSave();
     });
-    // In live mode a rename becomes one undo step when the field is left.
-    stopsList.on("change", ".gep-stop-name", () => {
+    stopsList.on("input", ".gep-stop-code", (e) => {
+      const i = this._stopAt(e.currentTarget);
+      if (i == null) return;
+      if (this._liveSource) {
+        const f = this._liveStopFeatures()[i];
+        if (f) f.set("code", e.currentTarget.value.trim());
+        return;
+      }
+      this.geom.stops[i].code = e.currentTarget.value.trim();
+      this._queueStopsSave();
+    });
+    // In live mode a rename/recode becomes one undo step when the field is left.
+    stopsList.on("change", ".gep-stop-name, .gep-stop-code", () => {
       if (this._liveSource) this.page.editorManager._snapshot();
     });
     stopsList.on("change", ".gep-stop-coord", (e) => {

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -414,31 +414,27 @@ APP.GtfsEditorManager = class {
       daysRow.append(label);
     });
     block.append(daysRow);
-    const row = $('<div class="gep-row"></div>');
-    row.append(
-      $("<label>Every </label>").append(
-        $('<input type="number" class="gep-headway" min="1" max="1440" />')
-          .attr("placeholder", this._defHeadwayMin || 30)
-          .val(sched.headway_secs ? Math.round(sched.headway_secs / 60) : "")
-      ).append(" min,")
+    // Time-of-day frequency bands (peak/off-peak); legacy single-headway
+    // schedules render as one band.
+    const bandList = $('<div class="gep-band-list"></div>');
+    const bands = sched.bands || [{
+      headway_secs: sched.headway_secs,
+      start_time: sched.start_time,
+      end_time: sched.end_time,
+    }];
+    bands.forEach((b) => bandList.append(this._bandRow(b)));
+    block.append(bandList);
+    const foot = $('<div class="gep-row"></div>');
+    foot.append(
+      $('<a class="gep-band-add" title="Add a peak/off-peak headway window">+ time band</a>')
     );
-    row.append(
-      $("<label>first </label>").append(
-        $('<input type="time" class="gep-start" />').val((sched.start_time || "").slice(0, 5))
-      )
-    );
-    row.append(
-      $("<label>last </label>").append(
-        $('<input type="time" class="gep-end" />').val((sched.end_time || "").slice(0, 5))
-      )
-    );
-    row.append(
+    foot.append(
       $("<label>run </label>").append(
         $('<input type="number" class="gep-run" min="1" max="360" placeholder="auto" />')
           .val(sched.run_secs ? Math.round(sched.run_secs / 60) : "")
       ).append(" min")
     );
-    block.append(row);
+    block.append(foot);
     const depRow = $('<div class="gep-row"></div>');
     depRow.append(
       $('<label class="gep-block">Exact departures — when filled, real trips are exported instead of the headway estimate.</label>').append(
@@ -448,6 +444,30 @@ APP.GtfsEditorManager = class {
     );
     block.append(depRow);
     return block;
+  }
+
+  /** One time-of-day frequency window: "every N min, HH:MM–HH:MM". */
+  _bandRow(band) {
+    const row = $('<div class="gep-row gep-band"></div>');
+    row.append(
+      $("<label>Every </label>").append(
+        $('<input type="number" class="gep-headway" min="1" max="1440" />')
+          .attr("placeholder", this._defHeadwayMin || 30)
+          .val(band.headway_secs ? Math.round(band.headway_secs / 60) : "")
+      ).append(" min,")
+    );
+    row.append(
+      $("<label>from </label>").append(
+        $('<input type="time" class="gep-start" />').val((band.start_time || "").slice(0, 5))
+      )
+    );
+    row.append(
+      $("<label>to </label>").append(
+        $('<input type="time" class="gep-end" />').val((band.end_time || "").slice(0, 5))
+      )
+    );
+    row.append($('<a class="gep-band-del" title="Remove this time band">✕</a>'));
+    return row;
   }
 
   _renderSched(blocks) {
@@ -490,10 +510,17 @@ APP.GtfsEditorManager = class {
     $("#gepSchedList .gep-sched-block").each((_, el) => {
       const b = $(el);
       const sched = {};
-      const headway = parseInt(b.find(".gep-headway").val(), 10);
-      if (headway > 0) sched.headway_secs = headway * 60;
-      if (b.find(".gep-start").val()) sched.start_time = b.find(".gep-start").val();
-      if (b.find(".gep-end").val()) sched.end_time = b.find(".gep-end").val();
+      const bands = [];
+      b.find(".gep-band").each((_, bel) => {
+        const bb = $(bel);
+        const band = {};
+        const headway = parseInt(bb.find(".gep-headway").val(), 10);
+        if (headway > 0) band.headway_secs = headway * 60;
+        if (bb.find(".gep-start").val()) band.start_time = bb.find(".gep-start").val();
+        if (bb.find(".gep-end").val()) band.end_time = bb.find(".gep-end").val();
+        if (Object.keys(band).length) bands.push(band);
+      });
+      if (bands.length) sched.bands = bands;
       const run = parseInt(b.find(".gep-run").val(), 10);
       if (run > 0) sched.run_secs = run * 60;
       const deps = b.find(".gep-departures").val().split(/[\s,;]+/).filter(Boolean);
@@ -563,6 +590,8 @@ APP.GtfsEditorManager = class {
         this._defaultAgency = agencies[0] || { id: "ADBS", name: (def.agency || {}).name || "Default" };
         this._renderAgencyRows(agencies);
         this._updateOperatorOptions();
+        const list = $("#gepHolidayList").empty();
+        (c.holidays || []).forEach((h) => list.append(this._holidayRow(h)));
         const fare = c.fare || {};
         $("#gepFarePrice").val(fare.price != null ? fare.price : "");
         $("#gepFareCurrency").val(fare.currency || "");
@@ -587,6 +616,41 @@ APP.GtfsEditorManager = class {
     row.append($('<input type="text" class="gep-agency-phone" placeholder="+673 …" />').val(a.phone || ""));
     row.append($('<a class="gep-agency-del" title="Remove operator">✕</a>'));
     return row;
+  }
+
+  _holidayRow(h) {
+    const row = $('<div class="gep-holiday-row"></div>');
+    const v = h.date
+      ? `${h.date.slice(0, 4)}-${h.date.slice(4, 6)}-${h.date.slice(6, 8)}`
+      : "";
+    row.append($('<input type="date" class="gep-holiday-date" />').val(v));
+    row.append(
+      $(
+        '<select class="gep-holiday-mode">' +
+          '<option value="none">no service</option>' +
+          '<option value="sunday">Sunday timetable</option></select>'
+      ).val(h.mode || "none")
+    );
+    row.append(
+      $('<input type="text" class="gep-holiday-name" placeholder="name (optional)" />')
+        .val(h.name || "")
+    );
+    row.append($('<a class="gep-holiday-del" title="Remove holiday">✕</a>'));
+    return row;
+  }
+
+  _holidayData() {
+    const out = [];
+    $("#gepHolidayList .gep-holiday-row").each((_, el) => {
+      const row = $(el);
+      const date = (row.find(".gep-holiday-date").val() || "").replace(/-/g, "");
+      if (!/^\d{8}$/.test(date)) return; // dateless rows are drafts
+      const entry = { date, mode: row.find(".gep-holiday-mode").val() || "none" };
+      const name = row.find(".gep-holiday-name").val().trim();
+      if (name) entry.name = name;
+      out.push(entry);
+    });
+    return out;
   }
 
   /** Operators as data, from the modal rows. Rows without an id get one
@@ -649,6 +713,8 @@ APP.GtfsEditorManager = class {
     const config = {};
     const agencies = this._agencyData(true); // pin ids now that typing settled
     if (agencies.length) config.agencies = agencies;
+    const holidays = this._holidayData();
+    if (holidays.length) config.holidays = holidays;
     const fare = {};
     if ($("#gepFarePrice").val() !== "") fare.price = parseFloat($("#gepFarePrice").val());
     if ($("#gepFareCurrency").val().trim()) fare.currency = $("#gepFareCurrency").val().trim();
@@ -856,6 +922,17 @@ APP.GtfsEditorManager = class {
       $("#gepSchedList").append(this._schedBlockEl({}));
       this._renumberSched();
     });
+    $("#gepSchedList").on("click", ".gep-band-add", (e) => {
+      const block = $(e.currentTarget).closest(".gep-sched-block");
+      if (block.find("input").prop("disabled")) return;
+      block.find(".gep-band-list").append(this._bandRow({}));
+    });
+    $("#gepSchedList").on("click", ".gep-band-del", (e) => {
+      const band = $(e.currentTarget).closest(".gep-band");
+      if (band.find("input").prop("disabled")) return;
+      band.remove();
+      this._queueSave();
+    });
     $("#gepFarePrice, #gepFareCurrency").on("input change", () => this._queueFeedSave());
     // Operator rows are dynamic — delegate, and refresh the route pane's
     // dropdown as names change.
@@ -870,6 +947,16 @@ APP.GtfsEditorManager = class {
     });
     $("#gepAgencyAdd").on("click", () => {
       $("#gepAgencyList").append(this._agencyRow({}));
+    });
+    $("#gepHolidayList").on("input change", "input, select", () =>
+      this._queueFeedSave()
+    );
+    $("#gepHolidayList").on("click", ".gep-holiday-del", (e) => {
+      $(e.currentTarget).closest(".gep-holiday-row").remove();
+      this._queueFeedSave();
+    });
+    $("#gepHolidayAdd").on("click", () => {
+      $("#gepHolidayList").append(this._holidayRow({}));
     });
 
     // Stops list (rows are rebuilt per route, so delegate). Every edit

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -374,9 +374,9 @@ APP.GtfsEditorManager = class {
 
   _formInputs() {
     return $(
-      "#gepHeadway, #gepStart, #gepEnd, #gepRun, #gepDepartures, " +
+      "#gepSchedList input, #gepSchedList textarea, #gepSchedAdd, " +
         "#gepShort, #gepLong, #gepColor, #gepOperator, #gepDirection, " +
-        "#gepHeadsign, #gepReturnHeadsign, .gep-day"
+        "#gepHeadsign, #gepReturnHeadsign"
     );
   }
 
@@ -386,20 +386,77 @@ APP.GtfsEditorManager = class {
 
   // --- Form <-> meta -------------------------------------------------------------
 
+  /** One day-type schedule block's form (weekday/weekend…). */
+  _schedBlockEl(sched) {
+    const block = $('<div class="gep-sched-block"></div>');
+    const head = $('<div class="gep-sched-head"></div>');
+    head.append($('<span class="gep-sched-title"></span>'));
+    head.append($('<a class="gep-sched-del" title="Remove this schedule block">✕</a>'));
+    block.append(head);
+    const days = sched.days || [1, 1, 1, 1, 1, 1, 1];
+    const daysRow = $('<div class="gep-row gep-days"></div>');
+    ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"].forEach((d, i) => {
+      const label = $("<label></label>").text(d);
+      label.prepend(
+        $('<input type="checkbox" class="gep-day" />').prop("checked", !!days[i])
+      );
+      daysRow.append(label);
+    });
+    block.append(daysRow);
+    const row = $('<div class="gep-row"></div>');
+    row.append(
+      $("<label>Every </label>").append(
+        $('<input type="number" class="gep-headway" min="1" max="1440" />')
+          .attr("placeholder", this._defHeadwayMin || 30)
+          .val(sched.headway_secs ? Math.round(sched.headway_secs / 60) : "")
+      ).append(" min,")
+    );
+    row.append(
+      $("<label>first </label>").append(
+        $('<input type="time" class="gep-start" />').val((sched.start_time || "").slice(0, 5))
+      )
+    );
+    row.append(
+      $("<label>last </label>").append(
+        $('<input type="time" class="gep-end" />').val((sched.end_time || "").slice(0, 5))
+      )
+    );
+    row.append(
+      $("<label>run </label>").append(
+        $('<input type="number" class="gep-run" min="1" max="360" placeholder="auto" />')
+          .val(sched.run_secs ? Math.round(sched.run_secs / 60) : "")
+      ).append(" min")
+    );
+    block.append(row);
+    const depRow = $('<div class="gep-row"></div>');
+    depRow.append(
+      $('<label class="gep-block">Exact departures — when filled, real trips are exported instead of the headway estimate.</label>').append(
+        $('<textarea class="gep-departures" rows="2" spellcheck="false" placeholder="06:30, 07:00, 07:45, …"></textarea>')
+          .val((sched.departures || []).map((t) => t.slice(0, 5)).join(", "))
+      )
+    );
+    block.append(depRow);
+    return block;
+  }
+
+  _renderSched(blocks) {
+    const list = $("#gepSchedList").empty();
+    (blocks.length ? blocks : [{}]).forEach((b) => list.append(this._schedBlockEl(b)));
+    this._renumberSched();
+  }
+
+  /** Title each block and only offer ✕ when there is more than one. */
+  _renumberSched() {
+    const rows = $("#gepSchedList .gep-sched-block");
+    rows.each((i, el) => {
+      $(el).find(".gep-sched-title").text(`Schedule ${i + 1}`);
+    });
+    $("#gepSchedList .gep-sched-head").toggle(rows.length > 1);
+  }
+
   _fillForm(meta) {
     this._populating = true;
-    const sched = meta.schedule || {};
-    $("#gepHeadway").val(sched.headway_secs ? Math.round(sched.headway_secs / 60) : "");
-    $("#gepStart").val((sched.start_time || "").slice(0, 5));
-    $("#gepEnd").val((sched.end_time || "").slice(0, 5));
-    $("#gepRun").val(sched.run_secs ? Math.round(sched.run_secs / 60) : "");
-    $("#gepDepartures").val(
-      (sched.departures || []).map((t) => t.slice(0, 5)).join(", ")
-    );
-    const days = sched.days || [1, 1, 1, 1, 1, 1, 1];
-    $(".gep-day").each((i, el) => {
-      el.checked = !!days[i];
-    });
+    this._renderSched(meta.schedules || (meta.schedule ? [meta.schedule] : []));
     $("#gepShort").val(meta.short_name || "");
     $("#gepLong").val(meta.long_name || "");
     $("#gepColor").val(meta.color ? "#" + meta.color : "");
@@ -418,21 +475,23 @@ APP.GtfsEditorManager = class {
 
   _readForm() {
     const meta = {};
-    const sched = {};
-    const headway = parseInt($("#gepHeadway").val(), 10);
-    if (headway > 0) sched.headway_secs = headway * 60;
-    if ($("#gepStart").val()) sched.start_time = $("#gepStart").val();
-    if ($("#gepEnd").val()) sched.end_time = $("#gepEnd").val();
-    const run = parseInt($("#gepRun").val(), 10);
-    if (run > 0) sched.run_secs = run * 60;
-    const deps = $("#gepDepartures")
-      .val()
-      .split(/[\s,;]+/)
-      .filter(Boolean);
-    if (deps.length) sched.departures = deps;
-    const days = $(".gep-day").map((_, el) => (el.checked ? 1 : 0)).get();
-    if (days.some((d) => !d)) sched.days = days; // only save non-default patterns
-    if (Object.keys(sched).length) meta.schedule = sched;
+    const blocks = [];
+    $("#gepSchedList .gep-sched-block").each((_, el) => {
+      const b = $(el);
+      const sched = {};
+      const headway = parseInt(b.find(".gep-headway").val(), 10);
+      if (headway > 0) sched.headway_secs = headway * 60;
+      if (b.find(".gep-start").val()) sched.start_time = b.find(".gep-start").val();
+      if (b.find(".gep-end").val()) sched.end_time = b.find(".gep-end").val();
+      const run = parseInt(b.find(".gep-run").val(), 10);
+      if (run > 0) sched.run_secs = run * 60;
+      const deps = b.find(".gep-departures").val().split(/[\s,;]+/).filter(Boolean);
+      if (deps.length) sched.departures = deps;
+      const days = b.find(".gep-day").map((_, d) => (d.checked ? 1 : 0)).get();
+      if (days.some((d) => !d)) sched.days = days; // only save non-default patterns
+      if (Object.keys(sched).length) blocks.push(sched); // all-default blocks drop out
+    });
+    if (blocks.length) meta.schedules = blocks;
     if ($("#gepShort").val().trim()) meta.short_name = $("#gepShort").val().trim();
     if ($("#gepLong").val().trim()) meta.long_name = $("#gepLong").val().trim();
     const color = $("#gepColor").val().trim();
@@ -497,7 +556,8 @@ APP.GtfsEditorManager = class {
         $("#gepFarePrice").val(fare.price != null ? fare.price : "");
         $("#gepFareCurrency").val(fare.currency || "");
         if (def.headway_secs) {
-          $("#gepHeadway").attr("placeholder", Math.round(def.headway_secs / 60));
+          this._defHeadwayMin = Math.round(def.headway_secs / 60);
+          $("#gepSchedList .gep-headway").attr("placeholder", this._defHeadwayMin);
         }
         this._populating = false;
       });
@@ -696,14 +756,26 @@ APP.GtfsEditorManager = class {
     $("#gepZoomOut").on("click", () => this._setZoom(this.zoom / 1.25));
     $("#gepFit").on("click", () => this._setZoom(1));
     $(
-      "#gepHeadway, #gepStart, #gepEnd, #gepRun, #gepDepartures, " +
-        "#gepShort, #gepLong, #gepColor, #gepOperator, #gepDirection, " +
+      "#gepShort, #gepLong, #gepColor, #gepOperator, #gepDirection, " +
         "#gepHeadsign, #gepReturnHeadsign"
     ).on("input change", () => this._queueSave());
     $("#gepDirection").on("change", () => {
       $("#gepReturnWrap").toggle($("#gepDirection").val() === "outback");
     });
-    $(".gep-day").on("change", () => this._queueSave());
+    // Schedule blocks are rebuilt per route — delegate.
+    $("#gepSchedList").on("input change", "input, textarea", () => this._queueSave());
+    $("#gepSchedList").on("click", ".gep-sched-del", (e) => {
+      const block = $(e.currentTarget).closest(".gep-sched-block");
+      if (block.find("input").prop("disabled")) return;
+      block.remove();
+      this._renumberSched();
+      this._queueSave();
+    });
+    $("#gepSchedAdd").on("click", () => {
+      if (!this.current) return;
+      $("#gepSchedList").append(this._schedBlockEl({}));
+      this._renumberSched();
+    });
     $("#gepFarePrice, #gepFareCurrency").on("input change", () => this._queueFeedSave());
     // Operator rows are dynamic — delegate, and refresh the route pane's
     // dropdown as names change.

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -165,6 +165,10 @@ APP.GtfsEditorManager = class {
     $("#gepHeadway").val(sched.headway_secs ? Math.round(sched.headway_secs / 60) : "");
     $("#gepStart").val((sched.start_time || "").slice(0, 5));
     $("#gepEnd").val((sched.end_time || "").slice(0, 5));
+    $("#gepRun").val(sched.run_secs ? Math.round(sched.run_secs / 60) : "");
+    $("#gepDepartures").val(
+      (sched.departures || []).map((t) => t.slice(0, 5)).join(", ")
+    );
     const days = sched.days || [1, 1, 1, 1, 1, 1, 1];
     $(".gep-day").each((i, el) => {
       el.checked = !!days[i];
@@ -182,6 +186,13 @@ APP.GtfsEditorManager = class {
     if (headway > 0) sched.headway_secs = headway * 60;
     if ($("#gepStart").val()) sched.start_time = $("#gepStart").val();
     if ($("#gepEnd").val()) sched.end_time = $("#gepEnd").val();
+    const run = parseInt($("#gepRun").val(), 10);
+    if (run > 0) sched.run_secs = run * 60;
+    const deps = $("#gepDepartures")
+      .val()
+      .split(/[\s,;]+/)
+      .filter(Boolean);
+    if (deps.length) sched.departures = deps;
     const days = $(".gep-day").map((_, el) => (el.checked ? 1 : 0)).get();
     if (days.some((d) => !d)) sched.days = days; // only save non-default patterns
     if (Object.keys(sched).length) meta.schedule = sched;
@@ -354,10 +365,10 @@ APP.GtfsEditorManager = class {
     $("#gepZoomIn").on("click", () => this._setZoom(this.zoom * 1.25));
     $("#gepZoomOut").on("click", () => this._setZoom(this.zoom / 1.25));
     $("#gepFit").on("click", () => this._setZoom(1));
-    $("#gepHeadway, #gepStart, #gepEnd, #gepShort, #gepLong, #gepColor").on(
-      "input change",
-      () => this._queueSave()
-    );
+    $(
+      "#gepHeadway, #gepStart, #gepEnd, #gepRun, #gepDepartures, " +
+        "#gepShort, #gepLong, #gepColor"
+    ).on("input change", () => this._queueSave());
     $(".gep-day").on("change", () => this._queueSave());
     $(
       "#gepAgencyName, #gepAgencyUrl, #gepAgencyPhone, #gepAgencyEmail, " +

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -758,10 +758,79 @@ APP.GtfsEditorManager = class {
     window.open(`/data/gtfs.zip${year ? "?year=" + encodeURIComponent(year) : ""}`);
   }
 
+  // --- Validation ----------------------------------------------------------------------
+
+  _validate() {
+    this._flushStopsSave();
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer);
+      this._saveTimer = null;
+      this._saveMeta();
+    }
+    if (this._feedTimer) {
+      clearTimeout(this._feedTimer);
+      this._feedTimer = null;
+      this._saveFeedConfig();
+    }
+    const year = this.year || "";
+    $("#validateYear").text(year || "default");
+    $("#validateSummary").attr("class", "gep-validate-summary").text("Validating…");
+    $("#validateList").empty();
+    $("#validateModal").modal("show");
+    fetch(`/data/gtfs-validate${year ? "?year=" + encodeURIComponent(year) : ""}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.error) {
+          $("#validateSummary").addClass("err").text(d.error);
+          return;
+        }
+        const s = d.stats || {};
+        const summary = $("#validateSummary");
+        summary
+          .addClass(d.errors ? "err" : d.warnings ? "warn" : "ok")
+          .text(
+            `${d.errors} error${d.errors === 1 ? "" : "s"}, ` +
+              `${d.warnings} warning${d.warnings === 1 ? "" : "s"} — ` +
+              `${s.routes} routes, ${s.trips} trips, ${s.stops} stops, ` +
+              `${Math.round(d.size / 1024)} KB` +
+              (d.errors ? "" : " · feed is structurally sound")
+          );
+        const list = $("#validateList");
+        (d.findings || []).forEach((f) => {
+          const row = $('<div class="gep-validate-row"></div>');
+          row.append(
+            $('<span class="gep-validate-badge"></span>')
+              .addClass(f.severity)
+              .text(f.severity === "error" ? "ERROR" : "WARN")
+          );
+          const body = $('<span class="gep-validate-msg"></span>').text(
+            `${f.message} (×${f.count})`
+          );
+          if (f.examples && f.examples.length) {
+            body.append(
+              $('<span class="gep-validate-ex"></span>').text(
+                " — " + f.examples.join(", ") + (f.count > f.examples.length ? ", …" : "")
+              )
+            );
+          }
+          row.append(body);
+          list.append(row);
+        });
+        if (!(d.findings || []).length) {
+          list.append('<div class="gep-empty">No findings — all checks passed.</div>');
+        }
+      })
+      .catch((err) => {
+        $("#validateSummary").addClass("err").text("Validation request failed");
+        console.error("gtfs-validate failed", err);
+      });
+  }
+
   // --- Events --------------------------------------------------------------------------
 
   _bind() {
     $("#gepDownload").on("click", () => this._download());
+    $("#gepValidate").on("click", () => this._validate());
     this.timingSelect.on("change", () => this._showTiming());
     $("#gepZoomIn").on("click", () => this._setZoom(this.zoom * 1.25));
     $("#gepZoomOut").on("click", () => this._setZoom(this.zoom / 1.25));

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -18,6 +18,9 @@ APP.GtfsEditorManager = class {
 
   init() {
     this.panel = document.getElementById("gtfsPanel");
+    // Docked mode (the /gtfs page): the panel is a fixed column — always
+    // visible, no drag/resize/close, and route-list toggles drive the form.
+    this.docked = this.panel.classList.contains("docked");
     this.routeSelect = $("#gtfsRouteSelect");
     this.timingSelect = $("#gtfsTimingSelect");
     this.timingImg = document.getElementById("gtfsTimingImg");
@@ -26,6 +29,21 @@ APP.GtfsEditorManager = class {
     this.status = document.getElementById("gepStatus");
     this.feedStatus = document.getElementById("gepFeedStatus");
     this._bind();
+    if (this.docked) this.show();
+  }
+
+  /** Load a specific route into the form (e.g. from a route-list toggle). */
+  selectRoute(year, file) {
+    const opt = this.routeSelect
+      .find("option")
+      .filter((_, o) => o.value === file && $(o).attr("data-year") === year)
+      .first();
+    if (!opt.length) return; // not a GTFS-exportable route (geojson, Points -)
+    if (this.routeSelect.val() === file && this.current && this.current.year === year) {
+      return;
+    }
+    this.routeSelect.val(opt.val());
+    this._showSelected();
   }
 
   // --- Data ----------------------------------------------------------------
@@ -37,10 +55,13 @@ APP.GtfsEditorManager = class {
       .then((d) => {
         this.routeSelect.empty();
         (d.years || []).forEach((y) => {
-          // Only KML routes carry stops, so only they appear in the feed.
-          const files = ((d[y] && d[y].routes) || []).filter(
+          // KML routes carry stops, so they appear in the feed — shipped ones
+          // plus user-created routes (the draw -> schedule -> export flow).
+          const shipped = ((d[y] && d[y].routes) || []).filter(
             (f) => !/^points\s*-/i.test(f)
           );
+          const user = (d[y] && d[y].user) || [];
+          const files = shipped.concat(user);
           if (!files.length) return;
           const names = (d[y] && d[y].names) || {};
           const group = $("<optgroup>").attr("label", `${y} routes`);
@@ -105,6 +126,7 @@ APP.GtfsEditorManager = class {
   }
 
   hide() {
+    if (this.docked) return; // the docked column never closes
     this._flushSaves();
     this.panel.style.display = "none";
   }
@@ -374,8 +396,18 @@ APP.GtfsEditorManager = class {
       "#gepAgencyName, #gepAgencyUrl, #gepAgencyPhone, #gepAgencyEmail, " +
         "#gepFarePrice, #gepFareCurrency"
     ).on("input change", () => this._queueFeedSave());
-    this._enableDrag();
-    this._enableResize();
+    if (this.docked) {
+      // Showing a route on the map also loads it into the GTFS form.
+      $("#routes").on("click", "input", (e) => {
+        if (!e.target.checked) return;
+        const sep = e.target.value.indexOf("::"); // id is "<year>::<file>"
+        if (sep < 0) return;
+        this.selectRoute(e.target.value.slice(0, sep), e.target.value.slice(sep + 2));
+      });
+    } else {
+      this._enableDrag();
+      this._enableResize();
+    }
   }
 
   _enableDrag() {

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -375,7 +375,7 @@ APP.GtfsEditorManager = class {
   _formInputs() {
     return $(
       "#gepHeadway, #gepStart, #gepEnd, #gepRun, #gepDepartures, " +
-        "#gepShort, #gepLong, #gepColor, .gep-day"
+        "#gepShort, #gepLong, #gepColor, #gepOperator, .gep-day"
     );
   }
 
@@ -402,6 +402,12 @@ APP.GtfsEditorManager = class {
     $("#gepShort").val(meta.short_name || "");
     $("#gepLong").val(meta.long_name || "");
     $("#gepColor").val(meta.color ? "#" + meta.color : "");
+    // Remember the assignment so the dropdown survives option rebuilds
+    // (operators may still be loading, or get edited in the modal).
+    this._currentOperator = meta.agency_id || "";
+    const op = $("#gepOperator");
+    op.val(this._currentOperator);
+    if (op.val() == null) op.val("");
     this._populating = false;
   }
 
@@ -426,6 +432,9 @@ APP.GtfsEditorManager = class {
     if ($("#gepLong").val().trim()) meta.long_name = $("#gepLong").val().trim();
     const color = $("#gepColor").val().trim();
     if (/^#?[0-9a-fA-F]{6}$/.test(color)) meta.color = color.replace("#", "");
+    const operator = $("#gepOperator").val();
+    if (operator) meta.agency_id = operator;
+    this._currentOperator = operator || "";
     return meta;
   }
 
@@ -459,7 +468,7 @@ APP.GtfsEditorManager = class {
       });
   }
 
-  // --- Feed-level settings (agency + fare modal) -----------------------------------
+  // --- Feed-level settings (operators + fare modal) ---------------------------------
 
   _loadFeedConfig() {
     return fetch("/data/gtfs-config")
@@ -467,13 +476,13 @@ APP.GtfsEditorManager = class {
       .then((d) => {
         const c = d.config || {};
         const def = d.defaults || {};
-        const agency = c.agency || {};
-        const defAgency = def.agency || {};
         this._populating = true;
-        $("#gepAgencyName").val(agency.name || "").attr("placeholder", defAgency.name || "");
-        $("#gepAgencyUrl").val(agency.url || "").attr("placeholder", defAgency.url || "");
-        $("#gepAgencyPhone").val(agency.phone || "").attr("placeholder", defAgency.phone || "");
-        $("#gepAgencyEmail").val(agency.email || "");
+        // Resolved operators = what the export will actually use (saved list,
+        // or the built-in default). Keep the first as the deletion fallback.
+        const agencies = d.agencies || [];
+        this._defaultAgency = agencies[0] || { id: "ADBS", name: (def.agency || {}).name || "Default" };
+        this._renderAgencyRows(agencies);
+        this._updateOperatorOptions();
         const fare = c.fare || {};
         $("#gepFarePrice").val(fare.price != null ? fare.price : "");
         $("#gepFareCurrency").val(fare.currency || "");
@@ -482,6 +491,67 @@ APP.GtfsEditorManager = class {
         }
         this._populating = false;
       });
+  }
+
+  _renderAgencyRows(agencies) {
+    const list = $("#gepAgencyList").empty();
+    agencies.forEach((a) => list.append(this._agencyRow(a)));
+    if (!agencies.length) list.append(this._agencyRow({}));
+  }
+
+  _agencyRow(a) {
+    const row = $('<div class="gep-agency-row"></div>').attr("data-id", a.id || "");
+    row.append($('<input type="text" class="gep-agency-name" placeholder="Operator name" />').val(a.name || ""));
+    row.append($('<input type="text" class="gep-agency-url" placeholder="https://…" />').val(a.url || ""));
+    row.append($('<input type="text" class="gep-agency-phone" placeholder="+673 …" />').val(a.phone || ""));
+    row.append($('<a class="gep-agency-del" title="Remove operator">✕</a>'));
+    return row;
+  }
+
+  /** Operators as data, from the modal rows. Rows without an id get one
+   * derived from the name (same slug rule as the server). With `pin` the id
+   * is written onto the row, freezing it so route assignments stay stable
+   * across later renames — pin only once typing has settled (save time),
+   * never per keystroke. */
+  _agencyData(pin) {
+    const out = [];
+    const seen = new Set();
+    $("#gepAgencyList .gep-agency-row").each((_, el) => {
+      const row = $(el);
+      const name = row.find(".gep-agency-name").val().trim();
+      if (!name) return;
+      let id = row.attr("data-id");
+      if (!id) {
+        id = name.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "").toUpperCase().slice(0, 30) || "OP";
+        let unique = id;
+        let n = 2;
+        while (seen.has(unique)) unique = `${id}-${n++}`;
+        id = unique;
+        if (pin) row.attr("data-id", id);
+      }
+      if (seen.has(id)) return;
+      seen.add(id);
+      const entry = { id, name };
+      const url = row.find(".gep-agency-url").val().trim();
+      const phone = row.find(".gep-agency-phone").val().trim();
+      if (url) entry.url = url;
+      if (phone) entry.phone = phone;
+      out.push(entry);
+    });
+    return out;
+  }
+
+  /** Rebuild the route pane's Operator dropdown from the modal rows,
+   * preserving the selected route's assignment. */
+  _updateOperatorOptions() {
+    const select = $("#gepOperator");
+    const agencies = this._agencyData();
+    const first = agencies[0] || this._defaultAgency || { id: "", name: "default" };
+    select.empty();
+    select.append($("<option>").val("").text(`(default — ${first.name})`));
+    agencies.forEach((a) => select.append($("<option>").val(a.id).text(a.name)));
+    select.val(this._currentOperator || "");
+    if (select.val() == null) select.val(""); // assignment to a removed operator
   }
 
   _queueFeedSave() {
@@ -496,12 +566,8 @@ APP.GtfsEditorManager = class {
 
   _saveFeedConfig() {
     const config = {};
-    const agency = {};
-    if ($("#gepAgencyName").val().trim()) agency.name = $("#gepAgencyName").val().trim();
-    if ($("#gepAgencyUrl").val().trim()) agency.url = $("#gepAgencyUrl").val().trim();
-    if ($("#gepAgencyPhone").val().trim()) agency.phone = $("#gepAgencyPhone").val().trim();
-    if ($("#gepAgencyEmail").val().trim()) agency.email = $("#gepAgencyEmail").val().trim();
-    if (Object.keys(agency).length) config.agency = agency;
+    const agencies = this._agencyData(true); // pin ids now that typing settled
+    if (agencies.length) config.agencies = agencies;
     const fare = {};
     if ($("#gepFarePrice").val() !== "") fare.price = parseFloat($("#gepFarePrice").val());
     if ($("#gepFareCurrency").val().trim()) fare.currency = $("#gepFareCurrency").val().trim();
@@ -515,6 +581,7 @@ APP.GtfsEditorManager = class {
       .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
       .then(({ ok, d }) => {
         this.feedStatus.textContent = ok ? "Saved ✓" : d.error || "Save failed";
+        if (ok) this._updateOperatorOptions();
       })
       .catch((err) => {
         this.feedStatus.textContent = "Save failed";
@@ -620,13 +687,24 @@ APP.GtfsEditorManager = class {
     $("#gepFit").on("click", () => this._setZoom(1));
     $(
       "#gepHeadway, #gepStart, #gepEnd, #gepRun, #gepDepartures, " +
-        "#gepShort, #gepLong, #gepColor"
+        "#gepShort, #gepLong, #gepColor, #gepOperator"
     ).on("input change", () => this._queueSave());
     $(".gep-day").on("change", () => this._queueSave());
-    $(
-      "#gepAgencyName, #gepAgencyUrl, #gepAgencyPhone, #gepAgencyEmail, " +
-        "#gepFarePrice, #gepFareCurrency"
-    ).on("input change", () => this._queueFeedSave());
+    $("#gepFarePrice, #gepFareCurrency").on("input change", () => this._queueFeedSave());
+    // Operator rows are dynamic — delegate, and refresh the route pane's
+    // dropdown as names change.
+    $("#gepAgencyList").on("input", "input", () => {
+      this._updateOperatorOptions();
+      this._queueFeedSave();
+    });
+    $("#gepAgencyList").on("click", ".gep-agency-del", (e) => {
+      $(e.currentTarget).closest(".gep-agency-row").remove();
+      this._updateOperatorOptions();
+      this._queueFeedSave();
+    });
+    $("#gepAgencyAdd").on("click", () => {
+      $("#gepAgencyList").append(this._agencyRow({}));
+    });
 
     // Stops list (rows are rebuilt per route, so delegate). Every edit
     // branches: live mode writes into the editor's features (persisted only

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -1,0 +1,421 @@
+// Floating GTFS editor panel. Per route: schedule (headway / service window /
+// operating days), short & long name, color — saved to /data/gtfs-meta and
+// merged into the /data/gtfs.zip export. Feed-wide: agency details and flat
+// fare via /data/gtfs-config. The official JPD timing signboard for the route
+// (docs/<year>/images/timings/) is shown alongside so real times can be
+// transcribed. Drag/resize/autosave follow the StopImageManager patterns.
+window.APP = window.APP || {};
+
+APP.GtfsEditorManager = class {
+  constructor() {
+    this.zoom = 1;
+    this.loaded = false;
+    this.current = null; // { year, file } of the route being edited
+    this._saveTimer = null;
+    this._feedTimer = null;
+    this._populating = false; // suppress autosave while filling the form
+  }
+
+  init() {
+    this.panel = document.getElementById("gtfsPanel");
+    this.routeSelect = $("#gtfsRouteSelect");
+    this.timingSelect = $("#gtfsTimingSelect");
+    this.timingImg = document.getElementById("gtfsTimingImg");
+    this.timingEmpty = document.getElementById("gtfsTimingEmpty");
+    this.routeLabel = document.getElementById("gepRouteLabel");
+    this.status = document.getElementById("gepStatus");
+    this.feedStatus = document.getElementById("gepFeedStatus");
+    this._bind();
+  }
+
+  // --- Data ----------------------------------------------------------------
+
+  _load() {
+    if (this.loaded) return Promise.resolve();
+    const routes = fetch("/data/catalog")
+      .then((r) => r.json())
+      .then((d) => {
+        this.routeSelect.empty();
+        (d.years || []).forEach((y) => {
+          // Only KML routes carry stops, so only they appear in the feed.
+          const files = ((d[y] && d[y].routes) || []).filter(
+            (f) => !/^points\s*-/i.test(f)
+          );
+          if (!files.length) return;
+          const names = (d[y] && d[y].names) || {};
+          const group = $("<optgroup>").attr("label", `${y} routes`);
+          files.forEach((f) => {
+            const stem = f.replace(/\.[^.]+$/, "");
+            $("<option>")
+              .val(f)
+              .attr("data-year", y)
+              .text(names[f] || stem)
+              .appendTo(group);
+          });
+          this.routeSelect.append(group);
+        });
+      });
+    const timings = fetch("/data/timing-images")
+      .then((r) => r.json())
+      .then((d) => {
+        this.timingSelect.empty();
+        this.timingSelect.append($("<option>").val("").text("— signboard —"));
+        (d.years || []).forEach((y) => {
+          const group = $("<optgroup>").attr("label", `${y} timings`);
+          (d.images[y] || []).forEach((im) => {
+            $("<option>")
+              .val(im.file)
+              .attr("data-year", y)
+              .attr("data-route", im.route)
+              .text(im.route + " — " + im.file.replace(/\.[^.]+$/, ""))
+              .appendTo(group);
+          });
+          this.timingSelect.append(group);
+        });
+      });
+    const config = this._loadFeedConfig();
+    return Promise.all([routes, timings, config])
+      .then(() => {
+        this.loaded = true;
+      })
+      .catch((err) => {
+        if (APP.MapUtils) APP.MapUtils.handleError(err, "Loading GTFS editor");
+        console.error("gtfs editor load failed", err);
+      });
+  }
+
+  // --- Show / hide -----------------------------------------------------------
+
+  toggle() {
+    if (this.panel.style.display === "none" || !this.panel.style.display) {
+      this.show();
+    } else {
+      this.hide();
+    }
+  }
+
+  show() {
+    this._load().then(() => {
+      this.panel.style.display = "flex";
+      if (!this.routeSelect.val() && this.routeSelect.find("option").length) {
+        this.routeSelect.prop("selectedIndex", 0);
+      }
+      this._showSelected();
+    });
+  }
+
+  hide() {
+    this._flushSaves();
+    this.panel.style.display = "none";
+  }
+
+  _flushSaves() {
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer);
+      this._saveTimer = null;
+      this._saveMeta();
+    }
+    if (this._feedTimer) {
+      clearTimeout(this._feedTimer);
+      this._feedTimer = null;
+      this._saveFeedConfig();
+    }
+  }
+
+  // --- Route selection -------------------------------------------------------
+
+  _showSelected() {
+    const opt = this.routeSelect.find("option:selected");
+    const year = opt.attr("data-year");
+    const file = opt.val();
+    if (!year || !file) {
+      this.current = null;
+      this.routeLabel.textContent = "—";
+      return;
+    }
+    // Flush a pending save for the route we're leaving.
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer);
+      this._saveTimer = null;
+      this._saveMeta();
+    }
+    this.current = { year, file };
+    this.routeLabel.textContent = `${opt.text()} (${year})`;
+    this.status.textContent = "Loading…";
+    const q = `?year=${encodeURIComponent(year)}&route=${encodeURIComponent(file)}`;
+    fetch(`/data/gtfs-meta${q}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (!this.current || this.current.file !== file || this.current.year !== year) {
+          return; // stale response, selection moved on
+        }
+        this._fillForm(d.meta || {});
+        this.status.textContent = "";
+        this._matchTimingImage();
+      })
+      .catch((err) => {
+        this.status.textContent = "Load failed";
+        console.error("gtfs-meta load failed", err);
+      });
+  }
+
+  _fillForm(meta) {
+    this._populating = true;
+    const sched = meta.schedule || {};
+    $("#gepHeadway").val(sched.headway_secs ? Math.round(sched.headway_secs / 60) : "");
+    $("#gepStart").val((sched.start_time || "").slice(0, 5));
+    $("#gepEnd").val((sched.end_time || "").slice(0, 5));
+    const days = sched.days || [1, 1, 1, 1, 1, 1, 1];
+    $(".gep-day").each((i, el) => {
+      el.checked = !!days[i];
+    });
+    $("#gepShort").val(meta.short_name || "");
+    $("#gepLong").val(meta.long_name || "");
+    $("#gepColor").val(meta.color ? "#" + meta.color : "");
+    this._populating = false;
+  }
+
+  _readForm() {
+    const meta = {};
+    const sched = {};
+    const headway = parseInt($("#gepHeadway").val(), 10);
+    if (headway > 0) sched.headway_secs = headway * 60;
+    if ($("#gepStart").val()) sched.start_time = $("#gepStart").val();
+    if ($("#gepEnd").val()) sched.end_time = $("#gepEnd").val();
+    const days = $(".gep-day").map((_, el) => (el.checked ? 1 : 0)).get();
+    if (days.some((d) => !d)) sched.days = days; // only save non-default patterns
+    if (Object.keys(sched).length) meta.schedule = sched;
+    if ($("#gepShort").val().trim()) meta.short_name = $("#gepShort").val().trim();
+    if ($("#gepLong").val().trim()) meta.long_name = $("#gepLong").val().trim();
+    const color = $("#gepColor").val().trim();
+    if (/^#?[0-9a-fA-F]{6}$/.test(color)) meta.color = color.replace("#", "");
+    return meta;
+  }
+
+  _queueSave() {
+    if (!this.current || this._populating) return;
+    this.status.textContent = "Saving…";
+    if (this._saveTimer) clearTimeout(this._saveTimer);
+    this._saveTimer = setTimeout(() => {
+      this._saveTimer = null;
+      this._saveMeta();
+    }, 600);
+  }
+
+  _saveMeta() {
+    if (!this.current) return;
+    const ctx = this.current;
+    fetch("/data/gtfs-meta", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ year: ctx.year, route: ctx.file, meta: this._readForm() }),
+    })
+      .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
+      .then(({ ok, d }) => {
+        if (this.current && this.current.file === ctx.file) {
+          this.status.textContent = ok ? "Saved ✓" : d.error || "Save failed";
+        }
+      })
+      .catch((err) => {
+        this.status.textContent = "Save failed";
+        console.error("gtfs-meta save failed", err);
+      });
+  }
+
+  // --- Feed-level settings (agency + fare) ------------------------------------
+
+  _loadFeedConfig() {
+    return fetch("/data/gtfs-config")
+      .then((r) => r.json())
+      .then((d) => {
+        const c = d.config || {};
+        const def = d.defaults || {};
+        const agency = c.agency || {};
+        const defAgency = def.agency || {};
+        this._populating = true;
+        $("#gepAgencyName").val(agency.name || "").attr("placeholder", defAgency.name || "");
+        $("#gepAgencyUrl").val(agency.url || "").attr("placeholder", defAgency.url || "");
+        $("#gepAgencyPhone").val(agency.phone || "").attr("placeholder", defAgency.phone || "");
+        $("#gepAgencyEmail").val(agency.email || "");
+        const fare = c.fare || {};
+        $("#gepFarePrice").val(fare.price != null ? fare.price : "");
+        $("#gepFareCurrency").val(fare.currency || "");
+        if (def.headway_secs) {
+          $("#gepHeadway").attr("placeholder", Math.round(def.headway_secs / 60));
+        }
+        this._populating = false;
+      });
+  }
+
+  _queueFeedSave() {
+    if (this._populating) return;
+    this.feedStatus.textContent = "Saving…";
+    if (this._feedTimer) clearTimeout(this._feedTimer);
+    this._feedTimer = setTimeout(() => {
+      this._feedTimer = null;
+      this._saveFeedConfig();
+    }, 600);
+  }
+
+  _saveFeedConfig() {
+    const config = {};
+    const agency = {};
+    if ($("#gepAgencyName").val().trim()) agency.name = $("#gepAgencyName").val().trim();
+    if ($("#gepAgencyUrl").val().trim()) agency.url = $("#gepAgencyUrl").val().trim();
+    if ($("#gepAgencyPhone").val().trim()) agency.phone = $("#gepAgencyPhone").val().trim();
+    if ($("#gepAgencyEmail").val().trim()) agency.email = $("#gepAgencyEmail").val().trim();
+    if (Object.keys(agency).length) config.agency = agency;
+    const fare = {};
+    if ($("#gepFarePrice").val() !== "") fare.price = parseFloat($("#gepFarePrice").val());
+    if ($("#gepFareCurrency").val().trim()) fare.currency = $("#gepFareCurrency").val().trim();
+    if (Object.keys(fare).length) config.fare = fare;
+    // The feed config applies to the export year — use the selected route's
+    // year (the default year when nothing is selected).
+    const year = this.current ? this.current.year : undefined;
+    fetch("/data/gtfs-config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ year, config }),
+    })
+      .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
+      .then(({ ok, d }) => {
+        this.feedStatus.textContent = ok ? "Saved ✓" : d.error || "Save failed";
+      })
+      .catch((err) => {
+        this.feedStatus.textContent = "Save failed";
+        console.error("gtfs-config save failed", err);
+      });
+  }
+
+  // --- Timing signboard --------------------------------------------------------
+
+  /** Auto-select the signboard whose route code matches the edited route
+   * (saved short_name first, else trailing code in the filename stem). */
+  _matchTimingImage() {
+    if (!this.current) return;
+    const stem = this.current.file.replace(/\.[^.]+$/, "");
+    const m = stem.match(/(\d+[A-Za-z]?)\s*$/);
+    const codes = [$("#gepShort").val().trim(), m ? m[1] : ""].filter(Boolean);
+    let found = null;
+    for (const code of codes) {
+      const opt = this.timingSelect
+        .find("option")
+        .filter((_, o) => $(o).attr("data-route") === code)
+        .first();
+      if (opt.length) {
+        found = opt;
+        break;
+      }
+    }
+    this.timingSelect.val(found ? found.val() : "");
+    this._showTiming();
+  }
+
+  _showTiming() {
+    const opt = this.timingSelect.find("option:selected");
+    const year = opt.attr("data-year");
+    const file = opt.val();
+    if (!year || !file) {
+      this.timingImg.style.display = "none";
+      this.timingEmpty.style.display = "";
+      return;
+    }
+    this.timingEmpty.style.display = "none";
+    this.timingImg.style.display = "";
+    this.timingImg.src =
+      "/data/timing-image/" +
+      encodeURIComponent(year) +
+      "/" +
+      encodeURIComponent(file);
+    this._setZoom(1);
+  }
+
+  _setZoom(z) {
+    this.zoom = Math.min(6, Math.max(0.3, z));
+    this.timingImg.style.width = this.zoom * 100 + "%";
+  }
+
+  // --- Download -----------------------------------------------------------------
+
+  _download() {
+    this._flushSaves();
+    const year = this.current ? this.current.year : "";
+    window.open(`/data/gtfs.zip${year ? "?year=" + encodeURIComponent(year) : ""}`);
+  }
+
+  // --- Events --------------------------------------------------------------------
+
+  _bind() {
+    $("#gtfsEditorToggle").on("click", () => this.toggle());
+    $("#gepClose").on("click", () => this.hide());
+    $("#gepDownload").on("click", () => this._download());
+    this.routeSelect.on("change", () => this._showSelected());
+    this.timingSelect.on("change", () => this._showTiming());
+    $("#gepZoomIn").on("click", () => this._setZoom(this.zoom * 1.25));
+    $("#gepZoomOut").on("click", () => this._setZoom(this.zoom / 1.25));
+    $("#gepFit").on("click", () => this._setZoom(1));
+    $("#gepHeadway, #gepStart, #gepEnd, #gepShort, #gepLong, #gepColor").on(
+      "input change",
+      () => this._queueSave()
+    );
+    $(".gep-day").on("change", () => this._queueSave());
+    $(
+      "#gepAgencyName, #gepAgencyUrl, #gepAgencyPhone, #gepAgencyEmail, " +
+        "#gepFarePrice, #gepFareCurrency"
+    ).on("input change", () => this._queueFeedSave());
+    this._enableDrag();
+    this._enableResize();
+  }
+
+  _enableDrag() {
+    const header = document.getElementById("gtfsHeader");
+    let sx, sy, sl, st, dragging = false;
+    const onMove = (e) => {
+      if (!dragging) return;
+      this.panel.style.left = sl + (e.clientX - sx) + "px";
+      this.panel.style.top = st + (e.clientY - sy) + "px";
+      this.panel.style.right = "auto";
+    };
+    const onUp = () => {
+      dragging = false;
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    };
+    header.addEventListener("mousedown", (e) => {
+      if (e.target.closest("button, select, input")) return;
+      const r = this.panel.getBoundingClientRect();
+      sx = e.clientX; sy = e.clientY; sl = r.left; st = r.top;
+      this.panel.style.left = r.left + "px";
+      this.panel.style.top = r.top + "px";
+      this.panel.style.right = "auto";
+      dragging = true;
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+      e.preventDefault();
+    });
+  }
+
+  _enableResize() {
+    const handle = document.getElementById("gtfsResize");
+    let sx, sy, sw, sh, resizing = false;
+    const onMove = (e) => {
+      if (!resizing) return;
+      this.panel.style.width = Math.max(280, sw + (e.clientX - sx)) + "px";
+      this.panel.style.height = Math.max(260, sh + (e.clientY - sy)) + "px";
+    };
+    const onUp = () => {
+      resizing = false;
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    };
+    handle.addEventListener("mousedown", (e) => {
+      const r = this.panel.getBoundingClientRect();
+      sx = e.clientX; sy = e.clientY; sw = r.width; sh = r.height;
+      resizing = true;
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+      e.preventDefault();
+      e.stopPropagation();
+    });
+  }
+};

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -1,27 +1,21 @@
-// Floating GTFS editor panel. Per route: schedule (headway / service window /
-// operating days), short & long name, color — saved to /data/gtfs-meta and
-// merged into the /data/gtfs.zip export. Feed-wide: agency details and flat
-// fare via /data/gtfs-config. The official JPD timing signboard for the route
-// (docs/<year>/images/timings/) is shown alongside so real times can be
-// transcribed. Drag/resize/autosave follow the StopImageManager patterns.
+// The GTFS pane on the /gtfs page. Edits one route at a time — whichever the
+// page has selected (GtfsPage.setRoute drives it). Per route: schedule
+// (headway / window / days), exact departures transcribed from the JPD timing
+// signboard shown alongside, run time, names, color — saved to /data/gtfs-meta
+// and merged into the /data/gtfs.zip export. Feed-wide agency + flat fare live
+// in the Feed settings modal (/data/gtfs-config); ⬇ Download grabs the zip.
 window.APP = window.APP || {};
 
 APP.GtfsEditorManager = class {
   constructor() {
     this.zoom = 1;
-    this.loaded = false;
-    this.current = null; // { year, file } of the route being edited
+    this.current = null; // { year, file, label }
     this._saveTimer = null;
     this._feedTimer = null;
     this._populating = false; // suppress autosave while filling the form
   }
 
   init() {
-    this.panel = document.getElementById("gtfsPanel");
-    // Docked mode (the /gtfs page): the panel is a fixed column — always
-    // visible, no drag/resize/close, and route-list toggles drive the form.
-    this.docked = this.panel.classList.contains("docked");
-    this.routeSelect = $("#gtfsRouteSelect");
     this.timingSelect = $("#gtfsTimingSelect");
     this.timingImg = document.getElementById("gtfsTimingImg");
     this.timingEmpty = document.getElementById("gtfsTimingEmpty");
@@ -29,141 +23,25 @@ APP.GtfsEditorManager = class {
     this.status = document.getElementById("gepStatus");
     this.feedStatus = document.getElementById("gepFeedStatus");
     this._bind();
-    if (this.docked) this.show();
+    this._setFormEnabled(false);
+    this._loadTimings();
+    this._loadFeedConfig();
   }
 
-  /** Load a specific route into the form (e.g. from a route-list toggle). */
-  selectRoute(year, file) {
-    const opt = this.routeSelect
-      .find("option")
-      .filter((_, o) => o.value === file && $(o).attr("data-year") === year)
-      .first();
-    if (!opt.length) return; // not a GTFS-exportable route (geojson, Points -)
-    if (this.routeSelect.val() === file && this.current && this.current.year === year) {
-      return;
-    }
-    this.routeSelect.val(opt.val());
-    this._showSelected();
-  }
+  // --- Selected route ----------------------------------------------------------
 
-  // --- Data ----------------------------------------------------------------
-
-  _load() {
-    if (this.loaded) return Promise.resolve();
-    const routes = fetch("/data/catalog")
-      .then((r) => r.json())
-      .then((d) => {
-        this.routeSelect.empty();
-        (d.years || []).forEach((y) => {
-          // KML routes carry stops, so they appear in the feed — shipped ones
-          // plus user-created routes (the draw -> schedule -> export flow).
-          const shipped = ((d[y] && d[y].routes) || []).filter(
-            (f) => !/^points\s*-/i.test(f)
-          );
-          const user = (d[y] && d[y].user) || [];
-          const files = shipped.concat(user);
-          if (!files.length) return;
-          const names = (d[y] && d[y].names) || {};
-          const group = $("<optgroup>").attr("label", `${y} routes`);
-          files.forEach((f) => {
-            const stem = f.replace(/\.[^.]+$/, "");
-            $("<option>")
-              .val(f)
-              .attr("data-year", y)
-              .text(names[f] || stem)
-              .appendTo(group);
-          });
-          this.routeSelect.append(group);
-        });
-      });
-    const timings = fetch("/data/timing-images")
-      .then((r) => r.json())
-      .then((d) => {
-        this.timingSelect.empty();
-        this.timingSelect.append($("<option>").val("").text("— signboard —"));
-        (d.years || []).forEach((y) => {
-          const group = $("<optgroup>").attr("label", `${y} timings`);
-          (d.images[y] || []).forEach((im) => {
-            $("<option>")
-              .val(im.file)
-              .attr("data-year", y)
-              .attr("data-route", im.route)
-              .text(im.route + " — " + im.file.replace(/\.[^.]+$/, ""))
-              .appendTo(group);
-          });
-          this.timingSelect.append(group);
-        });
-      });
-    const config = this._loadFeedConfig();
-    return Promise.all([routes, timings, config])
-      .then(() => {
-        this.loaded = true;
-      })
-      .catch((err) => {
-        if (APP.MapUtils) APP.MapUtils.handleError(err, "Loading GTFS editor");
-        console.error("gtfs editor load failed", err);
-      });
-  }
-
-  // --- Show / hide -----------------------------------------------------------
-
-  toggle() {
-    if (this.panel.style.display === "none" || !this.panel.style.display) {
-      this.show();
-    } else {
-      this.hide();
-    }
-  }
-
-  show() {
-    this._load().then(() => {
-      this.panel.style.display = "flex";
-      if (!this.routeSelect.val() && this.routeSelect.find("option").length) {
-        this.routeSelect.prop("selectedIndex", 0);
-      }
-      this._showSelected();
-    });
-  }
-
-  hide() {
-    if (this.docked) return; // the docked column never closes
-    this._flushSaves();
-    this.panel.style.display = "none";
-  }
-
-  _flushSaves() {
-    if (this._saveTimer) {
-      clearTimeout(this._saveTimer);
-      this._saveTimer = null;
-      this._saveMeta();
-    }
-    if (this._feedTimer) {
-      clearTimeout(this._feedTimer);
-      this._feedTimer = null;
-      this._saveFeedConfig();
-    }
-  }
-
-  // --- Route selection -------------------------------------------------------
-
-  _showSelected() {
-    const opt = this.routeSelect.find("option:selected");
-    const year = opt.attr("data-year");
-    const file = opt.val();
-    if (!year || !file) {
-      this.current = null;
-      this.routeLabel.textContent = "—";
-      return;
-    }
+  /** Load a route into the pane (called by GtfsPage on selection). */
+  setRoute(year, file, label) {
     // Flush a pending save for the route we're leaving.
     if (this._saveTimer) {
       clearTimeout(this._saveTimer);
       this._saveTimer = null;
       this._saveMeta();
     }
-    this.current = { year, file };
-    this.routeLabel.textContent = `${opt.text()} (${year})`;
+    this.current = { year, file, label: label || file.replace(/\.kml$/, "") };
+    this.routeLabel.textContent = this.current.label;
     this.status.textContent = "Loading…";
+    this._setFormEnabled(false);
     const q = `?year=${encodeURIComponent(year)}&route=${encodeURIComponent(file)}`;
     fetch(`/data/gtfs-meta${q}`)
       .then((r) => r.json())
@@ -172,6 +50,7 @@ APP.GtfsEditorManager = class {
           return; // stale response, selection moved on
         }
         this._fillForm(d.meta || {});
+        this._setFormEnabled(true);
         this.status.textContent = "";
         this._matchTimingImage();
       })
@@ -180,6 +59,40 @@ APP.GtfsEditorManager = class {
         console.error("gtfs-meta load failed", err);
       });
   }
+
+  /** Update the displayed name (e.g. after a rename in the editor). */
+  setLabel(label) {
+    if (!this.current) return;
+    this.current.label = label;
+    this.routeLabel.textContent = label;
+  }
+
+  clearRoute() {
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer);
+      this._saveTimer = null;
+    }
+    this.current = null;
+    this.routeLabel.textContent = "—";
+    this.status.textContent = "";
+    this._fillForm({});
+    this._setFormEnabled(false);
+    this.timingSelect.val("");
+    this._showTiming();
+  }
+
+  _formInputs() {
+    return $(
+      "#gepHeadway, #gepStart, #gepEnd, #gepRun, #gepDepartures, " +
+        "#gepShort, #gepLong, #gepColor, .gep-day"
+    );
+  }
+
+  _setFormEnabled(on) {
+    this._formInputs().prop("disabled", !on);
+  }
+
+  // --- Form <-> meta -------------------------------------------------------------
 
   _fillForm(meta) {
     this._populating = true;
@@ -255,7 +168,7 @@ APP.GtfsEditorManager = class {
       });
   }
 
-  // --- Feed-level settings (agency + fare) ------------------------------------
+  // --- Feed-level settings (agency + fare modal) -----------------------------------
 
   _loadFeedConfig() {
     return fetch("/data/gtfs-config")
@@ -302,8 +215,6 @@ APP.GtfsEditorManager = class {
     if ($("#gepFarePrice").val() !== "") fare.price = parseFloat($("#gepFarePrice").val());
     if ($("#gepFareCurrency").val().trim()) fare.currency = $("#gepFareCurrency").val().trim();
     if (Object.keys(fare).length) config.fare = fare;
-    // The feed config applies to the export year — use the selected route's
-    // year (the default year when nothing is selected).
     const year = this.current ? this.current.year : undefined;
     fetch("/data/gtfs-config", {
       method: "POST",
@@ -320,7 +231,29 @@ APP.GtfsEditorManager = class {
       });
   }
 
-  // --- Timing signboard --------------------------------------------------------
+  // --- Timing signboard --------------------------------------------------------------
+
+  _loadTimings() {
+    return fetch("/data/timing-images")
+      .then((r) => r.json())
+      .then((d) => {
+        this.timingSelect.empty();
+        this.timingSelect.append($("<option>").val("").text("— signboard —"));
+        (d.years || []).forEach((y) => {
+          const group = $("<optgroup>").attr("label", `${y} timings`);
+          (d.images[y] || []).forEach((im) => {
+            $("<option>")
+              .val(im.file)
+              .attr("data-year", y)
+              .attr("data-route", im.route)
+              .text(im.route + " — " + im.file.replace(/\.[^.]+$/, ""))
+              .appendTo(group);
+          });
+          this.timingSelect.append(group);
+        });
+      })
+      .catch((err) => console.error("timing-images load failed", err));
+  }
 
   /** Auto-select the signboard whose route code matches the edited route
    * (saved short_name first, else trailing code in the filename stem). */
@@ -368,21 +301,27 @@ APP.GtfsEditorManager = class {
     this.timingImg.style.width = this.zoom * 100 + "%";
   }
 
-  // --- Download -----------------------------------------------------------------
+  // --- Download ------------------------------------------------------------------------
 
   _download() {
-    this._flushSaves();
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer);
+      this._saveTimer = null;
+      this._saveMeta();
+    }
+    if (this._feedTimer) {
+      clearTimeout(this._feedTimer);
+      this._feedTimer = null;
+      this._saveFeedConfig();
+    }
     const year = this.current ? this.current.year : "";
     window.open(`/data/gtfs.zip${year ? "?year=" + encodeURIComponent(year) : ""}`);
   }
 
-  // --- Events --------------------------------------------------------------------
+  // --- Events --------------------------------------------------------------------------
 
   _bind() {
-    $("#gtfsEditorToggle").on("click", () => this.toggle());
-    $("#gepClose").on("click", () => this.hide());
     $("#gepDownload").on("click", () => this._download());
-    this.routeSelect.on("change", () => this._showSelected());
     this.timingSelect.on("change", () => this._showTiming());
     $("#gepZoomIn").on("click", () => this._setZoom(this.zoom * 1.25));
     $("#gepZoomOut").on("click", () => this._setZoom(this.zoom / 1.25));
@@ -396,69 +335,5 @@ APP.GtfsEditorManager = class {
       "#gepAgencyName, #gepAgencyUrl, #gepAgencyPhone, #gepAgencyEmail, " +
         "#gepFarePrice, #gepFareCurrency"
     ).on("input change", () => this._queueFeedSave());
-    if (this.docked) {
-      // Showing a route on the map also loads it into the GTFS form.
-      $("#routes").on("click", "input", (e) => {
-        if (!e.target.checked) return;
-        const sep = e.target.value.indexOf("::"); // id is "<year>::<file>"
-        if (sep < 0) return;
-        this.selectRoute(e.target.value.slice(0, sep), e.target.value.slice(sep + 2));
-      });
-    } else {
-      this._enableDrag();
-      this._enableResize();
-    }
-  }
-
-  _enableDrag() {
-    const header = document.getElementById("gtfsHeader");
-    let sx, sy, sl, st, dragging = false;
-    const onMove = (e) => {
-      if (!dragging) return;
-      this.panel.style.left = sl + (e.clientX - sx) + "px";
-      this.panel.style.top = st + (e.clientY - sy) + "px";
-      this.panel.style.right = "auto";
-    };
-    const onUp = () => {
-      dragging = false;
-      document.removeEventListener("mousemove", onMove);
-      document.removeEventListener("mouseup", onUp);
-    };
-    header.addEventListener("mousedown", (e) => {
-      if (e.target.closest("button, select, input")) return;
-      const r = this.panel.getBoundingClientRect();
-      sx = e.clientX; sy = e.clientY; sl = r.left; st = r.top;
-      this.panel.style.left = r.left + "px";
-      this.panel.style.top = r.top + "px";
-      this.panel.style.right = "auto";
-      dragging = true;
-      document.addEventListener("mousemove", onMove);
-      document.addEventListener("mouseup", onUp);
-      e.preventDefault();
-    });
-  }
-
-  _enableResize() {
-    const handle = document.getElementById("gtfsResize");
-    let sx, sy, sw, sh, resizing = false;
-    const onMove = (e) => {
-      if (!resizing) return;
-      this.panel.style.width = Math.max(280, sw + (e.clientX - sx)) + "px";
-      this.panel.style.height = Math.max(260, sh + (e.clientY - sy)) + "px";
-    };
-    const onUp = () => {
-      resizing = false;
-      document.removeEventListener("mousemove", onMove);
-      document.removeEventListener("mouseup", onUp);
-    };
-    handle.addEventListener("mousedown", (e) => {
-      const r = this.panel.getBoundingClientRect();
-      sx = e.clientX; sy = e.clientY; sw = r.width; sh = r.height;
-      resizing = true;
-      document.addEventListener("mousemove", onMove);
-      document.addEventListener("mouseup", onUp);
-      e.preventDefault();
-      e.stopPropagation();
-    });
   }
 };

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -31,15 +31,30 @@ APP.GtfsEditorManager = class {
   // --- Selected route ----------------------------------------------------------
 
   /** Load a route into the pane (called by GtfsPage on selection). */
-  setRoute(year, file, label) {
+  setRoute(year, file, label, kind) {
     // Flush a pending save for the route we're leaving.
     if (this._saveTimer) {
       clearTimeout(this._saveTimer);
       this._saveTimer = null;
       this._saveMeta();
     }
+    this.year = year; // for downloads, even when no schedulable route is current
+    if (kind === "geojson") {
+      // Path tracings have no stops, so they can't be scheduled or exported
+      // directly. Editing copies them to a KML route where stops can be added.
+      this.current = null;
+      this.routeLabel.textContent = label || file.replace(/\.geojson$/, "");
+      this.status.classList.add("hint");
+      this.status.textContent = "path only — ✎ Edit copies it, then add stops";
+      this._fillForm({});
+      this._setFormEnabled(false);
+      this.timingSelect.val("");
+      this._showTiming();
+      return;
+    }
     this.current = { year, file, label: label || file.replace(/\.kml$/, "") };
     this.routeLabel.textContent = this.current.label;
+    this.status.classList.remove("hint");
     this.status.textContent = "Loading…";
     this._setFormEnabled(false);
     const q = `?year=${encodeURIComponent(year)}&route=${encodeURIComponent(file)}`;
@@ -314,7 +329,7 @@ APP.GtfsEditorManager = class {
       this._feedTimer = null;
       this._saveFeedConfig();
     }
-    const year = this.current ? this.current.year : "";
+    const year = this.year || (this.current ? this.current.year : "");
     window.open(`/data/gtfs.zip${year ? "?year=" + encodeURIComponent(year) : ""}`);
   }
 

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -9,9 +9,12 @@ window.APP = window.APP || {};
 APP.GtfsEditorManager = class {
   constructor() {
     this.zoom = 1;
-    this.current = null; // { year, file, label }
+    this.current = null; // { year, file, label, isUser }
+    this.page = null; // GtfsPage backref (map focus, layer reload, editor state)
+    this.geom = null; // { segments, stops, name } of the selected route
     this._saveTimer = null;
     this._feedTimer = null;
+    this._stopsTimer = null;
     this._populating = false; // suppress autosave while filling the form
   }
 
@@ -22,6 +25,7 @@ APP.GtfsEditorManager = class {
     this.routeLabel = document.getElementById("gepRouteLabel");
     this.status = document.getElementById("gepStatus");
     this.feedStatus = document.getElementById("gepFeedStatus");
+    this.stopsStatus = document.getElementById("gepStopsStatus");
     this._bind();
     this._setFormEnabled(false);
     this._loadTimings();
@@ -31,18 +35,20 @@ APP.GtfsEditorManager = class {
   // --- Selected route ----------------------------------------------------------
 
   /** Load a route into the pane (called by GtfsPage on selection). */
-  setRoute(year, file, label, kind) {
-    // Flush a pending save for the route we're leaving.
+  setRoute(year, file, label, kind, isUser) {
+    // Flush pending saves for the route we're leaving.
     if (this._saveTimer) {
       clearTimeout(this._saveTimer);
       this._saveTimer = null;
       this._saveMeta();
     }
+    this._flushStopsSave();
     this.year = year; // for downloads, even when no schedulable route is current
     if (kind === "geojson") {
       // Path tracings have no stops, so they can't be scheduled or exported
       // directly. Editing copies them to a KML route where stops can be added.
       this.current = null;
+      this.geom = null;
       this.routeLabel.textContent = label || file.replace(/\.geojson$/, "");
       this.status.classList.add("hint");
       this.status.textContent = "path only — ✎ Edit copies it, then add stops";
@@ -50,9 +56,15 @@ APP.GtfsEditorManager = class {
       this._setFormEnabled(false);
       this.timingSelect.val("");
       this._showTiming();
+      this._renderStops();
       return;
     }
-    this.current = { year, file, label: label || file.replace(/\.kml$/, "") };
+    this.current = {
+      year,
+      file,
+      label: label || file.replace(/\.kml$/, ""),
+      isUser: !!isUser,
+    };
     this.routeLabel.textContent = this.current.label;
     this.status.classList.remove("hint");
     this.status.textContent = "Loading…";
@@ -73,6 +85,13 @@ APP.GtfsEditorManager = class {
         this.status.textContent = "Load failed";
         console.error("gtfs-meta load failed", err);
       });
+    this._loadStops();
+  }
+
+  /** Re-fetch the stops after the map editor saved or exited (geometry may
+   * have changed under us). */
+  refreshStops() {
+    if (this.current) this._loadStops();
   }
 
   /** Update the displayed name (e.g. after a rename in the editor). */
@@ -87,13 +106,167 @@ APP.GtfsEditorManager = class {
       clearTimeout(this._saveTimer);
       this._saveTimer = null;
     }
+    if (this._stopsTimer) {
+      clearTimeout(this._stopsTimer);
+      this._stopsTimer = null;
+    }
     this.current = null;
+    this.geom = null;
     this.routeLabel.textContent = "—";
     this.status.textContent = "";
     this._fillForm({});
     this._setFormEnabled(false);
     this.timingSelect.val("");
     this._showTiming();
+    this._renderStops();
+  }
+
+  // --- Stops list ----------------------------------------------------------------
+
+  _loadStops() {
+    const ctx = this.current;
+    if (!ctx) return;
+    this.geom = null;
+    this._renderStops();
+    this.stopsStatus.textContent = "Loading…";
+    const q = `?year=${encodeURIComponent(ctx.year)}`;
+    fetch(`/data/route-geometry/${encodeURIComponent(ctx.file)}${q}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (!this.current || this.current.file !== ctx.file || this.current.year !== ctx.year) {
+          return; // stale
+        }
+        this.geom = {
+          segments: d.segments || [],
+          stops: d.stops || [],
+          name: d.name || ctx.label,
+        };
+        this.stopsStatus.textContent = "";
+        this._renderStops();
+      })
+      .catch((err) => {
+        this.stopsStatus.textContent = "Load failed";
+        console.error("route-geometry load failed", err);
+      });
+  }
+
+  /** Stops are saved as a new geometry version, which only user routes
+   * accept; the map editor being active also pauses list editing. */
+  _stopsEditable() {
+    return !!(
+      this.current &&
+      this.current.isUser &&
+      this.geom &&
+      !(this.page && this.page.editorManager.active)
+    );
+  }
+
+  _renderStops() {
+    const list = $("#gepStopsList").empty();
+    const hint = $("#gepStopsHint");
+    const count = $("#gepStopCount");
+    const stops = (this.geom && this.geom.stops) || [];
+    count.text(stops.length ? `· ${stops.length}` : "");
+    if (!this.geom) {
+      hint.hide();
+      return;
+    }
+    if (!stops.length) {
+      hint
+        .text(
+          this.current && this.current.isUser
+            ? "No stops yet — ✎ Edit the route and use + Stop to place them."
+            : "No stops on this route."
+        )
+        .show();
+      return;
+    }
+    let note = "";
+    if (this.page && this.page.editorManager.active) {
+      note = "Map editor open — stop edits happen there until you exit.";
+    } else if (this.current && !this.current.isUser) {
+      note = "Official route — ✎ Edit copies it to make stops editable.";
+    }
+    hint.text(note).toggle(!!note);
+    const editable = this._stopsEditable();
+    stops.forEach((s, i) => {
+      const row = $('<div class="gep-stop-row"></div>').attr("data-i", i);
+      row.append(
+        $('<button type="button" class="gep-stop-seq" title="Show on map"></button>').text(i + 1)
+      );
+      row.append(
+        $('<input type="text" class="gep-stop-name" placeholder="(unnamed)" />')
+          .val(s.name || "")
+          .prop("disabled", !editable)
+      );
+      row.append(
+        $('<input type="text" class="gep-stop-coord gep-stop-lat" title="Latitude" />')
+          .val(s.lat.toFixed(6))
+          .prop("disabled", !editable)
+      );
+      row.append(
+        $('<input type="text" class="gep-stop-coord gep-stop-lon" title="Longitude" />')
+          .val(s.lon.toFixed(6))
+          .prop("disabled", !editable)
+      );
+      if (editable) {
+        const tools = $('<span class="gep-stop-tools"></span>');
+        tools.append($('<a class="gep-stop-up" title="Move earlier">↑</a>'));
+        tools.append($('<a class="gep-stop-down" title="Move later">↓</a>'));
+        tools.append($('<a class="gep-stop-del" title="Remove stop">✕</a>'));
+        row.append(tools);
+      }
+      list.append(row);
+    });
+  }
+
+  _stopAt(el) {
+    const i = parseInt($(el).closest(".gep-stop-row").attr("data-i"), 10);
+    const stops = (this.geom && this.geom.stops) || [];
+    return i >= 0 && i < stops.length ? i : null;
+  }
+
+  _queueStopsSave() {
+    if (!this._stopsEditable()) return;
+    this.stopsStatus.textContent = "Saving…";
+    if (this._stopsTimer) clearTimeout(this._stopsTimer);
+    this._stopsTimer = setTimeout(() => {
+      this._stopsTimer = null;
+      this._saveStops();
+    }, 800);
+  }
+
+  _flushStopsSave() {
+    if (this._stopsTimer) {
+      clearTimeout(this._stopsTimer);
+      this._stopsTimer = null;
+      this._saveStops();
+    }
+  }
+
+  _saveStops() {
+    if (!this.current || !this.geom) return;
+    const ctx = this.current;
+    fetch(`/data/edit/${encodeURIComponent(ctx.file)}?year=${encodeURIComponent(ctx.year)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        segments: this.geom.segments,
+        stops: this.geom.stops,
+        name: this.geom.name,
+        label: "Stop edits (GTFS pane)",
+      }),
+    })
+      .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
+      .then(({ ok, d }) => {
+        if (!this.current || this.current.file !== ctx.file) return;
+        this.stopsStatus.textContent = ok ? `Saved v${d.version} ✓` : d.error || "Save failed";
+        if (ok && this.page) this.page.reloadRoute(ctx.year, ctx.file);
+      })
+      .catch((err) => {
+        this.stopsStatus.textContent = "Save failed";
+        console.error("stops save failed", err);
+      });
   }
 
   _formInputs() {
@@ -319,6 +492,7 @@ APP.GtfsEditorManager = class {
   // --- Download ------------------------------------------------------------------------
 
   _download() {
+    this._flushStopsSave();
     if (this._saveTimer) {
       clearTimeout(this._saveTimer);
       this._saveTimer = null;
@@ -350,5 +524,53 @@ APP.GtfsEditorManager = class {
       "#gepAgencyName, #gepAgencyUrl, #gepAgencyPhone, #gepAgencyEmail, " +
         "#gepFarePrice, #gepFareCurrency"
     ).on("input change", () => this._queueFeedSave());
+
+    // Stops list (rows are rebuilt per route, so delegate).
+    const stopsList = $("#gepStopsList");
+    stopsList.on("click", ".gep-stop-seq", (e) => {
+      const i = this._stopAt(e.currentTarget);
+      if (i != null && this.page) {
+        const s = this.geom.stops[i];
+        this.page.focusStop(s.lon, s.lat);
+      }
+    });
+    stopsList.on("input", ".gep-stop-name", (e) => {
+      const i = this._stopAt(e.currentTarget);
+      if (i == null) return;
+      this.geom.stops[i].name = e.currentTarget.value;
+      this._queueStopsSave();
+    });
+    stopsList.on("change", ".gep-stop-coord", (e) => {
+      const i = this._stopAt(e.currentTarget);
+      if (i == null) return;
+      const v = parseFloat(e.currentTarget.value);
+      const isLat = $(e.currentTarget).hasClass("gep-stop-lat");
+      const ok = isFinite(v) && (isLat ? Math.abs(v) <= 90 : Math.abs(v) <= 180);
+      const s = this.geom.stops[i];
+      if (!ok) {
+        e.currentTarget.value = (isLat ? s.lat : s.lon).toFixed(6); // revert
+        return;
+      }
+      if (isLat) s.lat = v;
+      else s.lon = v;
+      this._queueStopsSave();
+    });
+    stopsList.on("click", ".gep-stop-up, .gep-stop-down", (e) => {
+      const i = this._stopAt(e.currentTarget);
+      if (i == null) return;
+      const j = $(e.currentTarget).hasClass("gep-stop-up") ? i - 1 : i + 1;
+      const stops = this.geom.stops;
+      if (j < 0 || j >= stops.length) return;
+      [stops[i], stops[j]] = [stops[j], stops[i]];
+      this._renderStops();
+      this._queueStopsSave();
+    });
+    stopsList.on("click", ".gep-stop-del", (e) => {
+      const i = this._stopAt(e.currentTarget);
+      if (i == null) return;
+      this.geom.stops.splice(i, 1);
+      this._renderStops();
+      this._queueStopsSave();
+    });
   }
 };

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -387,7 +387,7 @@ APP.GtfsEditorManager = class {
     return $(
       "#gepSchedList input, #gepSchedList textarea, #gepSchedAdd, " +
         "#gepShort, #gepLong, #gepColor, #gepOperator, #gepDirection, " +
-        "#gepHeadsign, #gepReturnHeadsign"
+        "#gepHeadsign, #gepReturnHeadsign, #gepDesc, #gepHail"
     );
   }
 
@@ -443,7 +443,24 @@ APP.GtfsEditorManager = class {
       )
     );
     block.append(depRow);
+    // Return-direction departures: only meaningful for out & back routes
+    // (visibility synced to the Type selector).
+    const retRow = $('<div class="gep-row gep-return-deps" style="display:none"></div>');
+    retRow.append(
+      $('<label class="gep-block">Return departures — optional; derived from outbound + run time when empty.</label>').append(
+        $('<textarea class="gep-ret-departures" rows="2" spellcheck="false" placeholder="07:30, 08:00, …"></textarea>')
+          .val((sched.return_departures || []).map((t) => t.slice(0, 5)).join(", "))
+      )
+    );
+    block.append(retRow);
     return block;
+  }
+
+  /** Show return-direction fields only for out & back routes. */
+  _syncReturnUI() {
+    const outback = $("#gepDirection").val() === "outback";
+    $("#gepReturnWrap").toggle(outback);
+    $("#gepSchedList .gep-return-deps").toggle(outback);
   }
 
   /** One time-of-day frequency window: "every N min, HH:MM–HH:MM". */
@@ -494,7 +511,9 @@ APP.GtfsEditorManager = class {
     $("#gepDirection").val(meta.direction || "");
     $("#gepHeadsign").val(meta.headsign || "");
     $("#gepReturnHeadsign").val(meta.return_headsign || "");
-    $("#gepReturnWrap").toggle(meta.direction === "outback");
+    $("#gepDesc").val(meta.desc || "");
+    $("#gepHail").prop("checked", !!meta.hail);
+    this._syncReturnUI();
     // Remember the assignment so the dropdown survives option rebuilds
     // (operators may still be loading, or get edited in the modal).
     this._currentOperator = meta.agency_id || "";
@@ -525,6 +544,10 @@ APP.GtfsEditorManager = class {
       if (run > 0) sched.run_secs = run * 60;
       const deps = b.find(".gep-departures").val().split(/[\s,;]+/).filter(Boolean);
       if (deps.length) sched.departures = deps;
+      const rdeps = b.find(".gep-ret-departures").val().split(/[\s,;]+/).filter(Boolean);
+      if (rdeps.length && $("#gepDirection").val() === "outback") {
+        sched.return_departures = rdeps;
+      }
       const days = b.find(".gep-day").map((_, d) => (d.checked ? 1 : 0)).get();
       if (days.some((d) => !d)) sched.days = days; // only save non-default patterns
       if (Object.keys(sched).length) blocks.push(sched); // all-default blocks drop out
@@ -542,6 +565,8 @@ APP.GtfsEditorManager = class {
     if ($("#gepReturnHeadsign").val().trim()) {
       meta.return_headsign = $("#gepReturnHeadsign").val().trim();
     }
+    if ($("#gepDesc").val().trim()) meta.desc = $("#gepDesc").val().trim();
+    if ($("#gepHail").prop("checked")) meta.hail = true;
     return meta;
   }
 
@@ -558,15 +583,27 @@ APP.GtfsEditorManager = class {
   _saveMeta() {
     if (!this.current) return;
     const ctx = this.current;
+    const meta = this._readForm();
     fetch("/data/gtfs-meta", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ year: ctx.year, route: ctx.file, meta: this._readForm() }),
+      body: JSON.stringify({ year: ctx.year, route: ctx.file, meta }),
     })
       .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
       .then(({ ok, d }) => {
         if (this.current && this.current.file === ctx.file) {
           this.status.textContent = ok ? "Saved ✓" : d.error || "Save failed";
+        }
+        if (ok && this.page) {
+          const blocks = meta.schedules || [];
+          this.page.setRouteStatus(ctx.year, ctx.file, {
+            schedule: blocks.length > 0,
+            departures: blocks.some(
+              (b) => (b.departures || []).length || (b.return_departures || []).length
+            ),
+            operator: !!meta.agency_id,
+            headsign: !!meta.headsign,
+          });
         }
       })
       .catch((err) => {
@@ -903,11 +940,9 @@ APP.GtfsEditorManager = class {
     $("#gepFit").on("click", () => this._setZoom(1));
     $(
       "#gepShort, #gepLong, #gepColor, #gepOperator, #gepDirection, " +
-        "#gepHeadsign, #gepReturnHeadsign"
+        "#gepHeadsign, #gepReturnHeadsign, #gepDesc, #gepHail"
     ).on("input change", () => this._queueSave());
-    $("#gepDirection").on("change", () => {
-      $("#gepReturnWrap").toggle($("#gepDirection").val() === "outback");
-    });
+    $("#gepDirection").on("change", () => this._syncReturnUI());
     // Schedule blocks are rebuilt per route — delegate.
     $("#gepSchedList").on("input change", "input, textarea", () => this._queueSave());
     $("#gepSchedList").on("click", ".gep-sched-del", (e) => {
@@ -921,6 +956,7 @@ APP.GtfsEditorManager = class {
       if (!this.current) return;
       $("#gepSchedList").append(this._schedBlockEl({}));
       this._renumberSched();
+      this._syncReturnUI();
     });
     $("#gepSchedList").on("click", ".gep-band-add", (e) => {
       const block = $(e.currentTarget).closest(".gep-sched-block");

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -375,7 +375,8 @@ APP.GtfsEditorManager = class {
   _formInputs() {
     return $(
       "#gepHeadway, #gepStart, #gepEnd, #gepRun, #gepDepartures, " +
-        "#gepShort, #gepLong, #gepColor, #gepOperator, .gep-day"
+        "#gepShort, #gepLong, #gepColor, #gepOperator, #gepDirection, " +
+        "#gepHeadsign, #gepReturnHeadsign, .gep-day"
     );
   }
 
@@ -402,6 +403,10 @@ APP.GtfsEditorManager = class {
     $("#gepShort").val(meta.short_name || "");
     $("#gepLong").val(meta.long_name || "");
     $("#gepColor").val(meta.color ? "#" + meta.color : "");
+    $("#gepDirection").val(meta.direction || "");
+    $("#gepHeadsign").val(meta.headsign || "");
+    $("#gepReturnHeadsign").val(meta.return_headsign || "");
+    $("#gepReturnWrap").toggle(meta.direction === "outback");
     // Remember the assignment so the dropdown survives option rebuilds
     // (operators may still be loading, or get edited in the modal).
     this._currentOperator = meta.agency_id || "";
@@ -435,6 +440,11 @@ APP.GtfsEditorManager = class {
     const operator = $("#gepOperator").val();
     if (operator) meta.agency_id = operator;
     this._currentOperator = operator || "";
+    if ($("#gepDirection").val() === "outback") meta.direction = "outback";
+    if ($("#gepHeadsign").val().trim()) meta.headsign = $("#gepHeadsign").val().trim();
+    if ($("#gepReturnHeadsign").val().trim()) {
+      meta.return_headsign = $("#gepReturnHeadsign").val().trim();
+    }
     return meta;
   }
 
@@ -687,8 +697,12 @@ APP.GtfsEditorManager = class {
     $("#gepFit").on("click", () => this._setZoom(1));
     $(
       "#gepHeadway, #gepStart, #gepEnd, #gepRun, #gepDepartures, " +
-        "#gepShort, #gepLong, #gepColor, #gepOperator"
+        "#gepShort, #gepLong, #gepColor, #gepOperator, #gepDirection, " +
+        "#gepHeadsign, #gepReturnHeadsign"
     ).on("input change", () => this._queueSave());
+    $("#gepDirection").on("change", () => {
+      $("#gepReturnWrap").toggle($("#gepDirection").val() === "outback");
+    });
     $(".gep-day").on("change", () => this._queueSave());
     $("#gepFarePrice, #gepFareCurrency").on("input change", () => this._queueFeedSave());
     // Operator rows are dynamic — delegate, and refresh the route pane's

--- a/static/js/gtfs-page.js
+++ b/static/js/gtfs-page.js
@@ -42,6 +42,12 @@ APP.GtfsPage = class {
     this.gtfsEditor.init();
 
     $("#gtfsEditBtn").on("click", () => this.editSelected());
+    // Brand-new routes enter the editor without hideRouteForEdit firing
+    // (no file yet) — engage the live stops list after the editor opens.
+    // (EditorManager bound these first, so it runs before us.)
+    $("#newRouteBtn, #sipCreate").on("click", () =>
+      setTimeout(() => this.gtfsEditor.enterLive(), 0)
+    );
     const list = $("#gtfsRouteList");
     list.on("click", ".gtfs-route-row", (e) => {
       if ($(e.target).closest(".gtfs-route-del").length) return;
@@ -302,16 +308,16 @@ APP.GtfsPage = class {
     if (this.selected && this.selected.id === this._id(year, file) && this.layer) {
       this.layer.setVisible(false);
     }
-    // Editor is taking over: the stops list pauses (re-render shows the hint).
-    this.gtfsEditor._renderStops();
+    // Editor is taking over: the stops list goes live against its session.
+    this.gtfsEditor.enterLive();
   }
 
   showRouteAfterEdit(year, file) {
     if (this.selected && this.selected.id === this._id(year, file) && this.layer) {
       this.layer.setVisible(true);
     }
-    // Editor exited: re-fetch stops, which it may have changed.
-    this.gtfsEditor.refreshStops();
+    // Editor exited: back to the last saved geometry.
+    this.gtfsEditor.exitLive();
   }
 
   reloadRoute(year, file) {

--- a/static/js/gtfs-page.js
+++ b/static/js/gtfs-page.js
@@ -114,9 +114,45 @@ APP.GtfsPage = class {
           }
         });
         $("#newRouteBtn").toggle(years.indexOf(APP.USER_ROUTE_YEAR) >= 0);
+        this._loadStatuses(years);
         if (first) this.select(first.year, first.file);
       })
       .catch((e) => APP.MapUtils.handleError(e, "Loading catalog"));
+  }
+
+  /** Transcription-progress badges: 4 segments per route (schedule,
+   * departures, operator, headsign). */
+  _loadStatuses(years) {
+    years.forEach((y) => {
+      fetch(`/data/gtfs-meta-summary?year=${encodeURIComponent(y)}`)
+        .then((r) => r.json())
+        .then((d) => {
+          Object.entries(d.routes || {}).forEach(([file, st]) =>
+            this.setRouteStatus(y, file, st)
+          );
+        })
+        .catch(() => {});
+    });
+  }
+
+  setRouteStatus(year, file, st) {
+    const row = this._rowFor(this._id(year, file));
+    if (!row.length) return;
+    let meter = row.find(".gtfs-route-meter");
+    const flags = ["schedule", "departures", "operator", "headsign"];
+    if (!meter.length) {
+      meter = $('<span class="gtfs-route-meter"></span>');
+      flags.forEach(() => meter.append("<i></i>"));
+      row.find(".gtfs-route-label").after(meter);
+    }
+    meter.children().each((i, el) => {
+      $(el).toggleClass("on", !!(st && st[flags[i]]));
+    });
+    meter.attr(
+      "title",
+      "transcribed: " +
+        flags.map((f) => `${f} ${st && st[f] ? "✓" : "—"}`).join(" · ")
+    );
   }
 
   _row(id, year, file, display, isUser, kind) {

--- a/static/js/gtfs-page.js
+++ b/static/js/gtfs-page.js
@@ -1,0 +1,318 @@
+// Bootstrap + orchestrator for the /gtfs workbench page. One selected route
+// drives everything: the map display, the geometry editor target, and the GTFS
+// pane. This class also acts as the EditorManager's routeManager adapter
+// (hide/show/reload/rename/add/remove) over its single-route layer and list.
+window.APP = window.APP || {};
+
+APP.GtfsPage = class {
+  constructor() {
+    this.map = null;
+    this.baseLayer = null;
+    this.selected = null; // { id, year, file, isUser }
+    this.layer = null; // vector layer for the selected route
+    this.names = {}; // id -> display name
+    this.userIds = new Set();
+    this.init();
+  }
+
+  init() {
+    const view = new ol.View({
+      center: APP.MapUtils.toOL(APP.MAP_CONFIG.INITIAL_CENTER),
+      zoom: APP.MAP_CONFIG.INITIAL_ZOOM,
+      minZoom: APP.MAP_CONFIG.MIN_ZOOM,
+      maxZoom: APP.MAP_CONFIG.MAX_ZOOM,
+    });
+    this.baseLayer = APP.MAP_STYLES.osm.create();
+    this.map = new ol.Map({ target: "map", layers: [this.baseLayer], view });
+    $("#mapStyle").on("change", (e) => {
+      this.map.removeLayer(this.baseLayer);
+      this.baseLayer = APP.MAP_STYLES[e.target.value].create();
+      this.map.getLayers().insertAt(0, this.baseLayer);
+    });
+
+    this.infoManager = new APP.InfoManager(this.map);
+    this.editorManager = new APP.EditorManager(this.map, this, this.infoManager);
+    this.stopImageManager = new APP.StopImageManager(this.editorManager);
+    this.gtfsEditor = new APP.GtfsEditorManager();
+    this.infoManager.init();
+    this.editorManager.init();
+    this.stopImageManager.init();
+    this.gtfsEditor.init();
+
+    $("#gtfsEditBtn").on("click", () => this.editSelected());
+    const list = $("#gtfsRouteList");
+    list.on("click", ".gtfs-route-row", (e) => {
+      if ($(e.target).closest(".gtfs-route-del").length) return;
+      const el = $(e.currentTarget);
+      this.select(el.attr("data-year"), el.attr("data-file"));
+    });
+    list.on("click", ".gtfs-route-del", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const row = $(e.currentTarget).closest(".gtfs-route-row");
+      this.deleteUserRoute(row.attr("data-year"), row.attr("data-file"));
+    });
+
+    this.loadList();
+  }
+
+  _id(year, file) {
+    return `${year}::${file}`;
+  }
+
+  // --- Route list ------------------------------------------------------------
+
+  loadList() {
+    fetch("/data/catalog")
+      .then((r) => r.json())
+      .then((cat) => {
+        const out = $("#gtfsRouteList").empty();
+        this.userIds.clear();
+        this.names = {};
+        const years = cat.years || [];
+        let first = null;
+        const head = (t) =>
+          out.append($('<div class="gtfs-list-head"></div>').text(t));
+        const add = (year, file, isUser, names) => {
+          const id = this._id(year, file);
+          this.names[id] = names[file] || file.replace(/\.kml$/, "");
+          if (isUser) this.userIds.add(id);
+          out.append(this._row(id, year, file, this.names[id], isUser));
+          if (!first) first = { year, file };
+        };
+        // The user's own routes first, then shipped KML routes per year.
+        // GeoJSON paths and "Points - " overlays carry no stops, so they're
+        // not part of the GTFS picture and stay on the main map page.
+        years.forEach((y) => {
+          const d = cat[y] || {};
+          if (d.user && d.user.length) {
+            head("My routes");
+            d.user.forEach((f) => add(y, f, true, d.names || {}));
+          }
+        });
+        years.forEach((y) => {
+          const d = cat[y] || {};
+          const shipped = (d.routes || []).filter((f) => !/^points\s*-/i.test(f));
+          if (shipped.length) {
+            head(`${y} routes`);
+            shipped.forEach((f) => add(y, f, false, d.names || {}));
+          }
+        });
+        $("#newRouteBtn").toggle(years.indexOf(APP.USER_ROUTE_YEAR) >= 0);
+        if (first) this.select(first.year, first.file);
+      })
+      .catch((e) => APP.MapUtils.handleError(e, "Loading catalog"));
+  }
+
+  _row(id, year, file, display, isUser) {
+    // Signage-style chip with the route code, where the name carries one.
+    const code = (display.match(/(\d+[A-Za-z]?)\s*$/) || [])[1] || "•";
+    const row = $('<div class="gtfs-route-row"></div>').attr({
+      "data-id": id,
+      "data-year": year,
+      "data-file": file,
+    });
+    if (isUser) row.addClass("user");
+    row.append($('<span class="gtfs-route-chip"></span>').text(code));
+    row.append($('<span class="gtfs-route-label"></span>').text(display));
+    if (isUser) {
+      row.append($('<a class="gtfs-route-del" title="Delete route">✕</a>'));
+    }
+    return row;
+  }
+
+  _rowFor(id) {
+    return $("#gtfsRouteList .gtfs-route-row").filter(
+      (_, el) => $(el).attr("data-id") === id
+    );
+  }
+
+  // --- Selection ---------------------------------------------------------------
+
+  select(year, file) {
+    if (this.editorManager.active) {
+      if (
+        !confirm("Exit the route editor? Unsaved in-session changes will be lost.")
+      ) {
+        return;
+      }
+      this.editorManager.exit();
+    }
+    this._setSelected(year, file);
+  }
+
+  /** Selection state + map + GTFS pane, without touching the editor. */
+  _setSelected(year, file) {
+    const id = this._id(year, file);
+    this.selected = { id, year, file, isUser: this.userIds.has(id) };
+    $("#gtfsRouteList .gtfs-route-row").removeClass("selected");
+    const row = this._rowFor(id).addClass("selected");
+    if (row.length) row[0].scrollIntoView({ block: "nearest" });
+    this._loadLayer();
+    this.gtfsEditor.setRoute(year, file, this.names[id]);
+    $("#gtfsEditBtn").show();
+  }
+
+  _loadLayer() {
+    if (this.layer) {
+      this.map.removeLayer(this.layer);
+      this.layer = null;
+    }
+    const { year, file } = this.selected;
+    const source = new ol.source.Vector({
+      url: `/data/kml/${encodeURIComponent(file)}?year=${encodeURIComponent(year)}`,
+      format: new ol.format.KML({
+        extractStyles: false,
+        dataProjection: "EPSG:4326",
+        featureProjection: "EPSG:3857",
+      }),
+    });
+    const layer = new ol.layer.Vector({
+      source,
+      style: (feat) => this._routeStyle(feat),
+    });
+    source.on("change", () => {
+      if (source.getState() === "ready" && source.getFeatures().length) {
+        const ext = source.getExtent();
+        if (ext && isFinite(ext[0])) {
+          this.map.getView().fit(ext, {
+            padding: [60, 60, 60, 60],
+            maxZoom: 16,
+            duration: 400,
+          });
+        }
+      }
+    });
+    this.layer = layer;
+    this.map.addLayer(layer);
+  }
+
+  _routeStyle(feature) {
+    // Same language as the editor: blue line, yellow labelled stops.
+    if (feature.getGeometry() instanceof ol.geom.Point) {
+      return new ol.style.Style({
+        image: new ol.style.Circle({
+          radius: 6,
+          fill: new ol.style.Fill({ color: "#ffd166" }),
+          stroke: new ol.style.Stroke({ color: "#7a5b00", width: 2 }),
+        }),
+        text: new ol.style.Text({
+          text: feature.get("name") || "",
+          offsetY: -14,
+          font: "12px sans-serif",
+          fill: new ol.style.Fill({ color: "#111" }),
+          stroke: new ol.style.Stroke({ color: "#fff", width: 3 }),
+        }),
+      });
+    }
+    return new ol.style.Style({
+      stroke: new ol.style.Stroke({ color: "#0074d9", width: 3 }),
+    });
+  }
+
+  // --- Editing -------------------------------------------------------------------
+
+  editSelected() {
+    if (!this.selected || this.editorManager.active) return;
+    const { id, year, file, isUser } = this.selected;
+    if (isUser) {
+      this.editorManager.enter(file, "kml", year);
+      return;
+    }
+    // Shipped routes are read-only — edit a copy, reusing an existing one.
+    const copyName = `${this.names[id]} (copy)`;
+    const existing = Array.from(this.userIds).find(
+      (uid) => this.names[uid] === copyName
+    );
+    if (existing) {
+      const sep = existing.indexOf("::");
+      const yr = existing.slice(0, sep);
+      const f = existing.slice(sep + 2);
+      this._setSelected(yr, f);
+      this.editorManager.enter(f, "kml", yr);
+      return;
+    }
+    // Creates the copy, adds its row (via addUserRouteRow) and opens it.
+    this.editorManager.copyToUserRoute(file, "kml", year);
+  }
+
+  deleteUserRoute(year, file) {
+    if (!confirm("Delete this route? This removes it and all its versions.")) {
+      return;
+    }
+    fetch(`/data/edit/${encodeURIComponent(file)}?year=${encodeURIComponent(year)}`, {
+      method: "DELETE",
+    })
+      .then((r) => r.json())
+      .then(() => this.removeRouteRow(year, file))
+      .catch((e) => APP.MapUtils.handleError(e, "Deleting route"));
+  }
+
+  // --- EditorManager adapter (the routeManager interface it relies on) ------------
+
+  hideRouteForEdit(year, file) {
+    if (this.selected && this.selected.id === this._id(year, file) && this.layer) {
+      this.layer.setVisible(false);
+    }
+  }
+
+  showRouteAfterEdit(year, file) {
+    if (this.selected && this.selected.id === this._id(year, file) && this.layer) {
+      this.layer.setVisible(true);
+    }
+  }
+
+  reloadRoute(year, file) {
+    if (this.selected && this.selected.id === this._id(year, file)) {
+      this._loadLayer();
+    }
+  }
+
+  setRouteDisplayName(year, file, name) {
+    const id = this._id(year, file);
+    this.names[id] = name || file.replace(/\.kml$/, "");
+    this._rowFor(id).find(".gtfs-route-label").text(this.names[id]);
+    if (this.selected && this.selected.id === id) {
+      this.gtfsEditor.setLabel(this.names[id]);
+    }
+  }
+
+  addUserRouteRow(year, file, displayName) {
+    const id = this._id(year, file);
+    if (this.names[id] != null) {
+      this.setRouteDisplayName(year, file, displayName);
+      return;
+    }
+    this.names[id] = displayName || file.replace(/\.kml$/, "");
+    this.userIds.add(id);
+    let head = $("#gtfsRouteList .gtfs-list-head").filter(
+      (_, el) => $(el).text() === "My routes"
+    );
+    if (!head.length) {
+      head = $('<div class="gtfs-list-head">My routes</div>');
+      $("#gtfsRouteList").prepend(head);
+    }
+    head.after(this._row(id, year, file, this.names[id], true));
+    // Saving a new/copied route makes it the working route — silently, so the
+    // active editing session isn't disturbed.
+    this._setSelected(year, file);
+  }
+
+  removeRouteRow(year, file) {
+    const id = this._id(year, file);
+    this._rowFor(id).remove();
+    this.userIds.delete(id);
+    delete this.names[id];
+    if (this.selected && this.selected.id === id) {
+      if (this.layer) {
+        this.map.removeLayer(this.layer);
+        this.layer = null;
+      }
+      this.selected = null;
+      this.gtfsEditor.clearRoute();
+      $("#gtfsEditBtn").hide();
+    }
+  }
+};
+
+$(document).ready(() => new APP.GtfsPage());

--- a/static/js/gtfs-page.js
+++ b/static/js/gtfs-page.js
@@ -35,6 +35,7 @@ APP.GtfsPage = class {
     this.editorManager = new APP.EditorManager(this.map, this, this.infoManager);
     this.stopImageManager = new APP.StopImageManager(this.editorManager);
     this.gtfsEditor = new APP.GtfsEditorManager();
+    this.gtfsEditor.page = this; // map focus, layer reloads, editor state
     this.infoManager.init();
     this.editorManager.init();
     this.stopImageManager.init();
@@ -159,8 +160,29 @@ APP.GtfsPage = class {
     const row = this._rowFor(id).addClass("selected");
     if (row.length) row[0].scrollIntoView({ block: "nearest" });
     this._loadLayer();
-    this.gtfsEditor.setRoute(year, file, this.names[id], kind);
+    this.gtfsEditor.setRoute(year, file, this.names[id], kind, this.userIds.has(id));
     $("#gtfsEditBtn").show();
+  }
+
+  /** Pan/zoom to a stop and flash a marker over it (from the stops list). */
+  focusStop(lon, lat) {
+    const center = APP.MapUtils.toOL([lon, lat]);
+    const view = this.map.getView();
+    view.animate({ center, zoom: Math.max(view.getZoom() || 0, 16), duration: 350 });
+    const flash = new ol.layer.Vector({
+      zIndex: 5000,
+      source: new ol.source.Vector({
+        features: [new ol.Feature(new ol.geom.Point(center))],
+      }),
+      style: new ol.style.Style({
+        image: new ol.style.Circle({
+          radius: 13,
+          stroke: new ol.style.Stroke({ color: "#ff4136", width: 3 }),
+        }),
+      }),
+    });
+    this.map.addLayer(flash);
+    setTimeout(() => this.map.removeLayer(flash), 1500);
   }
 
   _loadLayer() {
@@ -280,12 +302,16 @@ APP.GtfsPage = class {
     if (this.selected && this.selected.id === this._id(year, file) && this.layer) {
       this.layer.setVisible(false);
     }
+    // Editor is taking over: the stops list pauses (re-render shows the hint).
+    this.gtfsEditor._renderStops();
   }
 
   showRouteAfterEdit(year, file) {
     if (this.selected && this.selected.id === this._id(year, file) && this.layer) {
       this.layer.setVisible(true);
     }
+    // Editor exited: re-fetch stops, which it may have changed.
+    this.gtfsEditor.refreshStops();
   }
 
   reloadRoute(year, file) {

--- a/static/js/gtfs-page.js
+++ b/static/js/gtfs-page.js
@@ -309,7 +309,9 @@ APP.GtfsPage = class {
       this.layer.setVisible(false);
     }
     // Editor is taking over: the stops list goes live against its session.
-    this.gtfsEditor.enterLive();
+    // Deferred, because EditorManager.enter() calls this BEFORE it creates
+    // its editing source — binding now would find nothing to mirror.
+    setTimeout(() => this.gtfsEditor.enterLive(), 0);
   }
 
   showRouteAfterEdit(year, file) {

--- a/static/js/gtfs-page.js
+++ b/static/js/gtfs-page.js
@@ -8,9 +8,10 @@ APP.GtfsPage = class {
   constructor() {
     this.map = null;
     this.baseLayer = null;
-    this.selected = null; // { id, year, file, isUser }
+    this.selected = null; // { id, year, file, kind, isUser }
     this.layer = null; // vector layer for the selected route
     this.names = {}; // id -> display name
+    this.kinds = {}; // id -> "kml" | "geojson"
     this.userIds = new Set();
     this.init();
   }
@@ -69,20 +70,23 @@ APP.GtfsPage = class {
         const out = $("#gtfsRouteList").empty();
         this.userIds.clear();
         this.names = {};
+        this.kinds = {};
         const years = cat.years || [];
         let first = null;
         const head = (t) =>
           out.append($('<div class="gtfs-list-head"></div>').text(t));
-        const add = (year, file, isUser, names) => {
+        const add = (year, file, isUser, names, kind) => {
           const id = this._id(year, file);
-          this.names[id] = names[file] || file.replace(/\.kml$/, "");
+          this.names[id] = names[file] || file.replace(/\.(kml|geojson)$/, "");
+          this.kinds[id] = kind || "kml";
           if (isUser) this.userIds.add(id);
-          out.append(this._row(id, year, file, this.names[id], isUser));
+          out.append(this._row(id, year, file, this.names[id], isUser, kind));
           if (!first) first = { year, file };
         };
-        // The user's own routes first, then shipped KML routes per year.
-        // GeoJSON paths and "Points - " overlays carry no stops, so they're
-        // not part of the GTFS picture and stay on the main map page.
+        // The user's own routes first, then shipped KML routes per year, then
+        // the GeoJSON path tracings (line-only alternates — editable via copy,
+        // which is also how they gain stops and join the feed). "Points - "
+        // marker overlays aren't routes and stay on the main map page.
         years.forEach((y) => {
           const d = cat[y] || {};
           if (d.user && d.user.length) {
@@ -97,6 +101,10 @@ APP.GtfsPage = class {
             head(`${y} routes`);
             shipped.forEach((f) => add(y, f, false, d.names || {}));
           }
+          if (d.geojson && d.geojson.length) {
+            head(`${y} paths`);
+            d.geojson.forEach((f) => add(y, f, false, d.names || {}, "geojson"));
+          }
         });
         $("#newRouteBtn").toggle(years.indexOf(APP.USER_ROUTE_YEAR) >= 0);
         if (first) this.select(first.year, first.file);
@@ -104,7 +112,7 @@ APP.GtfsPage = class {
       .catch((e) => APP.MapUtils.handleError(e, "Loading catalog"));
   }
 
-  _row(id, year, file, display, isUser) {
+  _row(id, year, file, display, isUser, kind) {
     // Signage-style chip with the route code, where the name carries one.
     const code = (display.match(/(\d+[A-Za-z]?)\s*$/) || [])[1] || "•";
     const row = $('<div class="gtfs-route-row"></div>').attr({
@@ -113,6 +121,7 @@ APP.GtfsPage = class {
       "data-file": file,
     });
     if (isUser) row.addClass("user");
+    if (kind === "geojson") row.addClass("path");
     row.append($('<span class="gtfs-route-chip"></span>').text(code));
     row.append($('<span class="gtfs-route-label"></span>').text(display));
     if (isUser) {
@@ -144,12 +153,13 @@ APP.GtfsPage = class {
   /** Selection state + map + GTFS pane, without touching the editor. */
   _setSelected(year, file) {
     const id = this._id(year, file);
-    this.selected = { id, year, file, isUser: this.userIds.has(id) };
+    const kind = this.kinds[id] || "kml";
+    this.selected = { id, year, file, kind, isUser: this.userIds.has(id) };
     $("#gtfsRouteList .gtfs-route-row").removeClass("selected");
     const row = this._rowFor(id).addClass("selected");
     if (row.length) row[0].scrollIntoView({ block: "nearest" });
     this._loadLayer();
-    this.gtfsEditor.setRoute(year, file, this.names[id]);
+    this.gtfsEditor.setRoute(year, file, this.names[id], kind);
     $("#gtfsEditBtn").show();
   }
 
@@ -158,18 +168,28 @@ APP.GtfsPage = class {
       this.map.removeLayer(this.layer);
       this.layer = null;
     }
-    const { year, file } = this.selected;
-    const source = new ol.source.Vector({
-      url: `/data/kml/${encodeURIComponent(file)}?year=${encodeURIComponent(year)}`,
-      format: new ol.format.KML({
-        extractStyles: false,
-        dataProjection: "EPSG:4326",
-        featureProjection: "EPSG:3857",
-      }),
-    });
+    const { year, file, kind } = this.selected;
+    const q = `?year=${encodeURIComponent(year)}`;
+    const source =
+      kind === "geojson"
+        ? new ol.source.Vector({
+            url: `/data/geojson/${encodeURIComponent(file)}${q}`,
+            format: new ol.format.GeoJSON({
+              dataProjection: "EPSG:4326",
+              featureProjection: "EPSG:3857",
+            }),
+          })
+        : new ol.source.Vector({
+            url: `/data/kml/${encodeURIComponent(file)}${q}`,
+            format: new ol.format.KML({
+              extractStyles: false,
+              dataProjection: "EPSG:4326",
+              featureProjection: "EPSG:3857",
+            }),
+          });
     const layer = new ol.layer.Vector({
       source,
-      style: (feat) => this._routeStyle(feat),
+      style: (feat) => this._routeStyle(feat, kind),
     });
     source.on("change", () => {
       if (source.getState() === "ready" && source.getFeatures().length) {
@@ -187,8 +207,9 @@ APP.GtfsPage = class {
     this.map.addLayer(layer);
   }
 
-  _routeStyle(feature) {
+  _routeStyle(feature, kind) {
     // Same language as the editor: blue line, yellow labelled stops.
+    // GeoJSON path tracings draw dashed, like on the main map.
     if (feature.getGeometry() instanceof ol.geom.Point) {
       return new ol.style.Style({
         image: new ol.style.Circle({
@@ -206,7 +227,11 @@ APP.GtfsPage = class {
       });
     }
     return new ol.style.Style({
-      stroke: new ol.style.Stroke({ color: "#0074d9", width: 3 }),
+      stroke: new ol.style.Stroke({
+        color: "#0074d9",
+        width: 3,
+        lineDash: kind === "geojson" ? [6, 6] : undefined,
+      }),
     });
   }
 
@@ -214,12 +239,13 @@ APP.GtfsPage = class {
 
   editSelected() {
     if (!this.selected || this.editorManager.active) return;
-    const { id, year, file, isUser } = this.selected;
+    const { id, year, file, kind, isUser } = this.selected;
     if (isUser) {
       this.editorManager.enter(file, "kml", year);
       return;
     }
     // Shipped routes are read-only — edit a copy, reusing an existing one.
+    // Copies are always KML, so a copied GeoJSON path can gain stops.
     const copyName = `${this.names[id]} (copy)`;
     const existing = Array.from(this.userIds).find(
       (uid) => this.names[uid] === copyName
@@ -233,7 +259,7 @@ APP.GtfsPage = class {
       return;
     }
     // Creates the copy, adds its row (via addUserRouteRow) and opens it.
-    this.editorManager.copyToUserRoute(file, "kml", year);
+    this.editorManager.copyToUserRoute(file, kind, year);
   }
 
   deleteUserRoute(year, file) {
@@ -284,6 +310,7 @@ APP.GtfsPage = class {
       return;
     }
     this.names[id] = displayName || file.replace(/\.kml$/, "");
+    this.kinds[id] = "kml"; // user routes (incl. copies of geojson paths)
     this.userIds.add(id);
     let head = $("#gtfsRouteList .gtfs-list-head").filter(
       (_, el) => $(el).text() === "My routes"
@@ -303,6 +330,7 @@ APP.GtfsPage = class {
     this._rowFor(id).remove();
     this.userIds.delete(id);
     delete this.names[id];
+    delete this.kinds[id];
     if (this.selected && this.selected.id === id) {
       if (this.layer) {
         this.map.removeLayer(this.layer);

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -1,0 +1,288 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Brunei Bus Routes — GTFS workbench" />
+    <title>GTFS — Brunei Bus Routes</title>
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="apple-touch-icon" href="/favicon.png" />
+    <link rel="shortcut icon" type="image/png" href="/favicon.png" />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/bootstrap.min.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/ol@v8.1.0/ol.css"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/ol@v8.1.0/dist/ol.js"></script>
+    <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+  </head>
+  <body class="gtfs-page">
+    <nav class="navbar navbar-fixed-top navbar-inverse">
+      <div class="container">
+        <div class="navbar-header">
+          <a class="navbar-brand" href="/">Brunei Bus Routes · GTFS</a>
+        </div>
+        <ul class="nav navbar-nav">
+          <li>
+            <select id="mapStyle" class="form-control">
+              <option value="osm">OpenStreetMap</option>
+              <option value="satellite">Satellite</option>
+              <option value="terrain">Terrain</option>
+              <option value="dark">Dark</option>
+            </select>
+          </li>
+        </ul>
+        <a
+          href="/"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          title="Back to the route map"
+        >
+          🗺 Map
+        </a>
+        <button
+          id="stopImageToggle"
+          type="button"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          title="View official stop-list signboards while editing a route"
+        >
+          🚏 Official stops
+        </button>
+      </div>
+    </nav>
+
+    <div class="gtfs-layout">
+      <!-- Route list: same machinery as the map page — toggle to show on the
+           map and load into the GTFS form; ✎/📋/✕ edit per route. -->
+      <div class="gtfs-routes-col">
+        <div class="sidebar-title">Routes</div>
+        <button
+          id="newRouteBtn"
+          type="button"
+          class="btn btn-success btn-sm btn-block"
+          style="display: none; margin-bottom: 6px"
+        >
+          + New route
+        </button>
+        <div class="btn-group btn-group-justified" id="routeBulkControls">
+          <a class="btn btn-default btn-sm" id="showAll">Show all</a>
+          <a class="btn btn-default btn-sm" id="clearAll">Clear all</a>
+        </div>
+        <div class="list-group" id="routes"></div>
+      </div>
+
+      <!-- Map with the full geometry editor (line/stops tools, undo, history). -->
+      <div class="gtfs-map-col">
+        <div id="map"></div>
+        <div id="info">
+          <a class="btn btn-danger dismiss">X</a>
+          <h3 class="name"></h3>
+          <h5 class="location"></h5>
+        </div>
+        <div id="editorToolbar" style="display: none">
+          <span class="ed-title">✎ <span id="edRouteName"></span></span>
+          <button type="button" class="btn btn-default btn-sm" id="edRenameRoute"
+            title="Rename this route">Rename route</button>
+          <div class="btn-group btn-group-sm" role="group">
+            <button type="button" class="btn btn-default ed-tool" id="edTool-drawline"
+              title="Draw the route line (click to add points, double-click to finish)">Line</button>
+            <button type="button" class="btn btn-default ed-tool" id="edTool-move"
+              title="Move/insert vertices &amp; stops (Alt+click a vertex to delete)">Move/Edit</button>
+            <button type="button" class="btn btn-default ed-tool" id="edTool-addstop"
+              title="Add a stop">+ Stop</button>
+            <button type="button" class="btn btn-default ed-tool" id="edTool-delete"
+              title="Delete: click a stop or line to remove it">Delete</button>
+            <button type="button" class="btn btn-default ed-tool" id="edTool-rename"
+              title="Rename: click a stop to rename it">Rename</button>
+          </div>
+          <button type="button" class="btn btn-default btn-sm" id="edReverse"
+            title="Reverse route direction (flips the 3D ride travel direction)">⇄ Reverse</button>
+          <div class="btn-group btn-group-sm" role="group">
+            <button type="button" class="btn btn-default" id="edUndo" title="Undo">↶</button>
+            <button type="button" class="btn btn-default" id="edRedo" title="Redo">↷</button>
+          </div>
+          <div class="btn-group btn-group-sm" role="group">
+            <button type="button" class="btn btn-primary" id="edSave">Save</button>
+            <button type="button" class="btn btn-default" id="edHistory">History</button>
+            <button type="button" class="btn btn-warning" id="edRevert">Revert</button>
+            <button type="button" class="btn btn-default" id="edExit">Exit</button>
+          </div>
+          <span id="edStatus" class="ed-status"></span>
+        </div>
+        <div id="loading">Loading... <a class="btn btn-danger">X</a></div>
+      </div>
+
+      <!-- GTFS editor, docked as a permanent column on this page. -->
+      <div id="gtfsPanel" class="docked">
+        <div id="gtfsHeader">
+          <span class="gep-title">🕐 GTFS</span>
+          <select id="gtfsRouteSelect" class="form-control input-sm" title="Pick a route to edit"></select>
+          <span class="gep-tools">
+            <button type="button" class="btn btn-primary btn-xs" id="gepDownload" title="Download GTFS for this year">⬇ Download</button>
+          </span>
+        </div>
+        <div id="gtfsBody">
+          <div class="gep-section">
+            <div class="gep-section-head">
+              <span>🗓 Schedule — <span id="gepRouteLabel">—</span></span>
+              <span id="gepStatus" class="gep-status"></span>
+            </div>
+            <div class="gep-row">
+              <label>Every <input type="number" id="gepHeadway" min="1" max="1440" placeholder="30" /> min,</label>
+              <label>first <input type="time" id="gepStart" /></label>
+              <label>last <input type="time" id="gepEnd" /></label>
+              <label>run <input type="number" id="gepRun" min="1" max="360" placeholder="auto" /> min</label>
+            </div>
+            <div class="gep-row">
+              <label class="gep-block">Exact departures — transcribe from the timing signboard
+                (comma or newline separated). When filled, real trips are
+                exported instead of the headway estimate.
+                <textarea id="gepDepartures" rows="2" placeholder="06:30, 07:00, 07:45, …"></textarea>
+              </label>
+            </div>
+            <div class="gep-row gep-days">
+              <label><input type="checkbox" class="gep-day" checked />Mo</label>
+              <label><input type="checkbox" class="gep-day" checked />Tu</label>
+              <label><input type="checkbox" class="gep-day" checked />We</label>
+              <label><input type="checkbox" class="gep-day" checked />Th</label>
+              <label><input type="checkbox" class="gep-day" checked />Fr</label>
+              <label><input type="checkbox" class="gep-day" checked />Sa</label>
+              <label><input type="checkbox" class="gep-day" checked />Su</label>
+            </div>
+            <div class="gep-row">
+              <label>No. <input type="text" id="gepShort" size="5" placeholder="e.g. 01A" /></label>
+              <label>Name <input type="text" id="gepLong" placeholder="route long name" /></label>
+              <label>Color <input type="text" id="gepColor" size="7" placeholder="#RRGGBB" /></label>
+            </div>
+          </div>
+          <div class="gep-section">
+            <div class="gep-section-head">
+              <span>🕐 Timing signboard</span>
+              <span class="gep-tools">
+                <select id="gtfsTimingSelect" class="form-control input-sm" title="Pick a timing signboard"></select>
+                <button type="button" class="btn btn-default btn-xs" id="gepZoomOut" title="Zoom out">−</button>
+                <button type="button" class="btn btn-default btn-xs" id="gepZoomIn" title="Zoom in">+</button>
+                <button type="button" class="btn btn-default btn-xs" id="gepFit" title="Fit to width">Fit</button>
+              </span>
+            </div>
+            <div id="gtfsTimingBody">
+              <img id="gtfsTimingImg" alt="Official timing signboard" style="display: none" />
+              <div id="gtfsTimingEmpty" class="gep-empty">No timing signboard for this route.</div>
+            </div>
+          </div>
+          <details class="gep-section" id="gepFeedSection">
+            <summary class="gep-section-head">
+              <span>🏢 Feed settings (agency &amp; fare)</span>
+              <span id="gepFeedStatus" class="gep-status"></span>
+            </summary>
+            <div class="gep-row">
+              <label>Agency <input type="text" id="gepAgencyName" placeholder="ADBS Sdn Bhd" /></label>
+              <label>URL <input type="text" id="gepAgencyUrl" placeholder="https://…" /></label>
+            </div>
+            <div class="gep-row">
+              <label>Phone <input type="text" id="gepAgencyPhone" placeholder="+673 …" /></label>
+              <label>Email <input type="text" id="gepAgencyEmail" placeholder="ops@…" /></label>
+            </div>
+            <div class="gep-row">
+              <label>Flat fare <input type="number" id="gepFarePrice" min="0" step="0.10" placeholder="1.00" /></label>
+              <label>Currency <input type="text" id="gepFareCurrency" size="4" placeholder="BND" /></label>
+            </div>
+          </details>
+        </div>
+      </div>
+    </div>
+
+    <!-- Official stop-list signboard reference (floating, draggable, resizable) -->
+    <div id="stopImagePanel" style="display: none">
+      <div id="stopImageHeader">
+        <span class="sip-title">🚏 Official stops</span>
+        <select id="stopImageSelect" class="form-control input-sm" title="Pick a route signboard"></select>
+        <span class="sip-tools">
+          <button type="button" class="btn btn-default btn-xs" id="sipZoomOut" title="Zoom out">−</button>
+          <button type="button" class="btn btn-default btn-xs" id="sipZoomIn" title="Zoom in">+</button>
+          <button type="button" class="btn btn-default btn-xs" id="sipFit" title="Fit to width">Fit</button>
+          <button type="button" class="btn btn-success btn-xs" id="sipCreate" title="Create a new route while viewing this signboard">+ Route</button>
+          <button type="button" class="btn btn-danger btn-xs" id="sipClose" title="Close">×</button>
+        </span>
+      </div>
+      <div id="stopImageBody">
+        <img id="stopImageImg" alt="Official stop list" style="display: none" />
+        <div id="stopImageEmpty" class="sip-empty">No signboard selected.</div>
+      </div>
+      <div id="stopImageNotes">
+        <div class="sip-notes-head">
+          <span>📝 Notes — <span id="stopImageNotesRoute">—</span></span>
+          <span id="stopImageNotesStatus" class="sip-notes-status"></span>
+        </div>
+        <textarea
+          id="stopImageNotesText"
+          rows="3"
+          placeholder="Notes for this route — discrepancies vs the poster, source comparisons, decisions…"
+          disabled
+        ></textarea>
+      </div>
+      <div id="stopImageResize" title="Drag to resize"></div>
+    </div>
+
+    <!-- Per-route ride engine chooser -->
+    <div class="modal fade" id="engineModal" tabindex="-1" role="dialog">
+      <div class="modal-dialog modal-sm" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">
+              &times;
+            </button>
+            <h4 class="modal-title">🚌 Ride <span id="engineRouteName"></span></h4>
+          </div>
+          <div class="modal-body">
+            <p>Choose a 3D engine:</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" id="engineThree" data-dismiss="modal">
+              Three.js
+            </button>
+            <button type="button" class="btn btn-info" id="engineMaplibre" data-dismiss="modal">
+              MapLibre
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Route edit version history -->
+    <div class="modal fade" id="editHistoryModal" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+            <h4 class="modal-title">
+              Version history — <span id="editHistoryFile"></span>
+            </h4>
+          </div>
+          <div class="modal-body">
+            <div id="editHistoryList"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/config.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/location-tracker.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/route-manager.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/info-manager.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/editor-manager.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/stop-image-manager.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/gtfs-editor-manager.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/launcher.js') }}"></script>
+  </body>
+</html>

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -234,6 +234,11 @@
             </div>
             <div id="gepAgencyList"></div>
             <button type="button" class="btn btn-default btn-xs" id="gepAgencyAdd">+ Add operator</button>
+            <div class="gep-feed-subhead">Holidays
+              <span class="gep-hint-inline">service exceptions (calendar_dates.txt)</span>
+            </div>
+            <div id="gepHolidayList"></div>
+            <button type="button" class="btn btn-default btn-xs" id="gepHolidayAdd">+ Add holiday</button>
             <div class="gep-feed-subhead">Fare</div>
             <div class="gep-row">
               <label>Flat fare

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -17,6 +17,12 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/ol@v8.1.0/ol.css"
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&family=IBM+Plex+Mono:wght@400;600&display=swap"
+    />
     <link
       rel="stylesheet"
       href="{{ url_for('static', filename='css/styles.css') }}"
@@ -26,9 +32,9 @@
   </head>
   <body class="gtfs-page">
     <nav class="navbar navbar-fixed-top navbar-inverse">
-      <div class="container">
+      <div class="container-fluid">
         <div class="navbar-header">
-          <a class="navbar-brand" href="/">Brunei Bus Routes · GTFS</a>
+          <a class="navbar-brand" href="/">Brunei Bus Routes <span class="gtfs-brand-tag">GTFS</span></a>
         </div>
         <ul class="nav navbar-nav">
           <li>
@@ -40,13 +46,23 @@
             </select>
           </li>
         </ul>
-        <a
-          href="/"
-          class="btn btn-default btn-sm navbar-btn navbar-right"
-          title="Back to the route map"
+        <button
+          type="button"
+          class="btn btn-sm navbar-btn navbar-right gtfs-download-btn"
+          id="gepDownload"
+          title="Download GTFS for the selected route's year"
         >
-          🗺 Map
-        </a>
+          ⬇ Download GTFS
+        </button>
+        <button
+          type="button"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          data-toggle="modal"
+          data-target="#feedSettingsModal"
+          title="Feed-wide settings: agency details and flat fare"
+        >
+          ⚙ Feed settings
+        </button>
         <button
           id="stopImageToggle"
           type="button"
@@ -55,32 +71,39 @@
         >
           🚏 Official stops
         </button>
+        <a
+          href="/"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          title="Back to the route map"
+        >
+          🗺 Map
+        </a>
       </div>
     </nav>
 
     <div class="gtfs-layout">
-      <!-- Route list: same machinery as the map page — toggle to show on the
-           map and load into the GTFS form; ✎/📋/✕ edit per route. -->
+      <!-- One route is selected at a time: it shows on the map, is the editing
+           target, and fills the GTFS pane. -->
       <div class="gtfs-routes-col">
-        <div class="sidebar-title">Routes</div>
         <button
           id="newRouteBtn"
           type="button"
           class="btn btn-success btn-sm btn-block"
-          style="display: none; margin-bottom: 6px"
+          style="display: none; margin-bottom: 8px"
         >
           + New route
         </button>
-        <div class="btn-group btn-group-justified" id="routeBulkControls">
-          <a class="btn btn-default btn-sm" id="showAll">Show all</a>
-          <a class="btn btn-default btn-sm" id="clearAll">Clear all</a>
-        </div>
-        <div class="list-group" id="routes"></div>
+        <div id="gtfsRouteList"></div>
       </div>
 
-      <!-- Map with the full geometry editor (line/stops tools, undo, history). -->
+      <!-- Map: shows the selected route; ✎ enters the full geometry editor
+           (line/stops tools, undo, history). Shipped routes edit a copy. -->
       <div class="gtfs-map-col">
         <div id="map"></div>
+        <button id="gtfsEditBtn" type="button" style="display: none"
+          title="Edit this route's line and stops (official routes are edited as a copy)">
+          ✎ Edit route
+        </button>
         <div id="info">
           <a class="btn btn-danger dismiss">X</a>
           <h3 class="name"></h3>
@@ -103,7 +126,7 @@
               title="Rename: click a stop to rename it">Rename</button>
           </div>
           <button type="button" class="btn btn-default btn-sm" id="edReverse"
-            title="Reverse route direction (flips the 3D ride travel direction)">⇄ Reverse</button>
+            title="Reverse route direction">⇄ Reverse</button>
           <div class="btn-group btn-group-sm" role="group">
             <button type="button" class="btn btn-default" id="edUndo" title="Undo">↶</button>
             <button type="button" class="btn btn-default" id="edRedo" title="Redo">↷</button>
@@ -116,22 +139,17 @@
           </div>
           <span id="edStatus" class="ed-status"></span>
         </div>
-        <div id="loading">Loading... <a class="btn btn-danger">X</a></div>
       </div>
 
-      <!-- GTFS editor, docked as a permanent column on this page. -->
-      <div id="gtfsPanel" class="docked">
+      <!-- GTFS pane for the selected route. -->
+      <div id="gtfsPanel">
         <div id="gtfsHeader">
-          <span class="gep-title">🕐 GTFS</span>
-          <select id="gtfsRouteSelect" class="form-control input-sm" title="Pick a route to edit"></select>
-          <span class="gep-tools">
-            <button type="button" class="btn btn-primary btn-xs" id="gepDownload" title="Download GTFS for this year">⬇ Download</button>
-          </span>
+          <span class="gep-title">🕐 <span id="gepRouteLabel">—</span></span>
         </div>
         <div id="gtfsBody">
           <div class="gep-section">
             <div class="gep-section-head">
-              <span>🗓 Schedule — <span id="gepRouteLabel">—</span></span>
+              <span>Schedule</span>
               <span id="gepStatus" class="gep-status"></span>
             </div>
             <div class="gep-row">
@@ -139,13 +157,6 @@
               <label>first <input type="time" id="gepStart" /></label>
               <label>last <input type="time" id="gepEnd" /></label>
               <label>run <input type="number" id="gepRun" min="1" max="360" placeholder="auto" /> min</label>
-            </div>
-            <div class="gep-row">
-              <label class="gep-block">Exact departures — transcribe from the timing signboard
-                (comma or newline separated). When filled, real trips are
-                exported instead of the headway estimate.
-                <textarea id="gepDepartures" rows="2" placeholder="06:30, 07:00, 07:45, …"></textarea>
-              </label>
             </div>
             <div class="gep-row gep-days">
               <label><input type="checkbox" class="gep-day" checked />Mo</label>
@@ -157,14 +168,21 @@
               <label><input type="checkbox" class="gep-day" checked />Su</label>
             </div>
             <div class="gep-row">
+              <label class="gep-block">Exact departures — when filled, real trips are exported
+                instead of the headway estimate.
+                <textarea id="gepDepartures" rows="3" spellcheck="false"
+                  placeholder="06:30, 07:00, 07:45, …"></textarea>
+              </label>
+            </div>
+            <div class="gep-row">
               <label>No. <input type="text" id="gepShort" size="5" placeholder="e.g. 01A" /></label>
               <label>Name <input type="text" id="gepLong" placeholder="route long name" /></label>
               <label>Color <input type="text" id="gepColor" size="7" placeholder="#RRGGBB" /></label>
             </div>
           </div>
-          <div class="gep-section">
+          <div class="gep-section gep-section-grow">
             <div class="gep-section-head">
-              <span>🕐 Timing signboard</span>
+              <span>Timing signboard</span>
               <span class="gep-tools">
                 <select id="gtfsTimingSelect" class="form-control input-sm" title="Pick a timing signboard"></select>
                 <button type="button" class="btn btn-default btn-xs" id="gepZoomOut" title="Zoom out">−</button>
@@ -177,24 +195,43 @@
               <div id="gtfsTimingEmpty" class="gep-empty">No timing signboard for this route.</div>
             </div>
           </div>
-          <details class="gep-section" id="gepFeedSection">
-            <summary class="gep-section-head">
-              <span>🏢 Feed settings (agency &amp; fare)</span>
-              <span id="gepFeedStatus" class="gep-status"></span>
-            </summary>
+        </div>
+      </div>
+    </div>
+
+    <!-- Feed-wide settings: agency + flat fare (applies to the whole export). -->
+    <div class="modal fade" id="feedSettingsModal" tabindex="-1" role="dialog">
+      <div class="modal-dialog modal-sm" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+            <h4 class="modal-title">⚙ Feed settings
+              <small id="gepFeedStatus" class="gep-status"></small>
+            </h4>
+          </div>
+          <div class="modal-body gep-feed-form">
             <div class="gep-row">
-              <label>Agency <input type="text" id="gepAgencyName" placeholder="ADBS Sdn Bhd" /></label>
-              <label>URL <input type="text" id="gepAgencyUrl" placeholder="https://…" /></label>
+              <label class="gep-block">Agency name
+                <input type="text" id="gepAgencyName" placeholder="ADBS Sdn Bhd" /></label>
             </div>
             <div class="gep-row">
-              <label>Phone <input type="text" id="gepAgencyPhone" placeholder="+673 …" /></label>
-              <label>Email <input type="text" id="gepAgencyEmail" placeholder="ops@…" /></label>
+              <label class="gep-block">Agency URL
+                <input type="text" id="gepAgencyUrl" placeholder="https://…" /></label>
             </div>
             <div class="gep-row">
-              <label>Flat fare <input type="number" id="gepFarePrice" min="0" step="0.10" placeholder="1.00" /></label>
-              <label>Currency <input type="text" id="gepFareCurrency" size="4" placeholder="BND" /></label>
+              <label class="gep-block">Phone
+                <input type="text" id="gepAgencyPhone" placeholder="+673 …" /></label>
+              <label class="gep-block">Email
+                <input type="text" id="gepAgencyEmail" placeholder="ops@…" /></label>
             </div>
-          </details>
+            <div class="gep-row">
+              <label class="gep-block">Flat fare
+                <input type="number" id="gepFarePrice" min="0" step="0.10" placeholder="1.00" /></label>
+              <label class="gep-block">Currency
+                <input type="text" id="gepFareCurrency" size="4" placeholder="BND" /></label>
+            </div>
+            <p class="gep-hint">Saved automatically; applied to every download.</p>
+          </div>
         </div>
       </div>
     </div>
@@ -231,31 +268,6 @@
       <div id="stopImageResize" title="Drag to resize"></div>
     </div>
 
-    <!-- Per-route ride engine chooser -->
-    <div class="modal fade" id="engineModal" tabindex="-1" role="dialog">
-      <div class="modal-dialog modal-sm" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <button type="button" class="close" data-dismiss="modal">
-              &times;
-            </button>
-            <h4 class="modal-title">🚌 Ride <span id="engineRouteName"></span></h4>
-          </div>
-          <div class="modal-body">
-            <p>Choose a 3D engine:</p>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-primary" id="engineThree" data-dismiss="modal">
-              Three.js
-            </button>
-            <button type="button" class="btn btn-info" id="engineMaplibre" data-dismiss="modal">
-              MapLibre
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <!-- Route edit version history -->
     <div class="modal fade" id="editHistoryModal" tabindex="-1" role="dialog">
       <div class="modal-dialog" role="document">
@@ -276,13 +288,10 @@
     <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/config.js') }}"></script>
     <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/location-tracker.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/route-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/info-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/editor-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/stop-image-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/gtfs-editor-manager.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/ride/launcher.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/gtfs-page.js') }}"></script>
   </body>
 </html>

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -86,6 +86,15 @@
         >
           🗺 Map
         </a>
+        <a
+          href="/gtfs/guide"
+          target="_blank"
+          rel="noopener"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          title="Data entry guide — what goes where (opens in a new tab)"
+        >
+          ？ Guide
+        </a>
       </div>
     </nav>
 

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -183,6 +183,11 @@
               </label>
               <label>Headsign <input type="text" id="gepHeadsign" placeholder="e.g. PEKAN MUARA" /></label>
               <label id="gepReturnWrap" style="display: none">Return <input type="text" id="gepReturnHeadsign" placeholder="e.g. BSB" /></label>
+              <label title="Buses stop on demand anywhere along the route (continuous pickup/drop-off)"><input type="checkbox" id="gepHail" /> hail &amp; ride</label>
+            </div>
+            <div class="gep-row">
+              <label class="gep-block">Description
+                <input type="text" id="gepDesc" placeholder="e.g. BSB → Mall Gadong → Batu Bersurat: Kiulap — Jame'Asr — …" /></label>
             </div>
           </div>
           <div class="gep-section" id="gepStopsSection">

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -179,6 +179,9 @@
               <label>Name <input type="text" id="gepLong" placeholder="route long name" /></label>
               <label>Color <input type="text" id="gepColor" size="7" placeholder="#RRGGBB" /></label>
             </div>
+            <div class="gep-row">
+              <label>Operator <select id="gepOperator" title="Which company runs this route (define operators in ⚙ Feed settings)"></select></label>
+            </div>
           </div>
           <div class="gep-section" id="gepStopsSection">
             <div class="gep-section-head">
@@ -207,9 +210,9 @@
       </div>
     </div>
 
-    <!-- Feed-wide settings: agency + flat fare (applies to the whole export). -->
+    <!-- Feed-wide settings: operators + flat fare (applies to the whole export). -->
     <div class="modal fade" id="feedSettingsModal" tabindex="-1" role="dialog">
-      <div class="modal-dialog modal-sm" role="document">
+      <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal">&times;</button>
@@ -218,24 +221,22 @@
             </h4>
           </div>
           <div class="modal-body gep-feed-form">
-            <div class="gep-row">
-              <label class="gep-block">Agency name
-                <input type="text" id="gepAgencyName" placeholder="ADBS Sdn Bhd" /></label>
+            <div class="gep-feed-subhead">Operators
+              <span class="gep-hint-inline">first = default; assign per route in the route pane</span>
             </div>
-            <div class="gep-row">
-              <label class="gep-block">Agency URL
-                <input type="text" id="gepAgencyUrl" placeholder="https://…" /></label>
+            <div class="gep-agency-head">
+              <span class="gep-agency-col-name">Name</span>
+              <span class="gep-agency-col-url">URL</span>
+              <span class="gep-agency-col-phone">Phone</span>
+              <span class="gep-agency-col-x"></span>
             </div>
+            <div id="gepAgencyList"></div>
+            <button type="button" class="btn btn-default btn-xs" id="gepAgencyAdd">+ Add operator</button>
+            <div class="gep-feed-subhead">Fare</div>
             <div class="gep-row">
-              <label class="gep-block">Phone
-                <input type="text" id="gepAgencyPhone" placeholder="+673 …" /></label>
-              <label class="gep-block">Email
-                <input type="text" id="gepAgencyEmail" placeholder="ops@…" /></label>
-            </div>
-            <div class="gep-row">
-              <label class="gep-block">Flat fare
+              <label>Flat fare
                 <input type="number" id="gepFarePrice" min="0" step="0.10" placeholder="1.00" /></label>
-              <label class="gep-block">Currency
+              <label>Currency
                 <input type="text" id="gepFareCurrency" size="4" placeholder="BND" /></label>
             </div>
             <p class="gep-hint">Saved automatically; applied to every download.</p>

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -180,6 +180,14 @@
               <label>Color <input type="text" id="gepColor" size="7" placeholder="#RRGGBB" /></label>
             </div>
           </div>
+          <div class="gep-section" id="gepStopsSection">
+            <div class="gep-section-head">
+              <span>Stops <span id="gepStopCount" class="gep-count"></span></span>
+              <span id="gepStopsStatus" class="gep-status"></span>
+            </div>
+            <div id="gepStopsHint" class="gep-empty" style="display: none"></div>
+            <div id="gepStopsList"></div>
+          </div>
           <div class="gep-section gep-section-grow">
             <div class="gep-section-head">
               <span>Timing signboard</span>

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -152,28 +152,12 @@
               <span>Schedule</span>
               <span id="gepStatus" class="gep-status"></span>
             </div>
-            <div class="gep-row">
-              <label>Every <input type="number" id="gepHeadway" min="1" max="1440" placeholder="30" /> min,</label>
-              <label>first <input type="time" id="gepStart" /></label>
-              <label>last <input type="time" id="gepEnd" /></label>
-              <label>run <input type="number" id="gepRun" min="1" max="360" placeholder="auto" /> min</label>
-            </div>
-            <div class="gep-row gep-days">
-              <label><input type="checkbox" class="gep-day" checked />Mo</label>
-              <label><input type="checkbox" class="gep-day" checked />Tu</label>
-              <label><input type="checkbox" class="gep-day" checked />We</label>
-              <label><input type="checkbox" class="gep-day" checked />Th</label>
-              <label><input type="checkbox" class="gep-day" checked />Fr</label>
-              <label><input type="checkbox" class="gep-day" checked />Sa</label>
-              <label><input type="checkbox" class="gep-day" checked />Su</label>
-            </div>
-            <div class="gep-row">
-              <label class="gep-block">Exact departures — when filled, real trips are exported
-                instead of the headway estimate.
-                <textarea id="gepDepartures" rows="3" spellcheck="false"
-                  placeholder="06:30, 07:00, 07:45, …"></textarea>
-              </label>
-            </div>
+            <!-- Day-type schedule blocks (weekday/weekend…), built by JS -->
+            <div id="gepSchedList"></div>
+            <button type="button" class="btn btn-default btn-xs" id="gepSchedAdd"
+              title="Add a day-type schedule block — e.g. a different weekend timetable">
+              + Add day-type schedule
+            </button>
             <div class="gep-row">
               <label>No. <input type="text" id="gepShort" size="5" placeholder="e.g. 01A" /></label>
               <label>Name <input type="text" id="gepLong" placeholder="route long name" /></label>

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -57,6 +57,14 @@
         <button
           type="button"
           class="btn btn-default btn-sm navbar-btn navbar-right"
+          id="gepValidate"
+          title="Check the feed for structural problems before publishing"
+        >
+          ✔ Validate
+        </button>
+        <button
+          type="button"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
           data-toggle="modal"
           data-target="#feedSettingsModal"
           title="Feed-wide settings: agency details and flat fare"
@@ -269,6 +277,26 @@
         ></textarea>
       </div>
       <div id="stopImageResize" title="Drag to resize"></div>
+    </div>
+
+    <!-- Feed validation results -->
+    <div class="modal fade" id="validateModal" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+            <h4 class="modal-title">✔ Feed validation — <span id="validateYear"></span></h4>
+          </div>
+          <div class="modal-body">
+            <div id="validateSummary" class="gep-validate-summary"></div>
+            <div id="validateList"></div>
+            <p class="gep-hint">Structural checks built in. For publish-grade
+              conformance, also run
+              <a href="https://gtfs-validator.mobilitydata.org/" target="_blank" rel="noopener">MobilityData's canonical validator</a>
+              on the downloaded zip.</p>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Route edit version history -->

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -182,6 +182,16 @@
             <div class="gep-row">
               <label>Operator <select id="gepOperator" title="Which company runs this route (define operators in ⚙ Feed settings)"></select></label>
             </div>
+            <div class="gep-row">
+              <label>Type
+                <select id="gepDirection" title="Out &amp; back exports a return direction too: reversed stops &amp; shape, departures offset by the run time">
+                  <option value="">loop / one-way</option>
+                  <option value="outback">out &amp; back</option>
+                </select>
+              </label>
+              <label>Headsign <input type="text" id="gepHeadsign" placeholder="e.g. PEKAN MUARA" /></label>
+              <label id="gepReturnWrap" style="display: none">Return <input type="text" id="gepReturnHeadsign" placeholder="e.g. BSB" /></label>
+            </div>
           </div>
           <div class="gep-section" id="gepStopsSection">
             <div class="gep-section-head">

--- a/templates/gtfs_guide.html
+++ b/templates/gtfs_guide.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -36,7 +36,7 @@
         <p>The workbench has three columns:</p>
         <table class="guide-table">
           <tr>
-            <th>Left — route list</th>
+            <th scope="row">Left — route list</th>
             <td>Every route, with a <strong>4-segment progress meter</strong>
               next to its name: <em>schedule · departures · operator ·
               headsign</em>. A segment turns green when that data is entered.
@@ -44,14 +44,14 @@
               work on it.</td>
           </tr>
           <tr>
-            <th>Middle — map</th>
+            <th scope="row">Middle — map</th>
             <td>Shows the selected route's line (blue) and stops (yellow).
               <strong>✎ Edit route</strong> opens the drawing tools. Official
               routes are read-only — editing one automatically creates a copy
               under "My routes", which is the one you edit from then on.</td>
           </tr>
           <tr>
-            <th>Right — route form</th>
+            <th scope="row">Right — route form</th>
             <td>Everything about the selected route: schedule, stops list,
               names, operator, and the <strong>timing signboard photo</strong>
               you transcribe from. Every field saves automatically a moment
@@ -66,22 +66,22 @@
 
         <h3>Step 1 — Identify the route</h3>
         <table class="guide-table">
-          <tr><th>No.</th>
+          <tr><th scope="row">No.</th>
             <td>The public route number from the signboard, e.g.
               <code>01A</code>, <code>20</code>, <code>38</code>.</td></tr>
-          <tr><th>Name</th>
+          <tr><th scope="row">Name</th>
             <td>A human-readable route name, e.g.
               <code>BSB – Pekan Muara via Airport</code>.</td></tr>
-          <tr><th>Description</th>
+          <tr><th scope="row">Description</th>
             <td>The fuller routing summary if known, e.g.
               <code>BSB → Mall Gadong → Batu Bersurat: Kiulap — Jame'Asr —
               …</code>. The reference list in
               <code>docs/2016/reference/routes.txt</code> has these for most
               routes — copy them in.</td></tr>
-          <tr><th>Color</th>
+          <tr><th scope="row">Color</th>
             <td>Optional hex color like <code>#E91E63</code> if the route has
               an official color. Skip if unknown.</td></tr>
-          <tr><th>Operator</th>
+          <tr><th scope="row">Operator</th>
             <td>The company that runs this route. Pick from the dropdown —
               if the company isn't listed yet, add it first under
               <strong>⚙ Feed settings</strong> (see section 4). Leave on
@@ -90,19 +90,19 @@
 
         <h3>Step 2 — Type &amp; headsigns</h3>
         <table class="guide-table">
-          <tr><th>Type</th>
+          <tr><th scope="row">Type</th>
             <td><strong>loop / one-way</strong>: the bus goes round a circuit
               back to the start (e.g. BSB Circular).<br />
               <strong>out &amp; back</strong>: the bus drives to a far terminal
               and returns the same way (e.g. BSB → Pekan Muara → BSB). Choose
               this and the export automatically produces both directions.</td></tr>
-          <tr><th>Headsign</th>
+          <tr><th scope="row">Headsign</th>
             <td>What the front of the bus displays going out, e.g.
               <code>PEKAN MUARA</code>.</td></tr>
-          <tr><th>Return</th>
+          <tr><th scope="row">Return</th>
             <td>(out &amp; back only) The sign coming back, usually
               <code>BSB</code>.</td></tr>
-          <tr><th>hail &amp; ride</th>
+          <tr><th scope="row">hail &amp; ride</th>
             <td>Tick if the route stops on demand anywhere along the road, not
               only at marked stops — common in Brunei.</td></tr>
         </table>
@@ -111,28 +111,28 @@
         <p>The signboard photo appears below the form — zoom with
           <strong>− / + / Fit</strong>. Transcribe what it says:</p>
         <table class="guide-table">
-          <tr><th>Days</th>
+          <tr><th scope="row">Days</th>
             <td>Tick the days this timetable applies to. If weekends differ,
               <strong>+ Add day-type schedule</strong> and give the weekend its
               own block — e.g. block 1 Mo–Fr, block 2 Sa–Su.</td></tr>
-          <tr><th>Every … min, from … to …</th>
+          <tr><th scope="row">Every … min, from … to …</th>
             <td>Use when the signboard gives an interval ("every 30 minutes,
               6:00am–8:00pm"). If the interval changes during the day (peak /
               off-peak), <strong>+ time band</strong> for each window:<br />
               <code>Every 10 min, 06:00–08:30</code> ·
               <code>Every 30 min, 08:30–16:00</code> ·
               <code>Every 15 min, 16:00–19:00</code></td></tr>
-          <tr><th>Exact departures</th>
+          <tr><th scope="row">Exact departures</th>
             <td><strong>Preferred whenever the signboard lists actual
               times.</strong> Type them into the dark board, separated by
               commas or new lines: <code>06:30, 07:00, 07:45, 09:15</code>.
               When filled, this beats the interval — the export contains one
               real trip per departure.</td></tr>
-          <tr><th>Return departures</th>
+          <tr><th scope="row">Return departures</th>
             <td>(out &amp; back only) If the signboard lists departure times
               from the far terminal separately, enter them here. Leave empty
               and the system estimates them (outbound time + run time).</td></tr>
-          <tr><th>run … min</th>
+          <tr><th scope="row">run … min</th>
             <td>End-to-end journey time in minutes, if the signboard or local
               knowledge gives it. Leave on <em>auto</em> to estimate from the
               route's length.</td></tr>
@@ -142,19 +142,19 @@
         <p>The Stops section lists every stop in driving order — the order
           matters, it is the order passengers experience.</p>
         <table class="guide-table">
-          <tr><th>numbered chip</th>
+          <tr><th scope="row">numbered chip</th>
             <td>Click to fly the map to that stop (a red ring flashes).
               Use it to verify each row is the stop you think it is.</td></tr>
-          <tr><th>code</th>
+          <tr><th scope="row">code</th>
             <td>The public stop number if one exists on the physical
               signage.</td></tr>
-          <tr><th>name</th>
+          <tr><th scope="row">name</th>
             <td>The stop name as signed, e.g. <code>PBS OPP TERRACE
               HOTEL</code>. (PBS/EBS prefixes are kept as-is.)</td></tr>
-          <tr><th>lat / lon</th>
+          <tr><th scope="row">lat / lon</th>
             <td>Fine-tune coordinates by typing, or drag the stop on the map
               while editing. Bad values revert automatically.</td></tr>
-          <tr><th>↑ ↓ ✕</th>
+          <tr><th scope="row">↑ ↓ ✕</th>
             <td>Reorder or remove. To <em>add</em> stops, use
               <strong>✎ Edit route → + Stop</strong> on the map, with the
               <strong>🚏 Official stops</strong> signboard panel open for
@@ -181,12 +181,12 @@
       <section>
         <h2>3 · What the signboards give you</h2>
         <table class="guide-table">
-          <tr><th>🚏 Official stops panel</th>
+          <tr><th scope="row">🚏 Official stops panel</th>
             <td>Photos of the official stop-list signboards. Open it (top bar)
               while placing or renaming stops. It has a notes field per route —
               record discrepancies there (e.g. "poster lists a stop the trace
               doesn't have").</td></tr>
-          <tr><th>Timing signboard (in the form)</th>
+          <tr><th scope="row">Timing signboard (in the form)</th>
             <td>Photos of the official departure-time boards. This is the
               source for Step 3. If a route has no timing photo, enter interval
               service from local knowledge and note it in the stops panel
@@ -197,16 +197,16 @@
       <section>
         <h2>4 · Once per dataset — ⚙ Feed settings</h2>
         <table class="guide-table">
-          <tr><th>Operators</th>
+          <tr><th scope="row">Operators</th>
             <td>One row per bus company: name, website, phone. The
               <strong>first row is the default</strong> for routes with no
               explicit operator. Add all known companies here before assigning
               them per route.</td></tr>
-          <tr><th>Holidays</th>
+          <tr><th scope="row">Holidays</th>
             <td>Public holidays where service changes: pick the date and either
               <em>no service</em> or <em>Sunday timetable</em>. Add Hari Raya,
               National Day, etc.</td></tr>
-          <tr><th>Fare</th>
+          <tr><th scope="row">Fare</th>
             <td>The flat fare, e.g. <code>1.00</code> <code>BND</code>.</td></tr>
         </table>
       </section>
@@ -216,7 +216,9 @@
         <p>For the technically curious — where each field ends up in the
           exported zip:</p>
         <table class="guide-table guide-mono">
-          <tr><th>Form field</th><th>GTFS output</th></tr>
+          <thead>
+            <tr><th scope="col">Form field</th><th scope="col">GTFS output</th></tr>
+          </thead>
           <tr><td>No. / Name / Description / Color</td>
             <td>routes.txt — route_short_name, route_long_name, route_desc,
               route_color</td></tr>

--- a/templates/gtfs_guide.html
+++ b/templates/gtfs_guide.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Data entry guide for the GTFS workbench" />
+    <title>Data Entry Guide — Brunei Bus Routes GTFS</title>
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&family=IBM+Plex+Mono:wght@400;600&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
+  </head>
+  <body class="guide-page">
+    <div class="guide">
+      <header class="guide-masthead">
+        <div class="guide-kicker">Brunei Bus Routes · GTFS workbench</div>
+        <h1>Data Entry Guide</h1>
+        <p class="guide-lede">
+          You are turning photographed signboards and hand-traced routes into a
+          machine-readable national timetable (GTFS) — the format used by
+          Google Maps, Apple Maps and journey planners worldwide. This page
+          tells you exactly what goes where. Keep it open in a second tab while
+          you work in the <a href="/gtfs">workbench</a>.
+        </p>
+      </header>
+
+      <section>
+        <h2>1 · The screen</h2>
+        <p>The workbench has three columns:</p>
+        <table class="guide-table">
+          <tr>
+            <th>Left — route list</th>
+            <td>Every route, with a <strong>4-segment progress meter</strong>
+              next to its name: <em>schedule · departures · operator ·
+              headsign</em>. A segment turns green when that data is entered.
+              Your goal is four green segments on every route. Click a route to
+              work on it.</td>
+          </tr>
+          <tr>
+            <th>Middle — map</th>
+            <td>Shows the selected route's line (blue) and stops (yellow).
+              <strong>✎ Edit route</strong> opens the drawing tools. Official
+              routes are read-only — editing one automatically creates a copy
+              under "My routes", which is the one you edit from then on.</td>
+          </tr>
+          <tr>
+            <th>Right — route form</th>
+            <td>Everything about the selected route: schedule, stops list,
+              names, operator, and the <strong>timing signboard photo</strong>
+              you transcribe from. Every field saves automatically a moment
+              after you stop typing — watch for <em>Saved ✓</em>.</td>
+          </tr>
+        </table>
+      </section>
+
+      <section>
+        <h2>2 · Per-route checklist</h2>
+        <p>Work through one route at a time, top to bottom:</p>
+
+        <h3>Step 1 — Identify the route</h3>
+        <table class="guide-table">
+          <tr><th>No.</th>
+            <td>The public route number from the signboard, e.g.
+              <code>01A</code>, <code>20</code>, <code>38</code>.</td></tr>
+          <tr><th>Name</th>
+            <td>A human-readable route name, e.g.
+              <code>BSB – Pekan Muara via Airport</code>.</td></tr>
+          <tr><th>Description</th>
+            <td>The fuller routing summary if known, e.g.
+              <code>BSB → Mall Gadong → Batu Bersurat: Kiulap — Jame'Asr —
+              …</code>. The reference list in
+              <code>docs/2016/reference/routes.txt</code> has these for most
+              routes — copy them in.</td></tr>
+          <tr><th>Color</th>
+            <td>Optional hex color like <code>#E91E63</code> if the route has
+              an official color. Skip if unknown.</td></tr>
+          <tr><th>Operator</th>
+            <td>The company that runs this route. Pick from the dropdown —
+              if the company isn't listed yet, add it first under
+              <strong>⚙ Feed settings</strong> (see section 4). Leave on
+              <em>(default)</em> if unknown.</td></tr>
+        </table>
+
+        <h3>Step 2 — Type &amp; headsigns</h3>
+        <table class="guide-table">
+          <tr><th>Type</th>
+            <td><strong>loop / one-way</strong>: the bus goes round a circuit
+              back to the start (e.g. BSB Circular).<br />
+              <strong>out &amp; back</strong>: the bus drives to a far terminal
+              and returns the same way (e.g. BSB → Pekan Muara → BSB). Choose
+              this and the export automatically produces both directions.</td></tr>
+          <tr><th>Headsign</th>
+            <td>What the front of the bus displays going out, e.g.
+              <code>PEKAN MUARA</code>.</td></tr>
+          <tr><th>Return</th>
+            <td>(out &amp; back only) The sign coming back, usually
+              <code>BSB</code>.</td></tr>
+          <tr><th>hail &amp; ride</th>
+            <td>Tick if the route stops on demand anywhere along the road, not
+              only at marked stops — common in Brunei.</td></tr>
+        </table>
+
+        <h3>Step 3 — Schedule (from the timing signboard)</h3>
+        <p>The signboard photo appears below the form — zoom with
+          <strong>− / + / Fit</strong>. Transcribe what it says:</p>
+        <table class="guide-table">
+          <tr><th>Days</th>
+            <td>Tick the days this timetable applies to. If weekends differ,
+              <strong>+ Add day-type schedule</strong> and give the weekend its
+              own block — e.g. block 1 Mo–Fr, block 2 Sa–Su.</td></tr>
+          <tr><th>Every … min, from … to …</th>
+            <td>Use when the signboard gives an interval ("every 30 minutes,
+              6:00am–8:00pm"). If the interval changes during the day (peak /
+              off-peak), <strong>+ time band</strong> for each window:<br />
+              <code>Every 10 min, 06:00–08:30</code> ·
+              <code>Every 30 min, 08:30–16:00</code> ·
+              <code>Every 15 min, 16:00–19:00</code></td></tr>
+          <tr><th>Exact departures</th>
+            <td><strong>Preferred whenever the signboard lists actual
+              times.</strong> Type them into the dark board, separated by
+              commas or new lines: <code>06:30, 07:00, 07:45, 09:15</code>.
+              When filled, this beats the interval — the export contains one
+              real trip per departure.</td></tr>
+          <tr><th>Return departures</th>
+            <td>(out &amp; back only) If the signboard lists departure times
+              from the far terminal separately, enter them here. Leave empty
+              and the system estimates them (outbound time + run time).</td></tr>
+          <tr><th>run … min</th>
+            <td>End-to-end journey time in minutes, if the signboard or local
+              knowledge gives it. Leave on <em>auto</em> to estimate from the
+              route's length.</td></tr>
+        </table>
+
+        <h3>Step 4 — Stops</h3>
+        <p>The Stops section lists every stop in driving order — the order
+          matters, it is the order passengers experience.</p>
+        <table class="guide-table">
+          <tr><th>numbered chip</th>
+            <td>Click to fly the map to that stop (a red ring flashes).
+              Use it to verify each row is the stop you think it is.</td></tr>
+          <tr><th>code</th>
+            <td>The public stop number if one exists on the physical
+              signage.</td></tr>
+          <tr><th>name</th>
+            <td>The stop name as signed, e.g. <code>PBS OPP TERRACE
+              HOTEL</code>. (PBS/EBS prefixes are kept as-is.)</td></tr>
+          <tr><th>lat / lon</th>
+            <td>Fine-tune coordinates by typing, or drag the stop on the map
+              while editing. Bad values revert automatically.</td></tr>
+          <tr><th>↑ ↓ ✕</th>
+            <td>Reorder or remove. To <em>add</em> stops, use
+              <strong>✎ Edit route → + Stop</strong> on the map, with the
+              <strong>🚏 Official stops</strong> signboard panel open for
+              reference.</td></tr>
+        </table>
+        <p class="guide-note">While the map editor is open the list is
+          <strong>live</strong>: dragging a stop updates its row instantly, but
+          <em>nothing is saved until you press Save in the toolbar</em>.
+          Exit without saving and everything reverts. Outside the editor, list
+          edits save automatically as new versions.</p>
+
+        <h3>Step 5 — Check your work</h3>
+        <ul>
+          <li>All four meter segments green in the route list.</li>
+          <li>Click a few stop chips — does the map land where the stop really
+            is?</li>
+          <li>Run <strong>✔ Validate</strong> (top bar). A warning like
+            <em>"stop is over 150 m from its route's line"</em> means the stop
+            or the line is drawn in the wrong place — fix whichever is
+            wrong.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>3 · What the signboards give you</h2>
+        <table class="guide-table">
+          <tr><th>🚏 Official stops panel</th>
+            <td>Photos of the official stop-list signboards. Open it (top bar)
+              while placing or renaming stops. It has a notes field per route —
+              record discrepancies there (e.g. "poster lists a stop the trace
+              doesn't have").</td></tr>
+          <tr><th>Timing signboard (in the form)</th>
+            <td>Photos of the official departure-time boards. This is the
+              source for Step 3. If a route has no timing photo, enter interval
+              service from local knowledge and note it in the stops panel
+              notes.</td></tr>
+        </table>
+      </section>
+
+      <section>
+        <h2>4 · Once per dataset — ⚙ Feed settings</h2>
+        <table class="guide-table">
+          <tr><th>Operators</th>
+            <td>One row per bus company: name, website, phone. The
+              <strong>first row is the default</strong> for routes with no
+              explicit operator. Add all known companies here before assigning
+              them per route.</td></tr>
+          <tr><th>Holidays</th>
+            <td>Public holidays where service changes: pick the date and either
+              <em>no service</em> or <em>Sunday timetable</em>. Add Hari Raya,
+              National Day, etc.</td></tr>
+          <tr><th>Fare</th>
+            <td>The flat fare, e.g. <code>1.00</code> <code>BND</code>.</td></tr>
+        </table>
+      </section>
+
+      <section>
+        <h2>5 · Field-to-GTFS reference</h2>
+        <p>For the technically curious — where each field ends up in the
+          exported zip:</p>
+        <table class="guide-table guide-mono">
+          <tr><th>Form field</th><th>GTFS output</th></tr>
+          <tr><td>No. / Name / Description / Color</td>
+            <td>routes.txt — route_short_name, route_long_name, route_desc,
+              route_color</td></tr>
+          <tr><td>Operator</td><td>routes.txt agency_id → agency.txt</td></tr>
+          <tr><td>hail &amp; ride</td>
+            <td>routes.txt continuous_pickup / continuous_drop_off</td></tr>
+          <tr><td>Headsign / Return / Type</td>
+            <td>trips.txt trip_headsign + direction_id (0 out, 1 back)</td></tr>
+          <tr><td>Days per block</td><td>calendar.txt services</td></tr>
+          <tr><td>Time bands</td><td>frequencies.txt (one row per band)</td></tr>
+          <tr><td>Exact / Return departures</td>
+            <td>trips.txt + stop_times.txt (one real trip per time)</td></tr>
+          <tr><td>Stops list (code/name/position/order)</td>
+            <td>stops.txt + stop_times.txt stop_sequence</td></tr>
+          <tr><td>Route line (map editor)</td><td>shapes.txt</td></tr>
+          <tr><td>Holidays</td><td>calendar_dates.txt</td></tr>
+          <tr><td>Fare</td><td>fare_attributes.txt</td></tr>
+        </table>
+      </section>
+
+      <section>
+        <h2>6 · Golden rules</h2>
+        <ol class="guide-rules">
+          <li><strong>Transcribe, don't invent.</strong> Enter what the
+            signboard says. If you must estimate, leave a note in the
+            🚏 stops panel.</li>
+          <li><strong>Exact departures beat intervals.</strong> If the board
+            lists times, type the times.</li>
+          <li><strong>Stop order is sacred</strong> — it must match driving
+            order.</li>
+          <li><strong>Official routes are never edited directly</strong> — the
+            ✎ button gives you a copy; that's intentional, the original stays
+            as evidence.</li>
+          <li><strong>Validate before you stop for the day.</strong> Zero
+            errors always; investigate warnings.</li>
+          <li>Everything autosaves and is versioned — you can't destroy
+            anything, so work boldly.</li>
+        </ol>
+      </section>
+
+      <footer class="guide-footer">
+        <a class="btn btn-primary" href="/gtfs">Open the workbench →</a>
+        <span>Data via Land Transport Department (JPD) signboards · feed
+          format: <a href="https://gtfs.org/" target="_blank" rel="noopener">gtfs.org</a></span>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -66,6 +66,14 @@
         >
           🚏 Official stops
         </button>
+        <button
+          id="gtfsEditorToggle"
+          type="button"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          title="Edit GTFS schedule &amp; metadata, transcribe timing signboards, download the feed"
+        >
+          🕐 GTFS
+        </button>
       </div>
     </nav>
 
@@ -158,6 +166,80 @@
         <div id="stopImageResize" title="Drag to resize"></div>
       </div>
 
+      <!-- GTFS editor: per-route schedule/metadata, feed settings, timing
+           signboard reference (floating, draggable, resizable) -->
+      <div id="gtfsPanel" style="display: none">
+        <div id="gtfsHeader">
+          <span class="gep-title">🕐 GTFS</span>
+          <select id="gtfsRouteSelect" class="form-control input-sm" title="Pick a route to edit"></select>
+          <span class="gep-tools">
+            <button type="button" class="btn btn-primary btn-xs" id="gepDownload" title="Download the GTFS feed for this year">⬇ Feed</button>
+            <button type="button" class="btn btn-danger btn-xs" id="gepClose" title="Close">×</button>
+          </span>
+        </div>
+        <div id="gtfsBody">
+          <div class="gep-section">
+            <div class="gep-section-head">
+              <span>🗓 Schedule — <span id="gepRouteLabel">—</span></span>
+              <span id="gepStatus" class="gep-status"></span>
+            </div>
+            <div class="gep-row">
+              <label>Every <input type="number" id="gepHeadway" min="1" max="1440" placeholder="30" /> min,</label>
+              <label>first <input type="time" id="gepStart" /></label>
+              <label>last <input type="time" id="gepEnd" /></label>
+            </div>
+            <div class="gep-row gep-days">
+              <label><input type="checkbox" class="gep-day" checked />Mo</label>
+              <label><input type="checkbox" class="gep-day" checked />Tu</label>
+              <label><input type="checkbox" class="gep-day" checked />We</label>
+              <label><input type="checkbox" class="gep-day" checked />Th</label>
+              <label><input type="checkbox" class="gep-day" checked />Fr</label>
+              <label><input type="checkbox" class="gep-day" checked />Sa</label>
+              <label><input type="checkbox" class="gep-day" checked />Su</label>
+            </div>
+            <div class="gep-row">
+              <label>No. <input type="text" id="gepShort" size="5" placeholder="e.g. 01A" /></label>
+              <label>Name <input type="text" id="gepLong" placeholder="route long name" /></label>
+              <label>Color <input type="text" id="gepColor" size="7" placeholder="#RRGGBB" /></label>
+            </div>
+          </div>
+          <div class="gep-section">
+            <div class="gep-section-head">
+              <span>🕐 Timing signboard</span>
+              <span class="gep-tools">
+                <select id="gtfsTimingSelect" class="form-control input-sm" title="Pick a timing signboard"></select>
+                <button type="button" class="btn btn-default btn-xs" id="gepZoomOut" title="Zoom out">−</button>
+                <button type="button" class="btn btn-default btn-xs" id="gepZoomIn" title="Zoom in">+</button>
+                <button type="button" class="btn btn-default btn-xs" id="gepFit" title="Fit to width">Fit</button>
+              </span>
+            </div>
+            <div id="gtfsTimingBody">
+              <img id="gtfsTimingImg" alt="Official timing signboard" style="display: none" />
+              <div id="gtfsTimingEmpty" class="gep-empty">No timing signboard for this route.</div>
+            </div>
+          </div>
+          <details class="gep-section" id="gepFeedSection">
+            <summary class="gep-section-head">
+              <span>🏢 Feed settings (agency &amp; fare)</span>
+              <span id="gepFeedStatus" class="gep-status"></span>
+            </summary>
+            <div class="gep-row">
+              <label>Agency <input type="text" id="gepAgencyName" placeholder="ADBS Sdn Bhd" /></label>
+              <label>URL <input type="text" id="gepAgencyUrl" placeholder="https://…" /></label>
+            </div>
+            <div class="gep-row">
+              <label>Phone <input type="text" id="gepAgencyPhone" placeholder="+673 …" /></label>
+              <label>Email <input type="text" id="gepAgencyEmail" placeholder="ops@…" /></label>
+            </div>
+            <div class="gep-row">
+              <label>Flat fare <input type="number" id="gepFarePrice" min="0" step="0.10" placeholder="1.00" /></label>
+              <label>Currency <input type="text" id="gepFareCurrency" size="4" placeholder="BND" /></label>
+            </div>
+          </details>
+        </div>
+        <div id="gtfsResize" title="Drag to resize"></div>
+      </div>
+
       <div id="loading">Loading... <a class="btn btn-danger">X</a></div>
       <footer>
         Data via Land Transport Department docs provided for EOI for the
@@ -216,6 +298,7 @@
     <script src="{{ url_for('static', filename='js/info-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/editor-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/stop-image-manager.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/gtfs-editor-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
     <script src="{{ url_for('static', filename='js/ride/launcher.js') }}"></script>
   </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,6 +26,12 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/ol@v8.1.0/ol.css"
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&family=IBM+Plex+Mono:wght@400;600&display=swap"
+    />
     <link
       rel="stylesheet"
       href="{{ url_for('static', filename='css/styles.css') }}"

--- a/templates/index.html
+++ b/templates/index.html
@@ -66,14 +66,13 @@
         >
           🚏 Official stops
         </button>
-        <button
-          id="gtfsEditorToggle"
-          type="button"
+        <a
+          href="/gtfs"
           class="btn btn-default btn-sm navbar-btn navbar-right"
-          title="Edit GTFS schedule &amp; metadata, transcribe timing signboards, download the feed"
+          title="GTFS workbench: edit schedules &amp; route geometry, transcribe timing signboards, download GTFS"
         >
           🕐 GTFS
-        </button>
+        </a>
       </div>
     </nav>
 
@@ -166,88 +165,6 @@
         <div id="stopImageResize" title="Drag to resize"></div>
       </div>
 
-      <!-- GTFS editor: per-route schedule/metadata, feed settings, timing
-           signboard reference (floating, draggable, resizable) -->
-      <div id="gtfsPanel" style="display: none">
-        <div id="gtfsHeader">
-          <span class="gep-title">🕐 GTFS</span>
-          <select id="gtfsRouteSelect" class="form-control input-sm" title="Pick a route to edit"></select>
-          <span class="gep-tools">
-            <button type="button" class="btn btn-primary btn-xs" id="gepDownload" title="Download GTFS for this year">⬇ Download</button>
-            <button type="button" class="btn btn-danger btn-xs" id="gepClose" title="Close">×</button>
-          </span>
-        </div>
-        <div id="gtfsBody">
-          <div class="gep-section">
-            <div class="gep-section-head">
-              <span>🗓 Schedule — <span id="gepRouteLabel">—</span></span>
-              <span id="gepStatus" class="gep-status"></span>
-            </div>
-            <div class="gep-row">
-              <label>Every <input type="number" id="gepHeadway" min="1" max="1440" placeholder="30" /> min,</label>
-              <label>first <input type="time" id="gepStart" /></label>
-              <label>last <input type="time" id="gepEnd" /></label>
-              <label>run <input type="number" id="gepRun" min="1" max="360" placeholder="auto" /> min</label>
-            </div>
-            <div class="gep-row">
-              <label class="gep-block">Exact departures — transcribe from the timing signboard
-                (comma or newline separated). When filled, real trips are
-                exported instead of the headway estimate.
-                <textarea id="gepDepartures" rows="2" placeholder="06:30, 07:00, 07:45, …"></textarea>
-              </label>
-            </div>
-            <div class="gep-row gep-days">
-              <label><input type="checkbox" class="gep-day" checked />Mo</label>
-              <label><input type="checkbox" class="gep-day" checked />Tu</label>
-              <label><input type="checkbox" class="gep-day" checked />We</label>
-              <label><input type="checkbox" class="gep-day" checked />Th</label>
-              <label><input type="checkbox" class="gep-day" checked />Fr</label>
-              <label><input type="checkbox" class="gep-day" checked />Sa</label>
-              <label><input type="checkbox" class="gep-day" checked />Su</label>
-            </div>
-            <div class="gep-row">
-              <label>No. <input type="text" id="gepShort" size="5" placeholder="e.g. 01A" /></label>
-              <label>Name <input type="text" id="gepLong" placeholder="route long name" /></label>
-              <label>Color <input type="text" id="gepColor" size="7" placeholder="#RRGGBB" /></label>
-            </div>
-          </div>
-          <div class="gep-section">
-            <div class="gep-section-head">
-              <span>🕐 Timing signboard</span>
-              <span class="gep-tools">
-                <select id="gtfsTimingSelect" class="form-control input-sm" title="Pick a timing signboard"></select>
-                <button type="button" class="btn btn-default btn-xs" id="gepZoomOut" title="Zoom out">−</button>
-                <button type="button" class="btn btn-default btn-xs" id="gepZoomIn" title="Zoom in">+</button>
-                <button type="button" class="btn btn-default btn-xs" id="gepFit" title="Fit to width">Fit</button>
-              </span>
-            </div>
-            <div id="gtfsTimingBody">
-              <img id="gtfsTimingImg" alt="Official timing signboard" style="display: none" />
-              <div id="gtfsTimingEmpty" class="gep-empty">No timing signboard for this route.</div>
-            </div>
-          </div>
-          <details class="gep-section" id="gepFeedSection">
-            <summary class="gep-section-head">
-              <span>🏢 Feed settings (agency &amp; fare)</span>
-              <span id="gepFeedStatus" class="gep-status"></span>
-            </summary>
-            <div class="gep-row">
-              <label>Agency <input type="text" id="gepAgencyName" placeholder="ADBS Sdn Bhd" /></label>
-              <label>URL <input type="text" id="gepAgencyUrl" placeholder="https://…" /></label>
-            </div>
-            <div class="gep-row">
-              <label>Phone <input type="text" id="gepAgencyPhone" placeholder="+673 …" /></label>
-              <label>Email <input type="text" id="gepAgencyEmail" placeholder="ops@…" /></label>
-            </div>
-            <div class="gep-row">
-              <label>Flat fare <input type="number" id="gepFarePrice" min="0" step="0.10" placeholder="1.00" /></label>
-              <label>Currency <input type="text" id="gepFareCurrency" size="4" placeholder="BND" /></label>
-            </div>
-          </details>
-        </div>
-        <div id="gtfsResize" title="Drag to resize"></div>
-      </div>
-
       <div id="loading">Loading... <a class="btn btn-danger">X</a></div>
       <footer>
         Data via Land Transport Department docs provided for EOI for the
@@ -306,7 +223,6 @@
     <script src="{{ url_for('static', filename='js/info-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/editor-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/stop-image-manager.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/gtfs-editor-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
     <script src="{{ url_for('static', filename='js/ride/launcher.js') }}"></script>
   </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -173,7 +173,7 @@
           <span class="gep-title">🕐 GTFS</span>
           <select id="gtfsRouteSelect" class="form-control input-sm" title="Pick a route to edit"></select>
           <span class="gep-tools">
-            <button type="button" class="btn btn-primary btn-xs" id="gepDownload" title="Download the GTFS feed for this year">⬇ Feed</button>
+            <button type="button" class="btn btn-primary btn-xs" id="gepDownload" title="Download GTFS for this year">⬇ Download</button>
             <button type="button" class="btn btn-danger btn-xs" id="gepClose" title="Close">×</button>
           </span>
         </div>
@@ -187,6 +187,14 @@
               <label>Every <input type="number" id="gepHeadway" min="1" max="1440" placeholder="30" /> min,</label>
               <label>first <input type="time" id="gepStart" /></label>
               <label>last <input type="time" id="gepEnd" /></label>
+              <label>run <input type="number" id="gepRun" min="1" max="360" placeholder="auto" /> min</label>
+            </div>
+            <div class="gep-row">
+              <label class="gep-block">Exact departures — transcribe from the timing signboard
+                (comma or newline separated). When filled, real trips are
+                exported instead of the headway estimate.
+                <textarea id="gepDepartures" rows="2" placeholder="06:30, 07:00, 07:45, …"></textarea>
+              </label>
             </div>
             <div class="gep-row gep-days">
               <label><input type="checkbox" class="gep-day" checked />Mo</label>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Brunei Bus Routes Map" />
+    <title>Brunei Bus Routes</title>
     <meta name="author" content="" />
     <!-- Standard favicon -->
     <link rel="icon" type="image/png" href="/favicon.png" />


### PR DESCRIPTION
## Summary

Builds a full **GTFS editing workbench** at `/gtfs` on top of the feed export from #11, turning the placeholder feed into a transcribable, publishable one.

### The workbench (`/gtfs`)
- **One selected route drives everything**: the route list (with 4-segment transcription-progress meters), the map, the geometry editor target, and the GTFS pane
- **✎ Edit route** opens the full geometry editor; official routes seamlessly edit as an auto-created/reused copy; GeoJSON path tracings are included (copy to add stops)
- **Stops list**: sequence-ordered, editable codes/names/coordinates, reorder/remove, click-to-locate; mirrors the map editor **live** while it's open (persisted only by Save), autosaves as geometry versions otherwise
- **Transit-signage design language** (frontend-design plugin): ink slate + warm paper, signage-yellow accent, Barlow Condensed + IBM Plex Mono, departure-board departures field — extended to the homepage for cohesion

### Schedule & feed modeling
- **Day-type schedule blocks** (weekday/weekend) × **time-of-day frequency bands** (peak/off-peak) × **directions** (out & back with reversed shape/stops, per-direction headsigns, exact or derived return departures) × **exact departures** (pure schedule-based GTFS, `timepoint` flags)
- **Multi-operator support**: operator list in Feed settings, per-route `agency_id`
- **Holiday exceptions** (`calendar_dates.txt`, weekday-aware no-service/Sunday-timetable modes), flat fare, hail & ride (`continuous_pickup`), `route_desc`, stop codes, auto walking `transfers.txt`, date-stamped `feed_version`
- Per-route GTFS metadata lives in a new `gtfs_meta` table (history-archived on overwrite)

### Validation & docs
- **✔ Validate**: built-in structural validator (files/columns, referential integrity, monotonic times, frequency overlap, off-shape stops) as UI modal, endpoint, and `--validate` CLI flag — caught real defects on first runs (an invalid 1-stop route; 63 stops up to 2.5 km off their traced lines)
- **？ Guide** (`/gtfs/guide`): plain-language data-entry guide — per-route checklist, signboard usage, field-to-GTFS reference, golden rules
- Two frontend expert review passes applied (responsive navbar/layout fixes, contrast, a11y, dead CSS pruning)

## Test plan
- [x] Export verified end-to-end after every feature (override roundtrips, direction/band/holiday structure, referential integrity, gtfs-kit parses)
- [x] Built-in validator passes 0 errors on the real feed; detection verified against deliberately sabotaged feeds
- [x] CLI and endpoint produce identical override-aware feeds
- [x] All three pages render; CSS balanced; JS syntax-checked
- [ ] Manual click-through of editor flows on desktop + narrow viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)