### PR TITLE
GTFS feed preview: inspect emitted files in-app

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,10 +2,13 @@ from flask import (
     Flask, render_template, send_from_directory, jsonify, json, request, Response,
     url_for,
 )
+import csv
 import datetime
+import io
 import os
 import re
 import math
+import zipfile
 import xml.etree.ElementTree as ET
 from xml.sax.saxutils import escape as _xml_escape
 
@@ -945,6 +948,38 @@ def gtfs_validate():
         "warnings": len(findings) - errors,
         "findings": findings,
     })
+
+
+# Preview payloads stay bounded: stop_times.txt alone can run to tens of
+# thousands of rows, which would bloat the JSON and stall the browser table.
+GTFS_PREVIEW_MAX_ROWS = 500
+
+
+@app.route("/data/gtfs-preview")
+def gtfs_preview():
+    """Build the year's feed in memory and return every file's parsed contents,
+    so the workbench can show the data exactly as the export will emit it."""
+    year = _resolve_year(request.args.get("year"))
+    routes, agencies, params = gtfs_feed_inputs(year)
+    if not routes:
+        return jsonify({"error": "no routes to export"}), 404
+    data, stats = gtfs.build_feed(routes, agencies, params)
+    files = []
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        for name in zf.namelist():
+            text = zf.read(name).decode("utf-8-sig")
+            rows = list(csv.reader(io.StringIO(text)))
+            header = rows[0] if rows else []
+            body = rows[1:]
+            files.append({
+                "name": name,
+                "header": header,
+                "rows": body[:GTFS_PREVIEW_MAX_ROWS],
+                "total_rows": len(body),
+                "truncated": len(body) > GTFS_PREVIEW_MAX_ROWS,
+                "size": zf.getinfo(name).file_size,
+            })
+    return jsonify({"year": year, "size": len(data), "stats": stats, "files": files})
 
 
 @app.route("/data/gtfs.zip")

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1246,6 +1246,88 @@ body.editing #gtfsEditBtn {
   color: var(--gtfs-ink-soft);
 }
 
+/* Feed preview: tabbed view of the files the export emits */
+.gep-preview-dialog {
+  width: auto;
+  max-width: 1100px;
+  margin: 30px auto;
+}
+.gep-preview-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.gep-preview-toolbar #previewFilter {
+  flex: 0 1 260px;
+  margin-left: auto;
+}
+.gep-preview-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.gep-preview-tab {
+  font-family: var(--gtfs-mono);
+  font-size: 11px;
+  padding: 3px 8px;
+  border: 1px solid var(--gtfs-line);
+  border-radius: 3px;
+  background: #f0ede5;
+  color: var(--gtfs-ink);
+  cursor: pointer;
+}
+.gep-preview-tab:hover {
+  background: #e6e2d6;
+}
+.gep-preview-tab.active {
+  background: var(--gtfs-ink);
+  border-color: var(--gtfs-ink);
+  color: #fff;
+}
+.gep-preview-tab-count {
+  margin-left: 6px;
+  opacity: 0.65;
+}
+.gep-preview-meta {
+  font-family: var(--gtfs-mono);
+  font-size: 11px;
+  color: var(--gtfs-ink-soft);
+  margin-bottom: 4px;
+}
+.gep-preview-table-wrap {
+  max-height: 60vh;
+  overflow: auto;
+  border: 1px solid var(--gtfs-line);
+  border-radius: 4px;
+}
+.gep-preview-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-family: var(--gtfs-mono);
+  font-size: 11px;
+  white-space: nowrap;
+}
+.gep-preview-table th {
+  position: sticky;
+  top: 0;
+  background: var(--gtfs-ink);
+  color: #fff;
+  font-weight: 600;
+  text-align: left;
+  padding: 4px 8px;
+}
+.gep-preview-table td {
+  padding: 3px 8px;
+  border-bottom: 1px dotted var(--gtfs-line);
+  color: var(--gtfs-ink);
+}
+.gep-preview-table tbody tr:nth-child(even) {
+  background: #f7f5ee;
+}
+
 @media (max-width: 991px) {
   .gtfs-routes-col {
     flex-basis: 190px;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -906,9 +906,12 @@ body.editing #gtfsEditBtn {
 #gepStopsList {
   max-height: 230px;
   overflow-y: auto;
-  /* Keep the scrollbar off the row tools (the delete ✕ is the rightmost item). */
+  /* Keep the scrollbar off the row tools (the delete ✕ is the rightmost item).
+     Firefox/Zen overlay scrollbars ignore scrollbar-gutter (overlay gutter is
+     zero-width), so the padding must clear the bar's own width. */
   scrollbar-gutter: stable;
-  padding-right: 6px;
+  scrollbar-width: thin;
+  padding-right: 12px;
 }
 .gep-stop-row {
   display: flex;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -911,7 +911,7 @@ body.editing #gtfsEditBtn {
      zero-width), so the padding must clear the bar's own width. */
   scrollbar-gutter: stable;
   scrollbar-width: thin;
-  padding-right: 12px;
+  padding-right: 18px;
 }
 .gep-stop-row {
   display: flex;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -906,6 +906,9 @@ body.editing #gtfsEditBtn {
 #gepStopsList {
   max-height: 230px;
   overflow-y: auto;
+  /* Keep the scrollbar off the row tools (the delete ✕ is the rightmost item). */
+  scrollbar-gutter: stable;
+  padding-right: 6px;
 }
 .gep-stop-row {
   display: flex;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1297,6 +1297,43 @@ body.editing #gtfsEditBtn {
   color: var(--gtfs-ink-soft);
   margin-bottom: 4px;
 }
+.gep-preview-source {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--gtfs-ink);
+  padding: 5px 8px;
+  border-radius: 4px;
+  margin-bottom: 6px;
+  background: #f0ede5;
+}
+.gep-preview-source:empty {
+  display: none;
+}
+.gep-preview-source.edit {
+  background: #e6f2e6;
+}
+.gep-preview-source.partial {
+  background: #fdf3d7;
+}
+.gep-preview-source.auto {
+  background: #ece9e2;
+  color: var(--gtfs-ink-soft);
+}
+.gep-preview-source-badge {
+  flex: 0 0 auto;
+  font-family: var(--gtfs-mono);
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.gep-preview-source.edit .gep-preview-source-badge {
+  color: var(--gtfs-go);
+}
+.gep-preview-source.partial .gep-preview-source-badge {
+  color: #8a6d00;
+}
 .gep-preview-table-wrap {
   max-height: 60vh;
   overflow: auto;

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -929,6 +929,53 @@ APP.GtfsEditorManager = class {
   // The actual files the export emits, rebuilt on demand so the transcriber can
   // watch routes.txt / stop_times.txt / … take shape as they fill in the forms.
 
+  /** Where each GTFS file is shaped in-app. kind: "edit" = fully driven by a
+   * form/map control, "partial" = some columns computed, "auto" = derived,
+   * nothing to edit. Shown as a banner on the file's preview tab. */
+  static FILE_SOURCES = {
+    "agency.txt": { kind: "edit", where: "⚙ Feed settings → Operators" },
+    "routes.txt": {
+      kind: "edit",
+      where: "Route pane — No., Name, Color, Description, Operator",
+    },
+    "stops.txt": {
+      kind: "edit",
+      where:
+        "Map editor (✎ Edit route — add / move / rename stops) + stop codes in the Stops list",
+    },
+    "shapes.txt": {
+      kind: "edit",
+      where: "Map editor — the drawn route line is the shape",
+    },
+    "trips.txt": {
+      kind: "edit",
+      where: "Route pane — Headsign, Type (out & back), day-type schedule blocks",
+    },
+    "stop_times.txt": {
+      kind: "partial",
+      where:
+        "Departure times & timepoint flags in schedule blocks; in-between stop times are computed by projecting stops along the route geometry",
+    },
+    "frequencies.txt": {
+      kind: "edit",
+      where: "Time-of-day frequency bands in the route's schedule blocks",
+    },
+    "calendar.txt": {
+      kind: "edit",
+      where: "Day-type schedule blocks (weekday / weekend / …)",
+    },
+    "calendar_dates.txt": { kind: "edit", where: "⚙ Feed settings → Holidays" },
+    "fare_attributes.txt": { kind: "edit", where: "⚙ Feed settings → Fare" },
+    "transfers.txt": {
+      kind: "auto",
+      where: "Auto-generated from stop proximity (walking-distance pairs)",
+    },
+    "feed_info.txt": {
+      kind: "auto",
+      where: "Auto-generated — version is stamped with the export date",
+    },
+  };
+
   _preview() {
     this._flushPending();
     const year = this.year || "";
@@ -987,7 +1034,16 @@ APP.GtfsEditorManager = class {
     const f = (this._previewFiles || []).find((x) => x.name === this._previewTab);
     const wrap = $("#previewTableWrap").empty();
     const meta = $("#previewMeta").empty();
+    const src = $("#previewSource").empty().attr("class", "gep-preview-source");
     if (!f) return;
+    const info = APP.GtfsEditorManager.FILE_SOURCES[f.name];
+    if (info) {
+      const badge = { edit: "✎ editable", partial: "◐ partly editable", auto: "🔒 derived" };
+      src
+        .addClass(info.kind)
+        .append($('<span class="gep-preview-source-badge"></span>').text(badge[info.kind]))
+        .append($("<span></span>").text(info.where));
+    }
     const q = ($("#previewFilter").val() || "").trim().toLowerCase();
     const rows = q
       ? f.rows.filter((r) => r.some((c) => c.toLowerCase().indexOf(q) >= 0))

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -845,7 +845,9 @@ APP.GtfsEditorManager = class {
 
   // --- Download ------------------------------------------------------------------------
 
-  _download() {
+  /** Push any debounced route/feed saves now, so feed builds (download,
+   * validate, preview) reflect what's on screen. */
+  _flushPending() {
     this._flushStopsSave();
     if (this._saveTimer) {
       clearTimeout(this._saveTimer);
@@ -857,6 +859,10 @@ APP.GtfsEditorManager = class {
       this._feedTimer = null;
       this._saveFeedConfig();
     }
+  }
+
+  _download() {
+    this._flushPending();
     const year = this.year || (this.current ? this.current.year : "");
     window.open(`/data/gtfs.zip${year ? "?year=" + encodeURIComponent(year) : ""}`);
   }
@@ -864,17 +870,7 @@ APP.GtfsEditorManager = class {
   // --- Validation ----------------------------------------------------------------------
 
   _validate() {
-    this._flushStopsSave();
-    if (this._saveTimer) {
-      clearTimeout(this._saveTimer);
-      this._saveTimer = null;
-      this._saveMeta();
-    }
-    if (this._feedTimer) {
-      clearTimeout(this._feedTimer);
-      this._feedTimer = null;
-      this._saveFeedConfig();
-    }
+    this._flushPending();
     const year = this.year || "";
     $("#validateYear").text(year || "default");
     $("#validateSummary").attr("class", "gep-validate-summary").text("Validating…");
@@ -929,11 +925,110 @@ APP.GtfsEditorManager = class {
       });
   }
 
+  // --- Feed preview --------------------------------------------------------------------
+  // The actual files the export emits, rebuilt on demand so the transcriber can
+  // watch routes.txt / stop_times.txt / … take shape as they fill in the forms.
+
+  _preview() {
+    this._flushPending();
+    const year = this.year || "";
+    $("#previewYear").text(year || "default");
+    $("#previewSummary").text("Building feed…");
+    $("#previewModal").modal("show");
+    fetch(`/data/gtfs-preview${year ? "?year=" + encodeURIComponent(year) : ""}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.error) {
+          $("#previewSummary").text(d.error);
+          $("#previewTabs").empty();
+          $("#previewMeta").empty();
+          $("#previewTableWrap").empty();
+          this._previewFiles = null;
+          return;
+        }
+        this._previewFiles = d.files || [];
+        const s = d.stats || {};
+        $("#previewSummary").text(
+          `${this._previewFiles.length} files · ${s.routes} routes, ` +
+            `${s.trips} trips, ${s.stops} stops · ${Math.round(d.size / 1024)} KB`
+        );
+        const tabs = $("#previewTabs").empty();
+        this._previewFiles.forEach((f) => {
+          tabs.append(
+            $('<button type="button" class="gep-preview-tab"></button>')
+              .attr("data-file", f.name)
+              .append($("<span></span>").text(f.name))
+              .append(
+                $('<span class="gep-preview-tab-count"></span>').text(f.total_rows)
+              )
+          );
+        });
+        // Keep the tab the user was on across refreshes, else start at the top.
+        const current =
+          this._previewFiles.find((f) => f.name === this._previewTab) ||
+          this._previewFiles[0];
+        this._showPreviewFile(current ? current.name : null);
+      })
+      .catch((err) => {
+        $("#previewSummary").text("Preview request failed");
+        console.error("gtfs-preview failed", err);
+      });
+  }
+
+  _showPreviewFile(name) {
+    this._previewTab = name;
+    $("#previewTabs .gep-preview-tab").each((_, el) => {
+      $(el).toggleClass("active", $(el).attr("data-file") === name);
+    });
+    this._renderPreviewTable();
+  }
+
+  _renderPreviewTable() {
+    const f = (this._previewFiles || []).find((x) => x.name === this._previewTab);
+    const wrap = $("#previewTableWrap").empty();
+    const meta = $("#previewMeta").empty();
+    if (!f) return;
+    const q = ($("#previewFilter").val() || "").trim().toLowerCase();
+    const rows = q
+      ? f.rows.filter((r) => r.some((c) => c.toLowerCase().indexOf(q) >= 0))
+      : f.rows;
+    const bits = [`${f.total_rows} row${f.total_rows === 1 ? "" : "s"}`];
+    if (f.truncated) bits.push(`showing first ${f.rows.length}`);
+    if (q) bits.push(`${rows.length} match${rows.length === 1 ? "" : "es"}`);
+    bits.push(`${(f.size / 1024).toFixed(1)} KB`);
+    meta.text(`${f.name} — ${bits.join(" · ")}`);
+    if (!rows.length) {
+      wrap.append(
+        $('<div class="gep-empty"></div>').text(
+          q ? "No rows match the filter." : "No data rows."
+        )
+      );
+      return;
+    }
+    const table = $('<table class="gep-preview-table"></table>');
+    const thead = $("<thead></thead>").appendTo(table);
+    const hr = $("<tr></tr>").appendTo(thead);
+    f.header.forEach((h) => hr.append($("<th></th>").text(h)));
+    const tbody = $("<tbody></tbody>").appendTo(table);
+    rows.forEach((r) => {
+      const tr = $("<tr></tr>");
+      r.forEach((c) => tr.append($("<td></td>").text(c)));
+      tbody.append(tr);
+    });
+    wrap.append(table);
+  }
+
   // --- Events --------------------------------------------------------------------------
 
   _bind() {
     $("#gepDownload").on("click", () => this._download());
     $("#gepValidate").on("click", () => this._validate());
+    $("#gepPreview").on("click", () => this._preview());
+    $("#previewRefresh").on("click", () => this._preview());
+    $("#previewTabs").on("click", ".gep-preview-tab", (e) => {
+      this._showPreviewFile($(e.currentTarget).attr("data-file"));
+    });
+    $("#previewFilter").on("input", () => this._renderPreviewTable());
     this.timingSelect.on("change", () => this._showTiming());
     $("#gepZoomIn").on("click", () => this._setZoom(this.zoom * 1.25));
     $("#gepZoomOut").on("click", () => this._setZoom(this.zoom / 1.25));

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -329,6 +329,7 @@
                 title="Rebuild the feed with the latest edits">↻ Refresh</button>
             </div>
             <div id="previewMeta" class="gep-preview-meta"></div>
+            <div id="previewSource" class="gep-preview-source"></div>
             <div id="previewTableWrap" class="gep-preview-table-wrap"></div>
             <p class="gep-hint">This is the feed exactly as ⬇ Download GTFS will
               emit it, built from your current edits. Long files show the first

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -65,6 +65,14 @@
         <button
           type="button"
           class="btn btn-default btn-sm navbar-btn navbar-right"
+          id="gepPreview"
+          title="Inspect the GTFS files the export will produce, with your current edits applied"
+        >
+          📄 Preview
+        </button>
+        <button
+          type="button"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
           data-toggle="modal"
           data-target="#feedSettingsModal"
           title="Feed-wide settings: agency details and flat fare"
@@ -296,6 +304,38 @@
         ></textarea>
       </div>
       <div id="stopImageResize" title="Drag to resize"></div>
+    </div>
+
+    <!-- GTFS feed preview: the actual files the export emits, as tables -->
+    <div class="modal fade" id="previewModal" tabindex="-1" role="dialog">
+      <div class="modal-dialog gep-preview-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+            <h4 class="modal-title">📄 Feed preview — <span id="previewYear"></span>
+              <small id="previewSummary" class="gep-status"></small>
+            </h4>
+          </div>
+          <div class="modal-body gep-preview-body">
+            <div class="gep-preview-toolbar">
+              <div id="previewTabs" class="gep-preview-tabs"></div>
+              <input
+                type="text"
+                id="previewFilter"
+                class="form-control input-sm"
+                placeholder="Filter rows… (e.g. a route or stop id)"
+              />
+              <button type="button" class="btn btn-default btn-xs" id="previewRefresh"
+                title="Rebuild the feed with the latest edits">↻ Refresh</button>
+            </div>
+            <div id="previewMeta" class="gep-preview-meta"></div>
+            <div id="previewTableWrap" class="gep-preview-table-wrap"></div>
+            <p class="gep-hint">This is the feed exactly as ⬇ Download GTFS will
+              emit it, built from your current edits. Long files show the first
+              500 rows.</p>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Feed validation results -->


### PR DESCRIPTION
## Summary
- New `/data/gtfs-preview` endpoint: builds the year's feed in memory (same inputs as download/validate) and returns each file parsed into header + rows, capped at 500 rows/file
- 📄 Preview button on the /gtfs workbench: tabbed modal showing each GTFS file as a table, with row counts, a substring filter, and a refresh that flushes pending form saves first — watch the feed take shape while transcribing
- Per-file banner showing editability and where the file is shaped in-app (✎ editable / ◐ partly editable / 🔒 derived)
- Fix: stops-list vertical scrollbar covered each row's ✕ delete tool under Firefox/Zen overlay scrollbars; reserved gutter + right inset

## Test plan
- [x] `/data/gtfs-preview?year=2016` returns all 10 files with correct counts; 2026 works
- [x] JS syntax-checked; /gtfs loads
- [ ] Click 📄 Preview, switch tabs, filter rows, edit a departure → ↻ Refresh shows the change
- [ ] Long stops list in edit mode: ✕ clear of the scrollbar in Firefox/Zen

🤖 Generated with [Claude Code](https://claude.com/claude-code)