### PR TITLE
GTFS workbench: single left sidebar + editor fixes

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1000,6 +1000,9 @@ body.editing #gtfsEditBtn {
 .gep-stops-head span {
   padding: 1px 4px; /* match the rows' input padding so labels line up */
 }
+.gep-stops-head .gep-stop-tools {
+  padding: 0; /* width-matching spacer — the real tools cell has none */
+}
 .gep-stops-head-seq {
   flex: 0 0 26px;
   text-align: center;
@@ -1061,7 +1064,11 @@ body.editing #gtfsEditBtn {
   font-size: 10px !important;
 }
 .gep-stop-name {
-  flex: 1 1 auto;
+  /* Explicit basis: the header label and the input then share identical
+     grow/shrink math, keeping the columns after Name aligned. (With basis
+     auto, the input's ~160px intrinsic width shrinks while the short label
+     grows — different final widths.) */
+  flex: 1 1 60px;
   min-width: 60px;
 }
 .gep-stop-coord {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1056,7 +1056,7 @@ body.editing #gtfsEditBtn {
   background: #fffdf8;
 }
 .gep-stop-code {
-  flex: 0 0 48px;
+  flex: 0 0 34px;
   font-family: var(--gtfs-mono);
   font-size: 10px !important;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -410,13 +410,10 @@ body.editing #sidebar {
   margin-left: 4px;
 }
 
-/* --- Official stop-list signboard reference panel --- */
-#stopImagePanel {
+/* --- Floating reference panels (official stops + timing signboards) --- */
+#stopImagePanel,
+#timingPanel {
   position: absolute;
-  top: 120px;
-  left: 12px;
-  width: 340px;
-  height: 480px;
   min-width: 220px;
   min-height: 200px;
   max-width: calc(100% - 24px);
@@ -430,7 +427,26 @@ body.editing #sidebar {
   box-shadow: 0 4px 18px rgba(29, 42, 51, 0.35);
   overflow: hidden;
 }
-#stopImageHeader {
+#stopImagePanel {
+  top: 120px;
+  left: 12px;
+  width: 340px;
+  height: 480px;
+}
+/* On the workbench, clear the 400px sidebar so it doesn't cover the form. */
+body.gtfs-page #stopImagePanel {
+  left: 412px;
+}
+/* Timing docks over the map's right edge: source document beside the form
+   it's transcribed into, with the (idle-while-typing) map underneath. */
+#timingPanel {
+  top: 62px;
+  right: 12px;
+  width: 440px;
+  height: calc(100% - 140px);
+}
+#stopImageHeader,
+#timingPanelHeader {
   flex: 0 0 auto;
   display: flex;
   flex-wrap: wrap;
@@ -442,14 +458,16 @@ body.editing #sidebar {
   cursor: move;
   user-select: none;
 }
-#stopImageHeader .sip-title {
+#stopImageHeader .sip-title,
+#timingPanelHeader .sip-title {
   font-family: var(--gtfs-display);
   font-weight: 600;
   font-size: 14px;
   letter-spacing: 0.04em;
   margin-right: 2px;
 }
-#stopImageHeader select {
+#stopImageHeader select,
+#timingPanelHeader select {
   width: auto;
   max-width: 140px;
   height: 24px;
@@ -457,7 +475,8 @@ body.editing #sidebar {
   font-size: 12px;
   color: #333;
 }
-#stopImageHeader .sip-tools {
+#stopImageHeader .sip-tools,
+#timingPanelHeader .sip-tools {
   margin-left: auto;
   white-space: nowrap;
 }
@@ -505,7 +524,8 @@ body.editing #sidebar {
   border: 1px solid #ccc;
   border-radius: 4px;
 }
-#stopImageResize {
+#stopImageResize,
+#timingResize {
   position: absolute;
   right: 0;
   bottom: 0;
@@ -558,13 +578,75 @@ body.gtfs-page .navbar .navbar-btn {
   height: calc(100vh - 50px); /* below the fixed navbar */
 }
 
-/* --- Route list ------------------------------------------------------ */
-.gtfs-routes-col {
-  flex: 0 0 264px;
-  overflow-y: auto;
-  padding: 10px 0 10px 10px;
+/* --- Sidebar (route list stacked above the GTFS pane) ----------------- */
+.gtfs-sidebar {
+  flex: 0 0 400px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
   background: var(--gtfs-paper);
   border-right: 1px solid var(--gtfs-line);
+}
+
+/* --- Route list ------------------------------------------------------ */
+.gtfs-routes-col {
+  flex: 0 1 auto;
+  display: flex;
+  flex-direction: column;
+  max-height: 32vh;
+  min-height: 0;
+  background: var(--gtfs-paper);
+}
+.gtfs-routes-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--gtfs-ink);
+  color: #fff;
+  font-family: var(--gtfs-display);
+  font-weight: 600;
+  font-size: 16px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  user-select: none;
+}
+.gtfs-routes-current {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: none;
+  color: var(--gtfs-accent);
+  font-size: 14px;
+  letter-spacing: 0.04em;
+  text-transform: none;
+}
+/* When the list is out of sight, the header carries the selection. */
+.gtfs-routes-col.collapsed .gtfs-routes-current,
+body.editing .gtfs-routes-current {
+  display: block;
+}
+.gtfs-routes-caret {
+  flex: 0 0 auto;
+  transition: transform 0.15s ease;
+}
+.gtfs-routes-col.collapsed .gtfs-routes-caret {
+  transform: rotate(-90deg);
+}
+.gtfs-routes-scroll {
+  overflow-y: auto;
+  min-height: 0;
+  padding: 8px 0 8px 10px;
+}
+/* Collapsed manually, or forced shut while the geometry editor runs — the
+   sidebar's full height goes to the GTFS pane and its live stops list. */
+.gtfs-routes-col.collapsed .gtfs-routes-scroll,
+body.editing .gtfs-routes-scroll {
+  display: none;
 }
 .gtfs-list-head {
   font-family: var(--gtfs-display);
@@ -704,11 +786,12 @@ body.editing #gtfsEditBtn {
 
 /* --- GTFS pane --------------------------------------------------------- */
 #gtfsPanel {
-  flex: 0 0 400px;
+  flex: 1 1 auto;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   background: var(--gtfs-paper);
-  border-left: 1px solid var(--gtfs-line);
+  border-top: 1px solid var(--gtfs-line);
   overflow: hidden;
 }
 #gtfsHeader {
@@ -737,12 +820,6 @@ body.editing #gtfsEditBtn {
   border-radius: 6px;
   padding: 8px 10px 10px;
 }
-.gep-section-grow {
-  flex: 1 1 auto;
-  display: flex;
-  flex-direction: column;
-  min-height: 180px;
-}
 .gep-section-head {
   display: flex;
   align-items: center;
@@ -757,30 +834,6 @@ body.editing #gtfsEditBtn {
   margin-bottom: 6px;
   padding-bottom: 4px;
   border-bottom: 2px solid var(--gtfs-accent);
-}
-.gep-section-head .gep-tools {
-  display: flex;
-  align-items: center;
-  gap: 3px;
-}
-.gep-section-head .gep-tools select {
-  width: auto;
-  max-width: 150px;
-  height: 22px;
-  padding: 1px 4px;
-  font-size: 11px;
-  font-family: inherit;
-  letter-spacing: normal;
-  text-transform: none;
-  font-weight: 400;
-}
-/* Buttons in the head would otherwise inherit the display-type styling
-   ("FIT" in tracked uppercase Barlow). */
-.gep-section-head .gep-tools .btn {
-  font-family: "Helvetica Neue", Arial, sans-serif;
-  text-transform: none;
-  letter-spacing: normal;
-  font-weight: 400;
 }
 .gep-status {
   font-family: var(--gtfs-mono);
@@ -904,7 +957,8 @@ body.editing #gtfsEditBtn {
   color: var(--gtfs-ink-soft);
 }
 #gepStopsList {
-  max-height: 230px;
+  /* The timing viewer no longer competes for the column — let the list run. */
+  max-height: 40vh;
   overflow-y: auto;
   /* Keep the scrollbar off the row tools (the delete ✕ is the rightmost item).
      Firefox/Zen overlay scrollbars ignore scrollbar-gutter (overlay gutter is
@@ -990,11 +1044,10 @@ body.editing #gtfsEditBtn {
 
 #gtfsTimingBody {
   flex: 1 1 auto;
-  min-height: 140px;
+  min-height: 0;
   overflow: auto;
-  background: #e9e5da;
+  background: #e9e5da; /* photo well, matches #stopImageBody */
   text-align: center;
-  border-radius: 4px;
 }
 #gtfsTimingImg {
   display: block;
@@ -1372,15 +1425,18 @@ body.editing #gtfsEditBtn {
 }
 
 @media (max-width: 991px) {
-  .gtfs-routes-col {
-    flex-basis: 190px;
+  .gtfs-sidebar {
+    flex-basis: 340px;
   }
-  #gtfsPanel {
-    flex-basis: 320px;
+  body.gtfs-page #stopImagePanel {
+    left: 352px;
+  }
+  #timingPanel {
+    width: min(440px, calc(100vw - 376px));
   }
 }
-/* Below ~820px the three non-shrinking columns can't fit side by side and
-   the GTFS pane would be clipped off-screen — stack them instead. */
+/* Below ~820px the sidebar and map can't fit side by side — dissolve the
+   sidebar wrapper and stack: route list / map / GTFS pane. */
 @media (max-width: 820px) {
   body.gtfs-page {
     overflow: auto;
@@ -1389,25 +1445,38 @@ body.editing #gtfsEditBtn {
     flex-direction: column;
     height: auto;
   }
+  .gtfs-sidebar {
+    display: contents; /* children rejoin the column flex below */
+  }
   .gtfs-routes-col {
+    order: 1;
     flex: none;
     max-height: 30vh;
-    border-right: none;
     border-bottom: 1px solid var(--gtfs-line);
   }
   .gtfs-map-col {
+    order: 2;
     flex: none;
     height: 55vh;
     min-width: 0;
   }
   #gtfsPanel {
+    order: 3;
     flex: none;
     width: auto;
-    border-left: none;
     border-top: 1px solid var(--gtfs-line);
   }
   #gtfsBody {
     overflow-y: visible;
+  }
+  /* Floating reference panels overlay most of a phone screen — opened
+     explicitly via the navbar toggles, never auto-shown (see JS). */
+  body.gtfs-page #stopImagePanel {
+    left: 12px;
+  }
+  #timingPanel {
+    width: calc(100vw - 24px);
+    right: 12px;
   }
 }
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -978,15 +978,32 @@ body.editing #gtfsEditBtn {
   scrollbar-gutter: stable;
   scrollbar-width: thin;
   padding-right: 18px;
+  /* One shared column template for the head row AND every data row:
+     # | code | name | lat | lon. Tracks are fixed lengths or length-bounded
+     minmax, so no cell's content (header labels, input intrinsic widths) can
+     change a track — columns cannot drift the way two independently-resolved
+     flex containers did. */
+  --gep-stop-cols: 26px 40px minmax(60px, 1fr) minmax(56px, 72px) minmax(56px, 72px);
+}
+/* Edit mode (JS toggles the class): one extra ↑↓✕ tools track, sized by the
+   rows' identical tool spans; the head simply leaves that cell empty. */
+#gepStopsList.gep-has-tools {
+  --gep-stop-cols: 26px 40px minmax(60px, 1fr) minmax(56px, 72px) minmax(56px, 72px) max-content;
+}
+/* Head and data rows share the same grid, hence identical column edges by
+   construction. (JS keeps .gep-stops-head distinct from .gep-stop-row.) */
+.gep-stops-head,
+.gep-stop-row {
+  display: grid;
+  grid-template-columns: var(--gep-stop-cols);
+  align-items: center;
+  gap: 4px;
 }
 /* Column titles for the stops list, sticky while the list scrolls. */
 .gep-stops-head {
   position: sticky;
   top: 0;
   z-index: 1;
-  display: flex;
-  align-items: center;
-  gap: 4px;
   padding: 1px 0 2px;
   background: var(--gtfs-card);
   border-bottom: 1px solid var(--gtfs-line);
@@ -998,25 +1015,13 @@ body.editing #gtfsEditBtn {
   color: var(--gtfs-ink-soft);
 }
 .gep-stops-head span {
-  padding: 1px 4px; /* match the rows' input padding so labels line up */
-}
-.gep-stops-head .gep-stop-tools {
-  padding: 0; /* width-matching spacer — the real tools cell has none */
+  /* Inputs below have 4px padding + 1px (transparent) border: inset = 5px. */
+  padding: 1px 5px;
 }
 .gep-stops-head-seq {
-  flex: 0 0 26px;
   text-align: center;
 }
-.gep-stops-head .gep-stop-coord {
-  min-width: 56px;
-}
-.gep-stops-head .gep-stop-tools {
-  visibility: hidden; /* width-matching spacer only */
-}
 .gep-stop-row {
-  display: flex;
-  align-items: center;
-  gap: 4px;
   padding: 2px 0;
   transition: background 0.6s ease;
 }
@@ -1029,7 +1034,6 @@ body.editing #gtfsEditBtn {
   border-top: 1px dotted var(--gtfs-line);
 }
 .gep-stop-seq {
-  flex: 0 0 26px;
   padding: 1px 0 2px;
   text-align: center;
   background: var(--gtfs-ink);
@@ -1052,34 +1056,27 @@ body.editing #gtfsEditBtn {
   border-radius: 3px;
   background: transparent;
   color: var(--gtfs-ink);
+  /* Inputs report a large intrinsic minimum (≈20 chars); without this the
+     grid-stretch width is floored at min-width:auto and overflows the track. */
+  min-width: 0;
 }
 .gep-stop-row input:hover:not(:disabled),
 .gep-stop-row input:focus {
   border-color: #cfc8b8;
   background: #fffdf8;
 }
+/* Column widths live in --gep-stop-cols on #gepStopsList — only typography
+   stays on the cell classes. */
 .gep-stop-code {
-  flex: 0 0 34px;
   font-family: var(--gtfs-mono);
   font-size: 10px !important;
 }
-.gep-stop-name {
-  /* Explicit basis: the header label and the input then share identical
-     grow/shrink math, keeping the columns after Name aligned. (With basis
-     auto, the input's ~160px intrinsic width shrinks while the short label
-     grows — different final widths.) */
-  flex: 1 1 60px;
-  min-width: 60px;
-}
 .gep-stop-coord {
-  flex: 0 1 72px; /* shrinkable, or rows overflow the narrow-pane basis */
-  min-width: 56px;
   font-family: var(--gtfs-mono);
   font-size: 10px !important;
   color: var(--gtfs-ink-soft) !important;
 }
 .gep-stop-tools {
-  flex: 0 0 auto;
   white-space: nowrap;
 }
 .gep-stop-tools a {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -580,7 +580,7 @@ body.gtfs-page .navbar-fixed-top {
   background: #ffdd85;
   color: var(--gtfs-accent-ink);
 }
-body.gtfs-page .navbar .navbar-btn {
+.navbar .navbar-btn {
   margin-left: 6px;
 }
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -654,6 +654,9 @@ body.editing .gtfs-routes-current {
   min-height: 0;
   padding: 8px 0 8px 10px;
 }
+.gtfs-routes-scroll #newRouteBtn {
+  width: calc(100% - 10px); /* match the rows' 10px right inset */
+}
 /* Collapsed manually, or forced shut while the geometry editor runs — the
    sidebar's full height goes to the GTFS pane and its live stops list. */
 .gtfs-routes-col.collapsed .gtfs-routes-scroll,

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -222,8 +222,8 @@ nav.navbar {
 .navbar .navbar-btn,
 .navbar a.navbar-btn {
   float: none !important;
-  margin-top: 0;
-  margin-bottom: 0;
+  margin: 0; /* the flex gap spaces buttons; Bootstrap's .navbar-right
+                margin-right: -15px would overlap the first pair */
 }
 .navbar select.form-control {
   width: auto;
@@ -579,9 +579,6 @@ body.gtfs-page .navbar-fixed-top {
 .gtfs-download-btn:hover {
   background: #ffdd85;
   color: var(--gtfs-accent-ink);
-}
-.navbar .navbar-btn {
-  margin-left: 6px;
 }
 
 .gtfs-layout {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -967,6 +967,37 @@ body.editing #gtfsEditBtn {
   scrollbar-width: thin;
   padding-right: 18px;
 }
+/* Column titles for the stops list, sticky while the list scrolls. */
+.gep-stops-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 0 2px;
+  background: var(--gtfs-card);
+  border-bottom: 1px solid var(--gtfs-line);
+  font-family: var(--gtfs-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--gtfs-ink-soft);
+}
+.gep-stops-head span {
+  padding: 1px 4px; /* match the rows' input padding so labels line up */
+}
+.gep-stops-head-seq {
+  flex: 0 0 26px;
+  text-align: center;
+}
+.gep-stops-head .gep-stop-coord {
+  min-width: 56px;
+}
+.gep-stops-head .gep-stop-tools {
+  visibility: hidden; /* width-matching spacer only */
+}
 .gep-stop-row {
   display: flex;
   align-items: center;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -972,6 +972,12 @@ body.editing #gtfsEditBtn {
   align-items: center;
   gap: 4px;
   padding: 2px 0;
+  transition: background 0.6s ease;
+}
+/* Map → list echo: the row of a stop clicked in the editor. */
+.gep-stop-row.flash {
+  background: rgba(255, 209, 102, 0.5);
+  transition: none;
 }
 .gep-stop-row + .gep-stop-row {
   border-top: 1px dotted var(--gtfs-line);

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -542,9 +542,20 @@ body.gtfs-page #stopImagePanel {
    or a route code. The departures field reads like a departure board.
    ==================================================================== */
 body.gtfs-page {
-  height: 100%;
+  height: 100vh;
   overflow: hidden;
   background: var(--gtfs-paper);
+  /* Flex column with an in-flow navbar: when the many workbench buttons wrap
+     onto a second row on narrow windows, the layout starts below them instead
+     of being painted over (the fixed navbar assumed exactly 50px). */
+  display: flex;
+  flex-direction: column;
+  padding-top: 0;
+}
+body.gtfs-page .navbar-fixed-top {
+  position: static;
+  flex: 0 0 auto;
+  margin-bottom: 0;
 }
 .gtfs-brand-tag {
   display: inline-block;
@@ -575,7 +586,8 @@ body.gtfs-page .navbar .navbar-btn {
 
 .gtfs-layout {
   display: flex;
-  height: calc(100vh - 50px); /* below the fixed navbar */
+  flex: 1 1 auto; /* the space left under the (in-flow) navbar */
+  min-height: 0;
 }
 
 /* --- Sidebar (route list stacked above the GTFS pane) ----------------- */
@@ -1477,10 +1489,12 @@ body.editing #gtfsEditBtn {
 @media (max-width: 820px) {
   body.gtfs-page {
     overflow: auto;
+    height: auto;
+    min-height: 100vh;
   }
   .gtfs-layout {
     flex-direction: column;
-    height: auto;
+    flex: none; /* grow with the stacked content; the body scrolls */
   }
   .gtfs-sidebar {
     display: contents; /* children rejoin the column flex below */

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -28,13 +28,11 @@ APP.BusMap = class {
       this.routeManager,
       this.infoManager
     );
-    this.stopImageManager = new APP.StopImageManager(this.editorManager);
 
     this.locationTracker.init();
     this.routeManager.init();
     this.infoManager.init();
     this.editorManager.init();
-    this.stopImageManager.init();
   }
 
   /**

--- a/static/js/editor-manager.js
+++ b/static/js/editor-manager.js
@@ -343,7 +343,13 @@ APP.EditorManager = class {
   /** In rename/delete tools, act on the stop under the click. */
   _handleClick(e) {
     if (!this.active) return;
-    if (this.tool !== "rename" && this.tool !== "delete") return;
+    if (
+      this.tool !== "rename" &&
+      this.tool !== "delete" &&
+      this.tool !== "move"
+    ) {
+      return; // drawline/addstop: a click means "draw here", not "inspect"
+    }
     let stop = null;
     let line = null;
     this.map.forEachFeatureAtPixel(
@@ -355,6 +361,13 @@ APP.EditorManager = class {
       },
       { hitTolerance: 6, layerFilter: (l) => l === this.layer }
     );
+    // Surface the clicked stop in the workbench's stops list (no-op on the
+    // main map page, whose route manager has no such hook). Not for delete —
+    // the row is about to disappear.
+    if (stop && this.tool !== "delete" && this.routeManager.highlightStop) {
+      this.routeManager.highlightStop(stop);
+    }
+    if (this.tool === "move") return;
     if (this.tool === "rename") {
       if (!stop) return;
       const name = window.prompt("Rename stop:", stop.get("name") || "");

--- a/static/js/editor-manager.js
+++ b/static/js/editor-manager.js
@@ -234,7 +234,10 @@ APP.EditorManager = class {
         this.routeManager.setRouteDisplayName(this.year, this.file, this.routeName, this.kind);
         const ext = this.source.getExtent();
         if (ext && isFinite(ext[0])) {
-          this.map.getView().fit(ext, { padding: [60, 60, 60, 60], maxZoom: 17, duration: 400 });
+          // On /gtfs the timing panel may dock over the map's right edge.
+          const timing = $("#timingPanel");
+          const padRight = timing.is(":visible") ? timing.outerWidth() + 40 : 60;
+          this.map.getView().fit(ext, { padding: [60, padRight, 60, 60], maxZoom: 17, duration: 400 });
         }
         this.undoStack = [this._serialize()];
         this.redoStack = [];

--- a/static/js/editor-manager.js
+++ b/static/js/editor-manager.js
@@ -35,6 +35,7 @@ APP.EditorManager = class {
     this.undoStack = [];
     this.redoStack = [];
     this._suppressSnapshot = false;
+    this._seq = 0; // feature creation counter (stable ordering)
   }
 
   init() {
@@ -247,11 +248,16 @@ APP.EditorManager = class {
   }
 
   _buildFeatures(geom) {
+    // Stamp creation order: the vector source's own iteration order is its
+    // R-tree (spatial index), which shuffles as features move — serializing
+    // or listing in that order scrambles the stop sequence.
     this.source.clear();
+    this._seq = 0;
     geom.segments.forEach((seg) => {
       const coords = seg.map((p) => APP.MapUtils.toOL(p));
       const f = new ol.Feature(new ol.geom.LineString(coords));
       f.set("kind", "line");
+      f.set("seq", this._seq++);
       this.source.addFeature(f);
     });
     if (this.kind !== "geojson") {
@@ -260,15 +266,24 @@ APP.EditorManager = class {
         f.set("kind", "stop");
         f.set("name", s.name || "");
         f.set("code", s.code || ""); // public stop number (GTFS stop_code)
+        f.set("seq", this._seq++);
         this.source.addFeature(f);
       });
     }
   }
 
+  /** Source features in creation order (see _buildFeatures). */
+  orderedFeatures() {
+    return this.source
+      .getFeatures()
+      .slice()
+      .sort((a, b) => (a.get("seq") || 0) - (b.get("seq") || 0));
+  }
+
   _serialize() {
     const segments = [];
     const stops = [];
-    this.source.forEachFeature((f) => {
+    this.orderedFeatures().forEach((f) => {
       const geom = f.getGeometry();
       if (f.get("kind") === "line") {
         segments.push(
@@ -325,6 +340,7 @@ APP.EditorManager = class {
     this.draw.on("drawend", (e) => {
       const f = e.feature;
       f.set("kind", "stop");
+      f.set("seq", this._seq++); // new stops join the end of the sequence
       const name = window.prompt("Stop name:", "");
       f.set("name", name == null ? "" : name);
       // snapshot after the feature is committed to the source
@@ -334,6 +350,7 @@ APP.EditorManager = class {
     this.drawLine = new ol.interaction.Draw({ source: this.source, type: "LineString" });
     this.drawLine.on("drawend", (e) => {
       e.feature.set("kind", "line");
+      e.feature.set("seq", this._seq++);
       setTimeout(() => this._snapshot(), 0);
     });
 

--- a/static/js/editor-manager.js
+++ b/static/js/editor-manager.js
@@ -290,8 +290,36 @@ APP.EditorManager = class {
   // --- Tools / interactions --------------------------------------------------
 
   _addInteractions() {
-    this.modify = new ol.interaction.Modify({ source: this.source });
+    // A stop snapped onto the line sits exactly on a vertex/segment, and one
+    // Modify over the whole source would drag both together. Split: Translate
+    // moves stops (whole points), Modify handles the line but stands down
+    // whenever the pointer is over a stop.
+    const stopAtPixel = (e) => {
+      let hit = false;
+      this.map.forEachFeatureAtPixel(
+        e.pixel,
+        (f) => {
+          if (f.get("kind") === "stop") {
+            hit = true;
+            return true;
+          }
+        },
+        { hitTolerance: 8, layerFilter: (l) => l === this.layer }
+      );
+      return hit;
+    };
+    this.modify = new ol.interaction.Modify({
+      source: this.source,
+      condition: (e) => !stopAtPixel(e),
+    });
     this.modify.on("modifyend", () => this._snapshot());
+
+    this.translate = new ol.interaction.Translate({
+      layers: [this.layer],
+      filter: (f) => f.get("kind") === "stop",
+      hitTolerance: 8,
+    });
+    this.translate.on("translateend", () => this._snapshot());
 
     this.draw = new ol.interaction.Draw({ source: this.source, type: "Point" });
     this.draw.on("drawend", (e) => {
@@ -310,8 +338,10 @@ APP.EditorManager = class {
     });
 
     this.snap = new ol.interaction.Snap({ source: this.source }); // add last
-    [this.modify, this.draw, this.drawLine, this.snap].forEach((i) =>
-      this.map.addInteraction(i)
+    // Translate after Modify: later interactions see events first, so a
+    // grabbed stop never reaches the line editor.
+    [this.modify, this.translate, this.draw, this.drawLine, this.snap].forEach(
+      (i) => this.map.addInteraction(i)
     );
 
     // Rename/Delete act directly on the stop clicked — more reliable than a
@@ -321,12 +351,14 @@ APP.EditorManager = class {
   }
 
   _removeInteractions() {
-    [this.modify, this.draw, this.drawLine, this.snap].forEach((i) => {
-      if (i) this.map.removeInteraction(i);
-    });
+    [this.modify, this.translate, this.draw, this.drawLine, this.snap].forEach(
+      (i) => {
+        if (i) this.map.removeInteraction(i);
+      }
+    );
     if (this._onClick) this.map.un("singleclick", this._onClick);
     this._onClick = null;
-    this.modify = this.draw = this.drawLine = this.snap = null;
+    this.modify = this.translate = this.draw = this.drawLine = this.snap = null;
   }
 
   setTool(tool) {
@@ -334,6 +366,7 @@ APP.EditorManager = class {
     if (this.kind === "geojson" && tool === "addstop") tool = "move";
     this.tool = tool;
     if (this.modify) this.modify.setActive(tool === "move");
+    if (this.translate) this.translate.setActive(tool === "move");
     if (this.draw) this.draw.setActive(tool === "addstop");
     if (this.drawLine) this.drawLine.setActive(tool === "drawline");
     $(".ed-tool").removeClass("active");

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -305,6 +305,10 @@ APP.GtfsEditorManager = class {
     }
     hint.text(note).toggle(!!note);
     const editable = this._stopsEditable();
+    // Reorder/remove only inside the editor session, where they go through
+    // its undo stack and explicit Save. Outside it the list still allows
+    // name/code/coord edits (autosaved as versions), but not structure.
+    const showTools = live;
     // Column titles, sticky atop the scrolling list. Reuses the rows' column
     // classes (flex bases) so the labels line up with the inputs; the hidden
     // tools clone keeps Lat/Lon aligned when rows carry ↑↓✕.
@@ -314,7 +318,7 @@ APP.GtfsEditorManager = class {
     head.append($('<span class="gep-stop-name">Name</span>'));
     head.append($('<span class="gep-stop-coord">Lat</span>'));
     head.append($('<span class="gep-stop-coord">Lon</span>'));
-    if (editable) {
+    if (showTools) {
       head.append(
         $('<span class="gep-stop-tools" aria-hidden="true"><a>↑</a><a>↓</a><a>✕</a></span>')
       );
@@ -345,7 +349,7 @@ APP.GtfsEditorManager = class {
           .val(s.lon.toFixed(6))
           .prop("disabled", !editable)
       );
-      if (editable) {
+      if (showTools) {
         const tools = $('<span class="gep-stop-tools"></span>');
         tools.append($('<a class="gep-stop-up" title="Move earlier">↑</a>'));
         tools.append($('<a class="gep-stop-down" title="Move later">↓</a>'));
@@ -1284,34 +1288,24 @@ APP.GtfsEditorManager = class {
       else this.geom.stops[i].lon = v;
       this._queueStopsSave();
     });
+    // Structural changes only inside the editor session (undo + explicit
+    // Save); the tools don't render otherwise, this guards stale DOM.
     stopsList.on("click", ".gep-stop-up, .gep-stop-down", (e) => {
+      if (!this._liveSource) return;
       const i = this._stopAt(e.currentTarget);
       if (i == null) return;
       const j = $(e.currentTarget).hasClass("gep-stop-up") ? i - 1 : i + 1;
-      if (this._liveSource) {
-        this._liveReorder(i, j);
-        return;
-      }
-      const stops = this.geom.stops;
-      if (j < 0 || j >= stops.length) return;
-      [stops[i], stops[j]] = [stops[j], stops[i]];
-      this._renderStops();
-      this._queueStopsSave();
+      this._liveReorder(i, j);
     });
     stopsList.on("click", ".gep-stop-del", (e) => {
+      if (!this._liveSource) return;
       const i = this._stopAt(e.currentTarget);
       if (i == null) return;
-      if (this._liveSource) {
-        const f = this._liveStopFeatures()[i];
-        if (f) {
-          this._liveSource.removeFeature(f);
-          this.page.editorManager._snapshot();
-        }
-        return;
+      const f = this._liveStopFeatures()[i];
+      if (f) {
+        this._liveSource.removeFeature(f);
+        this.page.editorManager._snapshot();
       }
-      this.geom.stops.splice(i, 1);
-      this._renderStops();
-      this._queueStopsSave();
     });
   }
 };

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -211,6 +211,22 @@ APP.GtfsEditorManager = class {
     this.routeLabel.textContent = label;
   }
 
+  /** Pane state for a brand-new route being drawn (no file, no meta yet —
+   * the form attaches once the editor Save creates the route). */
+  beginNewRoute(name) {
+    // Flush pending saves so they land on the route we're leaving.
+    if (this._saveTimer) {
+      clearTimeout(this._saveTimer);
+      this._saveTimer = null;
+      this._saveMeta();
+    }
+    this._flushStopsSave();
+    this.clearRoute();
+    this.routeLabel.textContent = name || "New route";
+    this.status.classList.add("hint");
+    this.status.textContent = "new route — draw line & stops, Save to keep";
+  }
+
   clearRoute() {
     if (this._saveTimer) {
       clearTimeout(this._saveTimer);

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -305,6 +305,21 @@ APP.GtfsEditorManager = class {
     }
     hint.text(note).toggle(!!note);
     const editable = this._stopsEditable();
+    // Column titles, sticky atop the scrolling list. Reuses the rows' column
+    // classes (flex bases) so the labels line up with the inputs; the hidden
+    // tools clone keeps Lat/Lon aligned when rows carry ↑↓✕.
+    const head = $('<div class="gep-stops-head"></div>');
+    head.append($('<span class="gep-stops-head-seq">#</span>'));
+    head.append($('<span class="gep-stop-code">Code</span>'));
+    head.append($('<span class="gep-stop-name">Name</span>'));
+    head.append($('<span class="gep-stop-coord">Lat</span>'));
+    head.append($('<span class="gep-stop-coord">Lon</span>'));
+    if (editable) {
+      head.append(
+        $('<span class="gep-stop-tools" aria-hidden="true"><a>↑</a><a>↓</a><a>✕</a></span>')
+      );
+    }
+    list.append(head);
     stops.forEach((s, i) => {
       const row = $('<div class="gep-stop-row"></div>').attr("data-i", i);
       row.append(

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -309,20 +309,18 @@ APP.GtfsEditorManager = class {
     // its undo stack and explicit Save. Outside it the list still allows
     // name/code/coord edits (autosaved as versions), but not structure.
     const showTools = live;
+    // Head and rows are grids on one shared template (--gep-stop-cols in the
+    // CSS); this class picks the edit-mode template with the extra ↑↓✕ track,
+    // and the head simply leaves that last cell empty.
+    list.toggleClass("gep-has-tools", showTools);
     // Column titles, sticky atop the scrolling list. Reuses the rows' column
-    // classes (flex bases) so the labels line up with the inputs; the hidden
-    // tools clone keeps Lat/Lon aligned when rows carry ↑↓✕.
+    // classes so each label sits in the same grid track as its inputs.
     const head = $('<div class="gep-stops-head"></div>');
     head.append($('<span class="gep-stops-head-seq">#</span>'));
     head.append($('<span class="gep-stop-code">Code</span>'));
     head.append($('<span class="gep-stop-name">Name</span>'));
     head.append($('<span class="gep-stop-coord">Lat</span>'));
     head.append($('<span class="gep-stop-coord">Lon</span>'));
-    if (showTools) {
-      head.append(
-        $('<span class="gep-stop-tools" aria-hidden="true"><a>↑</a><a>↓</a><a>✕</a></span>')
-      );
-    }
     list.append(head);
     stops.forEach((s, i) => {
       const row = $('<div class="gep-stop-row"></div>').attr("data-i", i);

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -144,7 +144,13 @@ APP.GtfsEditorManager = class {
 
   _liveStopFeatures() {
     if (!this._liveSource) return [];
-    return this._liveSource.getFeatures().filter((f) => f.get("kind") === "stop");
+    // getFeatures() iterates the source's R-tree, whose order shuffles as
+    // features move — sort by the editor's creation stamp so the list matches
+    // the saved stop sequence (and row indexes are stable across drags).
+    return this._liveSource
+      .getFeatures()
+      .filter((f) => f.get("kind") === "stop")
+      .sort((a, b) => (a.get("seq") || 0) - (b.get("seq") || 0));
   }
 
   /** Update one row's inputs in place during a drag (no re-render, no focus loss). */

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -16,6 +16,7 @@ APP.GtfsEditorManager = class {
     this._feedTimer = null;
     this._stopsTimer = null;
     this._populating = false; // suppress autosave while filling the form
+    this._timingDismissed = false; // user closed the timing panel this session
   }
 
   init() {
@@ -826,6 +827,8 @@ APP.GtfsEditorManager = class {
     if (!year || !file) {
       this.timingImg.style.display = "none";
       this.timingEmpty.style.display = "";
+      // No signboard — an empty floating window is just clutter.
+      this._setTimingPanelVisible(false);
       return;
     }
     this.timingEmpty.style.display = "none";
@@ -836,6 +839,30 @@ APP.GtfsEditorManager = class {
       "/" +
       encodeURIComponent(file);
     this._setZoom(1);
+    if (!this._timingDismissed) this._setTimingPanelVisible(true);
+  }
+
+  /** The timing panel floats over the map (see gtfs.html). Auto-shown when a
+   * route has a signboard, auto-hidden when not; ✕ dismisses for the session
+   * and the navbar 🕐 toggle brings it back. */
+  _setTimingPanelVisible(show) {
+    const panel = document.getElementById("timingPanel");
+    if (!panel) return;
+    // Phones: the panel would overlay everything — only the toggle opens it.
+    if (show && window.matchMedia("(max-width: 820px)").matches) return;
+    panel.style.display = show ? "flex" : "none";
+  }
+
+  _toggleTimingPanel() {
+    const panel = document.getElementById("timingPanel");
+    if (!panel) return;
+    if (panel.style.display === "flex") {
+      this._timingDismissed = true;
+      panel.style.display = "none";
+    } else {
+      this._timingDismissed = false;
+      panel.style.display = "flex"; // explicit open bypasses the phone guard
+    }
   }
 
   _setZoom(z) {
@@ -1080,6 +1107,19 @@ APP.GtfsEditorManager = class {
     $("#gepDownload").on("click", () => this._download());
     $("#gepValidate").on("click", () => this._validate());
     $("#gepPreview").on("click", () => this._preview());
+    $("#timingToggle").on("click", () => this._toggleTimingPanel());
+    $("#timingClose").on("click", () => {
+      this._timingDismissed = true;
+      this._setTimingPanelVisible(false);
+    });
+    const timingPanel = document.getElementById("timingPanel");
+    if (timingPanel) {
+      APP.MapUtils.makeFloatingPanel(
+        timingPanel,
+        document.getElementById("timingPanelHeader"),
+        document.getElementById("timingResize")
+      );
+    }
     $("#previewRefresh").on("click", () => this._preview());
     $("#previewTabs").on("click", ".gep-preview-tab", (e) => {
       this._showPreviewFile($(e.currentTarget).attr("data-file"));

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -165,6 +165,23 @@ APP.GtfsEditorManager = class {
     set(".gep-stop-code", feature.get("code") || "");
   }
 
+  /** Map → list: flash and scroll to the row of a stop clicked in the editor
+   * (the counterpart of the row's ① chip, which pans the map to the stop). */
+  highlightStopFeature(feature) {
+    const i = this._liveStopFeatures().indexOf(feature);
+    if (i < 0) return;
+    const rows = $("#gepStopsList .gep-stop-row");
+    rows.removeClass("flash");
+    const row = rows.eq(i);
+    if (!row.length) return;
+    row[0].scrollIntoView({ block: "nearest" });
+    // Force a reflow so re-clicking the same stop restarts the fade.
+    void row[0].offsetWidth;
+    row.addClass("flash");
+    clearTimeout(this._flashTimer);
+    this._flashTimer = setTimeout(() => row.removeClass("flash"), 1600);
+  }
+
   /** Stops as plain data, from the live editor session or saved geometry. */
   _stopsData() {
     if (this._liveSource) {

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -960,7 +960,7 @@ APP.GtfsEditorManager = class {
     $("#validateList").empty();
     $("#validateModal").modal("show");
     fetch(`/data/gtfs-validate${year ? "?year=" + encodeURIComponent(year) : ""}`)
-      .then((r) => r.json())
+      .then((r) => r.json().catch(() => ({ error: `request failed (HTTP ${r.status})` })))
       .then((d) => {
         if (d.error) {
           $("#validateSummary").addClass("err").text(d.error);
@@ -1066,7 +1066,9 @@ APP.GtfsEditorManager = class {
     $("#previewSummary").text("Building feed…");
     $("#previewModal").modal("show");
     fetch(`/data/gtfs-preview${year ? "?year=" + encodeURIComponent(year) : ""}`)
-      .then((r) => r.json())
+      // Error statuses normally carry a JSON {error}; if the body isn't JSON
+      // (e.g. an HTML 404 page), report the status instead of a parse throw.
+      .then((r) => r.json().catch(() => ({ error: `request failed (HTTP ${r.status})` })))
       .then((d) => {
         if (d.error) {
           $("#previewSummary").text(d.error);

--- a/static/js/gtfs-page.js
+++ b/static/js/gtfs-page.js
@@ -43,10 +43,19 @@ APP.GtfsPage = class {
 
     $("#gtfsEditBtn").on("click", () => this.editSelected());
     // Brand-new routes enter the editor without hideRouteForEdit firing
-    // (no file yet) — engage the live stops list after the editor opens.
-    // (EditorManager bound these first, so it runs before us.)
+    // (no file yet). The pane must stop showing — and saving meta for — the
+    // previously selected route: clear the selection, mark the pane as "new
+    // route", then engage the live stops list against the fresh session.
+    // (EditorManager bound these first, so it runs before us; the guard
+    // covers a cancelled name prompt.)
     $("#newRouteBtn, #sipCreate").on("click", () =>
-      setTimeout(() => this.gtfsEditor.enterLive(), 0)
+      setTimeout(() => {
+        const em = this.editorManager;
+        if (!em.active || !em.creating) return;
+        this.clearSelection();
+        this.gtfsEditor.beginNewRoute(em.routeName);
+        this.gtfsEditor.enterLive();
+      }, 0)
     );
     // The route list shares the sidebar with the GTFS pane — collapsible so
     // the pane can take the full height (forced shut while editing, via CSS).
@@ -223,6 +232,19 @@ APP.GtfsPage = class {
     this._loadLayer();
     this.gtfsEditor.setRoute(year, file, this.names[id], kind, this.userIds.has(id));
     $("#gtfsEditBtn").show();
+  }
+
+  /** Drop the current selection (e.g. a brand-new route is being drawn):
+   * no row highlighted, no layer on the map, no edit target. */
+  clearSelection() {
+    if (this.layer) {
+      this.map.removeLayer(this.layer);
+      this.layer = null;
+    }
+    this.selected = null;
+    $("#gtfsRouteList .gtfs-route-row").removeClass("selected");
+    $("#gtfsRoutesCurrent").text("");
+    $("#gtfsEditBtn").hide();
   }
 
   /** Pan/zoom to a stop and flash a marker over it (from the stops list). */

--- a/static/js/gtfs-page.js
+++ b/static/js/gtfs-page.js
@@ -48,6 +48,11 @@ APP.GtfsPage = class {
     $("#newRouteBtn, #sipCreate").on("click", () =>
       setTimeout(() => this.gtfsEditor.enterLive(), 0)
     );
+    // The route list shares the sidebar with the GTFS pane — collapsible so
+    // the pane can take the full height (forced shut while editing, via CSS).
+    $("#gtfsRoutesHead").on("click", () =>
+      $(".gtfs-routes-col").toggleClass("collapsed")
+    );
     const list = $("#gtfsRouteList");
     list.on("click", ".gtfs-route-row", (e) => {
       if ($(e.target).closest(".gtfs-route-del").length) return;
@@ -201,6 +206,8 @@ APP.GtfsPage = class {
     $("#gtfsRouteList .gtfs-route-row").removeClass("selected");
     const row = this._rowFor(id).addClass("selected");
     if (row.length) row[0].scrollIntoView({ block: "nearest" });
+    // Collapsed-list header carries the selection.
+    $("#gtfsRoutesCurrent").text(this.names[id] || "");
     this._loadLayer();
     this.gtfsEditor.setRoute(year, file, this.names[id], kind, this.userIds.has(id));
     $("#gtfsEditBtn").show();
@@ -259,8 +266,13 @@ APP.GtfsPage = class {
       if (source.getState() === "ready" && source.getFeatures().length) {
         const ext = source.getExtent();
         if (ext && isFinite(ext[0])) {
+          // Keep the fitted route clear of the timing panel docked on the
+          // map's right edge.
+          const timing = $("#timingPanel");
+          const padRight =
+            timing.is(":visible") ? timing.outerWidth() + 40 : 60;
           this.map.getView().fit(ext, {
-            padding: [60, 60, 60, 60],
+            padding: [60, padRight, 60, 60],
             maxZoom: 16,
             duration: 400,
           });
@@ -347,7 +359,13 @@ APP.GtfsPage = class {
     // Editor is taking over: the stops list goes live against its session.
     // Deferred, because EditorManager.enter() calls this BEFORE it creates
     // its editing source — binding now would find nothing to mirror.
-    setTimeout(() => this.gtfsEditor.enterLive(), 0);
+    setTimeout(() => {
+      this.gtfsEditor.enterLive();
+      // The route list collapses while editing (CSS) — bring the live stops
+      // list into view, since it's the map editor's mirror.
+      const stops = document.getElementById("gepStopsSection");
+      if (stops) stops.scrollIntoView({ block: "start" });
+    }, 0);
   }
 
   showRouteAfterEdit(year, file) {
@@ -370,6 +388,7 @@ APP.GtfsPage = class {
     this._rowFor(id).find(".gtfs-route-label").text(this.names[id]);
     if (this.selected && this.selected.id === id) {
       this.gtfsEditor.setLabel(this.names[id]);
+      $("#gtfsRoutesCurrent").text(this.names[id]);
     }
   }
 

--- a/static/js/gtfs-page.js
+++ b/static/js/gtfs-page.js
@@ -144,12 +144,11 @@ APP.GtfsPage = class {
     const row = this._rowFor(this._id(year, file));
     if (!row.length) return;
     let meter = row.find(".gtfs-route-meter");
-    const flags = ["schedule", "departures", "operator", "headsign"];
     if (!meter.length) {
-      meter = $('<span class="gtfs-route-meter"></span>');
-      flags.forEach(() => meter.append("<i></i>"));
+      meter = this._meterEl();
       row.find(".gtfs-route-label").after(meter);
     }
+    const flags = ["schedule", "departures", "operator", "headsign"];
     meter.children().each((i, el) => {
       $(el).toggleClass("on", !!(st && st[flags[i]]));
     });
@@ -158,6 +157,16 @@ APP.GtfsPage = class {
       "transcribed: " +
         flags.map((f) => `${f} ${st && st[f] ? "✓" : "—"}`).join(" · ")
     );
+  }
+
+  /** A fresh all-off transcription meter (4 segments). */
+  _meterEl() {
+    const meter = $('<span class="gtfs-route-meter"></span>').attr(
+      "title",
+      "transcribed: schedule — · departures — · operator — · headsign —"
+    );
+    for (let i = 0; i < 4; i++) meter.append("<i></i>");
+    return meter;
   }
 
   _row(id, year, file, display, isUser, kind) {
@@ -172,6 +181,9 @@ APP.GtfsPage = class {
     if (kind === "geojson") row.addClass("path");
     row.append($('<span class="gtfs-route-chip"></span>').text(code));
     row.append($('<span class="gtfs-route-label"></span>').text(display));
+    // Every schedulable route shows its transcription meter up front (all-off
+    // until the meta summary fills it in). Paths can't carry GTFS meta.
+    if (kind !== "geojson") row.append(this._meterEl());
     if (isUser) {
       row.append($('<a class="gtfs-route-del" title="Delete route">✕</a>'));
     }

--- a/static/js/gtfs-page.js
+++ b/static/js/gtfs-page.js
@@ -382,6 +382,11 @@ APP.GtfsPage = class {
     }
   }
 
+  /** Map → list: a stop clicked in the editor flashes its row in the pane. */
+  highlightStop(feature) {
+    this.gtfsEditor.highlightStopFeature(feature);
+  }
+
   setRouteDisplayName(year, file, name) {
     const id = this._id(year, file);
     this.names[id] = name || file.replace(/\.kml$/, "");

--- a/static/js/stop-image-manager.js
+++ b/static/js/stop-image-manager.js
@@ -213,60 +213,10 @@ APP.StopImageManager = class {
     $("#sipFit").on("click", () => this._setZoom(1));
     $("#sipCreate").on("click", () => this._createRoute());
     $(this.notes).on("input", () => this._queueSave());
-    this._enableDrag();
-    this._enableResize();
-  }
-
-  _enableDrag() {
-    const header = document.getElementById("stopImageHeader");
-    let sx, sy, sl, st, dragging = false;
-    const onMove = (e) => {
-      if (!dragging) return;
-      this.panel.style.left = sl + (e.clientX - sx) + "px";
-      this.panel.style.top = st + (e.clientY - sy) + "px";
-      this.panel.style.right = "auto";
-    };
-    const onUp = () => {
-      dragging = false;
-      document.removeEventListener("mousemove", onMove);
-      document.removeEventListener("mouseup", onUp);
-    };
-    header.addEventListener("mousedown", (e) => {
-      // Don't start a drag when interacting with the header controls.
-      if (e.target.closest("button, select")) return;
-      const r = this.panel.getBoundingClientRect();
-      sx = e.clientX; sy = e.clientY; sl = r.left; st = r.top;
-      this.panel.style.left = r.left + "px";
-      this.panel.style.top = r.top + "px";
-      this.panel.style.right = "auto";
-      dragging = true;
-      document.addEventListener("mousemove", onMove);
-      document.addEventListener("mouseup", onUp);
-      e.preventDefault();
-    });
-  }
-
-  _enableResize() {
-    const handle = document.getElementById("stopImageResize");
-    let sx, sy, sw, sh, resizing = false;
-    const onMove = (e) => {
-      if (!resizing) return;
-      this.panel.style.width = Math.max(220, sw + (e.clientX - sx)) + "px";
-      this.panel.style.height = Math.max(200, sh + (e.clientY - sy)) + "px";
-    };
-    const onUp = () => {
-      resizing = false;
-      document.removeEventListener("mousemove", onMove);
-      document.removeEventListener("mouseup", onUp);
-    };
-    handle.addEventListener("mousedown", (e) => {
-      const r = this.panel.getBoundingClientRect();
-      sx = e.clientX; sy = e.clientY; sw = r.width; sh = r.height;
-      resizing = true;
-      document.addEventListener("mousemove", onMove);
-      document.addEventListener("mouseup", onUp);
-      e.preventDefault();
-      e.stopPropagation();
-    });
+    APP.MapUtils.makeFloatingPanel(
+      this.panel,
+      document.getElementById("stopImageHeader"),
+      document.getElementById("stopImageResize")
+    );
   }
 };

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -27,4 +27,60 @@ APP.MapUtils = {
   handleError: function (error, context) {
     console.error(`Error in ${context}:`, error);
   },
+
+  /**
+   * Make a panel float: draggable by its header, resizable from a corner
+   * handle. Shared by the Official-stops and Timing signboard panels.
+   * @param {HTMLElement} panel
+   * @param {HTMLElement} header drag handle (clicks on button/select ignored)
+   * @param {HTMLElement} [resizeHandle] corner resize grip
+   */
+  makeFloatingPanel: function (panel, header, resizeHandle) {
+    let sx, sy, sl, st, dragging = false;
+    const onDragMove = (e) => {
+      if (!dragging) return;
+      panel.style.left = sl + (e.clientX - sx) + "px";
+      panel.style.top = st + (e.clientY - sy) + "px";
+      panel.style.right = "auto";
+    };
+    const onDragUp = () => {
+      dragging = false;
+      document.removeEventListener("mousemove", onDragMove);
+      document.removeEventListener("mouseup", onDragUp);
+    };
+    header.addEventListener("mousedown", (e) => {
+      // Don't start a drag when interacting with the header controls.
+      if (e.target.closest("button, select")) return;
+      const r = panel.getBoundingClientRect();
+      sx = e.clientX; sy = e.clientY; sl = r.left; st = r.top;
+      panel.style.left = r.left + "px";
+      panel.style.top = r.top + "px";
+      panel.style.right = "auto";
+      dragging = true;
+      document.addEventListener("mousemove", onDragMove);
+      document.addEventListener("mouseup", onDragUp);
+      e.preventDefault();
+    });
+    if (!resizeHandle) return;
+    let rx, ry, rw, rh, resizing = false;
+    const onResizeMove = (e) => {
+      if (!resizing) return;
+      panel.style.width = Math.max(220, rw + (e.clientX - rx)) + "px";
+      panel.style.height = Math.max(200, rh + (e.clientY - ry)) + "px";
+    };
+    const onResizeUp = () => {
+      resizing = false;
+      document.removeEventListener("mousemove", onResizeMove);
+      document.removeEventListener("mouseup", onResizeUp);
+    };
+    resizeHandle.addEventListener("mousedown", (e) => {
+      const r = panel.getBoundingClientRect();
+      rx = e.clientX; ry = e.clientY; rw = r.width; rh = r.height;
+      resizing = true;
+      document.addEventListener("mousemove", onResizeMove);
+      document.addEventListener("mouseup", onResizeUp);
+      e.preventDefault();
+      e.stopPropagation();
+    });
+  },
 };

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -87,6 +87,14 @@
         >
           🚏 Official stops
         </button>
+        <button
+          id="timingToggle"
+          type="button"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          title="View the official timing signboard while transcribing departures"
+        >
+          🕐 Timing
+        </button>
         <a
           href="/"
           class="btn btn-default btn-sm navbar-btn navbar-right"
@@ -107,64 +115,29 @@
     </nav>
 
     <div class="gtfs-layout">
-      <!-- One route is selected at a time: it shows on the map, is the editing
-           target, and fills the GTFS pane. -->
-      <div class="gtfs-routes-col">
-        <button
-          id="newRouteBtn"
-          type="button"
-          class="btn btn-success btn-sm btn-block"
-          style="display: none; margin-bottom: 8px"
-        >
-          + New route
-        </button>
-        <div id="gtfsRouteList"></div>
-      </div>
-
-      <!-- Map: shows the selected route; ✎ enters the full geometry editor
-           (line/stops tools, undo, history). Shipped routes edit a copy. -->
-      <div class="gtfs-map-col">
-        <div id="map"></div>
-        <button id="gtfsEditBtn" type="button" style="display: none"
-          title="Edit this route's line and stops (official routes are edited as a copy)">
-          ✎ Edit route
-        </button>
-        <div id="info">
-          <a class="btn btn-danger dismiss">X</a>
-          <h3 class="name"></h3>
-          <h5 class="location"></h5>
+      <!-- Single left sidebar: route list (collapsible) stacked above the GTFS
+           pane. One route is selected at a time: it shows on the map, is the
+           editing target, and fills the GTFS pane. -->
+      <div class="gtfs-sidebar">
+        <div class="gtfs-routes-col">
+          <div class="gtfs-routes-head" id="gtfsRoutesHead"
+            title="Collapse / expand the route list">
+            <span>Routes</span>
+            <span id="gtfsRoutesCurrent" class="gtfs-routes-current"></span>
+            <span class="gtfs-routes-caret">▾</span>
+          </div>
+          <div class="gtfs-routes-scroll">
+            <button
+              id="newRouteBtn"
+              type="button"
+              class="btn btn-success btn-sm btn-block"
+              style="display: none; margin-bottom: 8px"
+            >
+              + New route
+            </button>
+            <div id="gtfsRouteList"></div>
+          </div>
         </div>
-        <div id="editorToolbar" style="display: none">
-          <span class="ed-title">✎ <span id="edRouteName"></span></span>
-          <button type="button" class="btn btn-default btn-sm" id="edRenameRoute"
-            title="Rename this route">Rename route</button>
-          <div class="btn-group btn-group-sm" role="group">
-            <button type="button" class="btn btn-default ed-tool" id="edTool-drawline"
-              title="Draw the route line (click to add points, double-click to finish)">Line</button>
-            <button type="button" class="btn btn-default ed-tool" id="edTool-move"
-              title="Move/insert vertices &amp; stops (Alt+click a vertex to delete)">Move/Edit</button>
-            <button type="button" class="btn btn-default ed-tool" id="edTool-addstop"
-              title="Add a stop">+ Stop</button>
-            <button type="button" class="btn btn-default ed-tool" id="edTool-delete"
-              title="Delete: click a stop or line to remove it">Delete</button>
-            <button type="button" class="btn btn-default ed-tool" id="edTool-rename"
-              title="Rename: click a stop to rename it">Rename</button>
-          </div>
-          <button type="button" class="btn btn-default btn-sm" id="edReverse"
-            title="Reverse route direction">⇄ Reverse</button>
-          <div class="btn-group btn-group-sm" role="group">
-            <button type="button" class="btn btn-default" id="edUndo" title="Undo">↶</button>
-            <button type="button" class="btn btn-default" id="edRedo" title="Redo">↷</button>
-          </div>
-          <div class="btn-group btn-group-sm" role="group">
-            <button type="button" class="btn btn-primary" id="edSave">Save</button>
-            <button type="button" class="btn btn-default" id="edHistory">History</button>
-            <button type="button" class="btn btn-warning" id="edRevert">Revert</button>
-            <button type="button" class="btn btn-default" id="edExit">Exit</button>
-          </div>
-          <span id="edStatus" class="ed-status"></span>
-        </div>
-      </div>
 
       <!-- GTFS pane for the selected route. -->
       <div id="gtfsPanel">
@@ -215,23 +188,76 @@
             <div id="gepStopsHint" class="gep-empty" style="display: none"></div>
             <div id="gepStopsList"></div>
           </div>
-          <div class="gep-section gep-section-grow">
-            <div class="gep-section-head">
-              <span>Timing signboard</span>
-              <span class="gep-tools">
-                <select id="gtfsTimingSelect" class="form-control input-sm" title="Pick a timing signboard"></select>
-                <button type="button" class="btn btn-default btn-xs" id="gepZoomOut" title="Zoom out">−</button>
-                <button type="button" class="btn btn-default btn-xs" id="gepZoomIn" title="Zoom in">+</button>
-                <button type="button" class="btn btn-default btn-xs" id="gepFit" title="Fit to width">Fit</button>
-              </span>
-            </div>
-            <div id="gtfsTimingBody">
-              <img id="gtfsTimingImg" alt="Official timing signboard" style="display: none" />
-              <div id="gtfsTimingEmpty" class="gep-empty">No timing signboard for this route.</div>
-            </div>
-          </div>
         </div>
       </div>
+      </div>
+
+      <!-- Map: shows the selected route; ✎ enters the full geometry editor
+           (line/stops tools, undo, history). Shipped routes edit a copy. -->
+      <div class="gtfs-map-col">
+        <div id="map"></div>
+        <button id="gtfsEditBtn" type="button" style="display: none"
+          title="Edit this route's line and stops (official routes are edited as a copy)">
+          ✎ Edit route
+        </button>
+        <div id="info">
+          <a class="btn btn-danger dismiss">X</a>
+          <h3 class="name"></h3>
+          <h5 class="location"></h5>
+        </div>
+        <div id="editorToolbar" style="display: none">
+          <span class="ed-title">✎ <span id="edRouteName"></span></span>
+          <button type="button" class="btn btn-default btn-sm" id="edRenameRoute"
+            title="Rename this route">Rename route</button>
+          <div class="btn-group btn-group-sm" role="group">
+            <button type="button" class="btn btn-default ed-tool" id="edTool-drawline"
+              title="Draw the route line (click to add points, double-click to finish)">Line</button>
+            <button type="button" class="btn btn-default ed-tool" id="edTool-move"
+              title="Move/insert vertices &amp; stops (Alt+click a vertex to delete)">Move/Edit</button>
+            <button type="button" class="btn btn-default ed-tool" id="edTool-addstop"
+              title="Add a stop">+ Stop</button>
+            <button type="button" class="btn btn-default ed-tool" id="edTool-delete"
+              title="Delete: click a stop or line to remove it">Delete</button>
+            <button type="button" class="btn btn-default ed-tool" id="edTool-rename"
+              title="Rename: click a stop to rename it">Rename</button>
+          </div>
+          <button type="button" class="btn btn-default btn-sm" id="edReverse"
+            title="Reverse route direction">⇄ Reverse</button>
+          <div class="btn-group btn-group-sm" role="group">
+            <button type="button" class="btn btn-default" id="edUndo" title="Undo">↶</button>
+            <button type="button" class="btn btn-default" id="edRedo" title="Redo">↷</button>
+          </div>
+          <div class="btn-group btn-group-sm" role="group">
+            <button type="button" class="btn btn-primary" id="edSave">Save</button>
+            <button type="button" class="btn btn-default" id="edHistory">History</button>
+            <button type="button" class="btn btn-warning" id="edRevert">Revert</button>
+            <button type="button" class="btn btn-default" id="edExit">Exit</button>
+          </div>
+          <span id="edStatus" class="ed-status"></span>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Official timing signboard reference (floating, draggable, resizable —
+         docked over the map's right edge; the freed sidebar space goes to the
+         schedule form and stops list) -->
+    <div id="timingPanel" style="display: none">
+      <div id="timingPanelHeader">
+        <span class="sip-title">🕐 Timing</span>
+        <select id="gtfsTimingSelect" class="form-control input-sm" title="Pick a timing signboard"></select>
+        <span class="sip-tools">
+          <button type="button" class="btn btn-default btn-xs" id="gepZoomOut" title="Zoom out">−</button>
+          <button type="button" class="btn btn-default btn-xs" id="gepZoomIn" title="Zoom in">+</button>
+          <button type="button" class="btn btn-default btn-xs" id="gepFit" title="Fit to width">Fit</button>
+          <button type="button" class="btn btn-danger btn-xs" id="timingClose" title="Close">×</button>
+        </span>
+      </div>
+      <div id="gtfsTimingBody">
+        <img id="gtfsTimingImg" alt="Official timing signboard" style="display: none" />
+        <div id="gtfsTimingEmpty" class="gep-empty">No timing signboard for this route.</div>
+      </div>
+      <div id="timingResize" title="Drag to resize"></div>
     </div>
 
     <!-- Feed-wide settings: operators + flat fare (applies to the whole export). -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -65,14 +65,6 @@
         >
           ☰ Routes
         </button>
-        <button
-          id="stopImageToggle"
-          type="button"
-          class="btn btn-default btn-sm navbar-btn navbar-right"
-          title="View official stop-list signboards while building a route"
-        >
-          🚏 Official stops
-        </button>
         <a
           href="/gtfs"
           class="btn btn-default btn-sm navbar-btn navbar-right"
@@ -140,38 +132,6 @@
         </div>
         <div class="list-group" id="routes"></div>
       </div>
-      <!-- Official stop-list signboard reference (floating, draggable, resizable) -->
-      <div id="stopImagePanel" style="display: none">
-        <div id="stopImageHeader">
-          <span class="sip-title">🚏 Official stops</span>
-          <select id="stopImageSelect" class="form-control input-sm" title="Pick a route signboard"></select>
-          <span class="sip-tools">
-            <button type="button" class="btn btn-default btn-xs" id="sipZoomOut" title="Zoom out">−</button>
-            <button type="button" class="btn btn-default btn-xs" id="sipZoomIn" title="Zoom in">+</button>
-            <button type="button" class="btn btn-default btn-xs" id="sipFit" title="Fit to width">Fit</button>
-            <button type="button" class="btn btn-success btn-xs" id="sipCreate" title="Create a new route while viewing this signboard">+ Route</button>
-            <button type="button" class="btn btn-danger btn-xs" id="sipClose" title="Close">×</button>
-          </span>
-        </div>
-        <div id="stopImageBody">
-          <img id="stopImageImg" alt="Official stop list" style="display: none" />
-          <div id="stopImageEmpty" class="sip-empty">No signboard selected.</div>
-        </div>
-        <div id="stopImageNotes">
-          <div class="sip-notes-head">
-            <span>📝 Notes — <span id="stopImageNotesRoute">—</span></span>
-            <span id="stopImageNotesStatus" class="sip-notes-status"></span>
-          </div>
-          <textarea
-            id="stopImageNotesText"
-            rows="3"
-            placeholder="Notes for this route — discrepancies vs the poster, source comparisons, decisions…"
-            disabled
-          ></textarea>
-        </div>
-        <div id="stopImageResize" title="Drag to resize"></div>
-      </div>
-
       <div id="loading">Loading... <a class="btn btn-danger">X</a></div>
       <footer>
         Data via Land Transport Department docs provided for EOI for the
@@ -229,7 +189,6 @@
     <script src="{{ url_for('static', filename='js/route-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/info-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/editor-manager.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/stop-image-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
     <script src="{{ url_for('static', filename='js/ride/launcher.js') }}"></script>
   </body>


### PR DESCRIPTION
## Summary
Layout redesign (per frontend design review) plus a batch of editor fixes found while testing.

### Layout
- Single 400px left sidebar: collapsible route list stacked above the GTFS pane; collapsed (or while editing, forced) the header carries the selected route and the pane gets full height
- Timing signboard promoted to a floating, draggable, resizable panel docked over the map (auto-shows when the route has a signboard; navbar 🕐 toggle); drag/resize extracted into a shared APP.MapUtils.makeFloatingPanel
- Navbar is in-flow on the workbench so wrapped button rows can't paint over the sidebar/Edit button; flex-gap button spacing fixed on every page (Bootstrap's .navbar-right -15px margin overlapped the homepage pair)
- Official stops panel removed from the homepage — it lives on the workbench

### Stops list
- Sticky column titles (# / Code / Name / Lat / Lon); header and rows are CSS grid on one shared column template, so titles align with fields by construction
- Map → list echo: clicking a stop in the editor flashes and scrolls to its row
- Reorder/remove (↑↓✕) only inside the editor session; inline name/code/coord edits still autosave outside it
- Transcription meter visible on every schedulable route (all-off until transcribed)

### Editor fixes
- Stable stop ordering: features stamped with a creation counter; serialization no longer iterates the vector source's R-tree, which scrambled saved stop order (load-bearing for stop_times projection)
- Dragging a stop snapped onto the line no longer drags the line: Translate (stops) + Modify (line, stands down over stops)
- New route: page clears the previous selection so the pane can't keep showing — or save meta onto — the previously selected route
- Preview/validate fetches surface HTTP errors instead of JSON.parse throws

## Test plan
- [x] JS syntax-checked; /, /gtfs load; preview/validate endpoints OK
- [x] Stop order consistent between view and edit mode
- [ ] Visual pass: sidebar collapse, edit-mode flow, timing panel drag/resize, stops list alignment at narrow widths
- [ ] Mobile (<820px) stacked layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)