### PR TITLE
Trip planner: RAPTOR journey finder with 2016/my-routes sources and 3D preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,11 @@ journeys always match what a GTFS consumer of the feed would compute.
   access/egress (up to ~1 km), transfers between nearby stops, and an
   end-to-end walk when the two points are close.
 - Selecting a journey draws it on the map — colored ride legs along the real
-  route shapes, dashed walk legs — and **🚌 3D preview** rides the whole
-  journey end-to-end in either 3D engine (Three.js or MapLibre), walks
-  included.
+  route shapes, dashed walk legs that follow real roads (via the public OSM
+  foot router, falling back to straight lines offline) — and **🚌 3D preview**
+  rides the whole journey end-to-end in either 3D engine. Walked stretches
+  swap the bus for a pedestrian: an animated 3D person in Three.js, a 🚶
+  marker in MapLibre.
 
 Routes without transcribed departures plan against their synthetic headway
 (default: every 30 min, 06:00–20:00), so waits and arrival times are nominal

--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ journeys always match what a GTFS consumer of the feed would compute.
   or **My routes** (the routes you drew and scheduled in the GTFS workbench).
 - Set start (A) and destination (B) by clicking the map or typing a stop name;
   pick a departure time and day of travel.
+- Every planned search lands in a **Recent trips** list (persisted in the
+  browser, deduped, newest first) — click one to make it the active trip
+  again, ✕ to remove it, or clear them all. One trip is active at a time;
+  the ✕ next to Plan trip clears the current search.
 - Results are the Pareto set over arrival time vs. transfers: each extra
   transfer is only offered when it strictly arrives earlier. Walking covers
   access/egress (up to ~1 km), transfers between nearby stops, and an

--- a/README.md
+++ b/README.md
@@ -219,6 +219,31 @@ and a field-to-GTFS reference.
 Edits auto-save to the local SQLite store (`instance/edits.db`) and are merged
 into every subsequent export from both the endpoint and the CLI.
 
+## Trip Planner
+
+The trip planner (`/planner`, 🧭 Planner in the navbar) answers point-to-point
+journey queries — where to board, which routes to ride, where to transfer —
+using the [RAPTOR](https://www.microsoft.com/en-us/research/publication/round-based-public-transit-routing/)
+algorithm over the same in-memory GTFS feed the export emits, so planned
+journeys always match what a GTFS consumer of the feed would compute.
+
+- **Two data sources**, switchable in the sidebar: the **2016 official** dataset
+  or **My routes** (the routes you drew and scheduled in the GTFS workbench).
+- Set start (A) and destination (B) by clicking the map or typing a stop name;
+  pick a departure time and day of travel.
+- Results are the Pareto set over arrival time vs. transfers: each extra
+  transfer is only offered when it strictly arrives earlier. Walking covers
+  access/egress (up to ~1 km), transfers between nearby stops, and an
+  end-to-end walk when the two points are close.
+- Selecting a journey draws it on the map — colored ride legs along the real
+  route shapes, dashed walk legs — and **🚌 3D preview** rides the whole
+  journey end-to-end in either 3D engine (Three.js or MapLibre), walks
+  included.
+
+Routes without transcribed departures plan against their synthetic headway
+(default: every 30 min, 06:00–20:00), so waits and arrival times are nominal
+until real timetables are transcribed in the workbench.
+
 ## Technologies Used
 
 - [Flask](https://flask.palletsprojects.com/) — Python web server
@@ -232,9 +257,8 @@ into every subsequent export from both the endpoint and the CLI.
 Recommended features that would enhance the app, in rough order of impact and
 feasibility:
 
-1. **Journey Planner** (highest impact) — route planning between any two points,
-   multiple route options with transfer points, walking directions to/from
-   stops, and journey time and fare estimates.
+1. ~~**Journey Planner**~~ — done: see [Trip Planner](#trip-planner). Remaining
+   ideas: fare estimates and richer alternatives (e.g. depart-later options).
 2. **Enhanced Bus Stop Information** — comprehensive stop database,
    arrival/departure schedules, stop amenities, and photos and accessibility
    details. (A frequency-based [GTFS export](#gtfs-export) already exists; real
@@ -246,9 +270,9 @@ feasibility:
 5. **Community Features** — user reviews/ratings, issue reporting, service
    feedback, and crowdsourced updates.
 
-The journey planner would be the most valuable addition: it would transform the
-app from an informational tool into a practical trip-planning solution,
-significantly improving its utility for daily commuters and tourists alike.
+With the journey planner in place, transcribing real timetables (item 2) is now
+the highest-value work: planned waits and arrival times are only as good as the
+schedules behind them.
 
 ## Credits
 

--- a/app.py
+++ b/app.py
@@ -78,6 +78,22 @@ os.makedirs(app.instance_path, exist_ok=True)
 db.init_db(os.path.join(app.instance_path, "edits.db"))
 
 
+@app.context_processor
+def _asset_version():
+    """Cache-buster for our own static assets: templates append ?v={{ asset_v }}
+    so browsers re-fetch JS/CSS whenever any of it changes on disk."""
+    latest = 0
+    for sub in ("js", "css"):
+        base = os.path.join(app.static_folder, sub)
+        for root, _dirs, files in os.walk(base):
+            for f in files:
+                try:
+                    latest = max(latest, int(os.path.getmtime(os.path.join(root, f))))
+                except OSError:
+                    continue
+    return {"asset_v": latest}
+
+
 def _available_years():
     """Year folders under static/data that hold a routes.json (sorted)."""
     base = os.path.join(app.static_folder, "data")

--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from xml.sax.saxutils import escape as _xml_escape
 
 import db
 import gtfs
+import planner
 
 # Prefer defusedxml to guard against XXE / entity-expansion attacks; fall back
 # to the stdlib parser (our KML files are trusted, shipped-in-repo assets).
@@ -996,6 +997,80 @@ def gtfs_feed():
         mimetype="application/zip",
         headers={"Content-Disposition": f'attachment; filename="brunei-gtfs-{year}.zip"'},
     )
+
+
+# --- Trip planner --------------------------------------------------------------
+# The RAPTOR network is built from the same in-memory GTFS feed the export
+# emits, then cached per year until that year's edits change.
+_PLANNER_CACHE = {}  # year -> (db change stamp, planner.Network)
+
+
+def _planner_network(year):
+    stamp = db.change_stamp(year)
+    cached = _PLANNER_CACHE.get(year)
+    if cached and cached[0] == stamp:
+        return cached[1]
+    routes, agencies, params = gtfs_feed_inputs(year)
+    if not routes:
+        return None
+    data, _stats = gtfs.build_feed(routes, agencies, params)
+    net = planner.Network(data)
+    _PLANNER_CACHE[year] = (stamp, net)
+    return net
+
+
+@app.route("/planner")
+def planner_page():
+    # Trip planner: point-to-point journeys over a chosen dataset year.
+    return render_template("planner.html")
+
+
+@app.route("/data/planner-stops")
+def planner_stops():
+    """All stops in the year's plannable network, for the search boxes."""
+    year = _resolve_year(request.args.get("year"))
+    net = _planner_network(year)
+    return jsonify({"year": year, "stops": net.stop_list() if net else []})
+
+
+@app.route("/data/plan")
+def plan_trip():
+    """Point-to-point journeys: ?from=lon,lat&to=lon,lat&time=HH:MM&day=0..6."""
+    year = _resolve_year(request.args.get("year"))
+
+    def point(name):
+        parts = (request.args.get(name) or "").split(",")
+        if len(parts) != 2:
+            return None
+        try:
+            lon, lat = float(parts[0]), float(parts[1])
+        except ValueError:
+            return None
+        if not (-180 <= lon <= 180 and -90 <= lat <= 90):
+            return None
+        return (lon, lat)
+
+    origin, dest = point("from"), point("to")
+    if not origin or not dest:
+        return jsonify({"error": "from and to must be 'lon,lat'"}), 400
+    t = _norm_time(request.args.get("time"))
+    if t is None:
+        return jsonify({"error": "time must be HH:MM or HH:MM:SS"}), 400
+    h, m, s = (int(x) for x in t.split(":"))
+    dep_secs = h * 3600 + m * 60 + s
+    try:
+        day = int(request.args.get("day", ""))
+    except ValueError:
+        return jsonify({"error": "day must be 0..6 (Mon..Sun)"}), 400
+    if not (0 <= day <= 6):
+        return jsonify({"error": "day must be 0..6 (Mon..Sun)"}), 400
+
+    net = _planner_network(year)
+    if net is None:
+        return jsonify({"error": "this source has no routes with stops to plan over"}), 404
+    result = net.plan(origin, dest, dep_secs, day)
+    result["year"] = year
+    return jsonify(result)
 
 
 @app.route("/")

--- a/db.py
+++ b/db.py
@@ -282,6 +282,26 @@ def all_gtfs_meta(year):
     return out
 
 
+def change_stamp(year):
+    """Cheap fingerprint of a year's edits, for cache invalidation: changes
+    whenever route geometry or GTFS metadata is saved, replaced, or deleted."""
+    with _connect() as conn:
+        rv = conn.execute(
+            "SELECT COUNT(*), COALESCE(MAX(id), 0) FROM route_versions WHERE year=?",
+            (year,),
+        ).fetchone()
+        gm = conn.execute(
+            "SELECT COUNT(*), COALESCE(MAX(updated_at), '') FROM gtfs_meta WHERE year=?",
+            (year,),
+        ).fetchone()
+        # History grows on every overwrite, catching same-second meta updates.
+        gh = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) FROM gtfs_meta_history WHERE year=?",
+            (year,),
+        ).fetchone()
+    return (rv[0], rv[1], gm[0], gm[1], gh[0])
+
+
 def delete_all(year, filename):
     """Remove every version for a route (revert to original). Returns rows deleted."""
     with _connect() as conn:

--- a/planner.py
+++ b/planner.py
@@ -1,0 +1,552 @@
+"""RAPTOR journey planner over the GTFS feed built by gtfs.py.
+
+The Network loads the in-memory GTFS zip (the same bytes /data/gtfs.zip
+serves) into a timetable and answers point-to-point queries with RAPTOR
+(round-based: each round adds at most one more ride). Planning over the
+feed itself — rather than the raw route files — means a journey the planner
+returns is exactly what a GTFS consumer of the export would compute.
+
+Frequency-based trips (routes without transcribed departures) are expanded
+into explicit departures at their headway. Walking is planner-side and
+geometry-derived: access/egress to nearby stops plus stop-to-stop transfer
+paths, independent of the feed's transfers.txt.
+
+Pure stdlib; no Flask imports.
+"""
+import csv
+import heapq
+import io
+import zipfile
+from bisect import bisect_left
+
+from gtfs import _haversine
+
+# Walking parameters.
+WALK_SPEED = 1.2             # m/s — relaxed urban walking pace
+ACCESS_RADIUS_M = 1000.0     # origin/destination -> stop
+TRANSFER_RADIUS_M = 350.0    # stop -> stop direct hop between rides
+TRANSFER_SLACK_S = 30        # buffer added to every walk between stops
+TRANSFER_MAX_S = 900         # cap on a chained walk between rides (~15 min)
+MAX_DIRECT_WALK_M = 2000.0   # offer a walk-only journey under this
+MAX_ROUNDS = 5               # rides per journey (= 4 transfers)
+
+_INF = float("inf")
+_DAY_COLS = ("monday", "tuesday", "wednesday", "thursday", "friday",
+             "saturday", "sunday")
+
+
+def _secs(t):
+    """'HH:MM:SS' -> seconds since midnight (GTFS allows hours >= 24)."""
+    h, m, s = t.split(":")
+    return int(h) * 3600 + int(m) * 60 + int(s)
+
+
+def _walk_secs(dist_m):
+    return int(dist_m / WALK_SPEED) + TRANSFER_SLACK_S
+
+
+def _read(zf, name):
+    if name not in zf.namelist():
+        return []
+    with zf.open(name) as fh:
+        return list(csv.DictReader(io.TextIOWrapper(fh, "utf-8-sig")))
+
+
+class Network:
+    """A queryable timetable parsed from GTFS feed bytes."""
+
+    def __init__(self, feed_bytes):
+        zf = zipfile.ZipFile(io.BytesIO(feed_bytes))
+
+        # --- stops ---------------------------------------------------------
+        self.stops = []   # [{id, code, name, lat, lon}]
+        idx = {}
+        for s in _read(zf, "stops.txt"):
+            idx[s["stop_id"]] = len(self.stops)
+            self.stops.append({
+                "id": s["stop_id"],
+                "code": s.get("stop_code", ""),
+                "name": s.get("stop_name", "") or s["stop_id"],
+                "lat": float(s["stop_lat"]),
+                "lon": float(s["stop_lon"]),
+            })
+
+        routes_info = {r["route_id"]: r for r in _read(zf, "routes.txt")}
+        service_days = {
+            c["service_id"]: tuple(int(c.get(d, "0") or 0) for d in _DAY_COLS)
+            for c in _read(zf, "calendar.txt")
+        }
+        trips_info = {t["trip_id"]: t for t in _read(zf, "trips.txt")}
+
+        st_by_trip = {}
+        for st in _read(zf, "stop_times.txt"):
+            st_by_trip.setdefault(st["trip_id"], []).append(st)
+        for rows in st_by_trip.values():
+            rows.sort(key=lambda r: int(r["stop_sequence"]))
+
+        freq = {}  # trip_id -> [(start_secs, end_secs, headway_secs)]
+        for f in _read(zf, "frequencies.txt"):
+            freq.setdefault(f["trip_id"], []).append(
+                (_secs(f["start_time"]), _secs(f["end_time"]),
+                 int(f["headway_secs"])))
+
+        # --- shapes (for drawing ride legs) ---------------------------------
+        self.shapes = {}  # shape_id -> (points [[lon,lat]], cum dists [m])
+        pts_by_shape = {}
+        for row in _read(zf, "shapes.txt"):
+            pts_by_shape.setdefault(row["shape_id"], []).append((
+                int(row["shape_pt_sequence"]),
+                float(row["shape_pt_lon"]), float(row["shape_pt_lat"]),
+                float(row.get("shape_dist_traveled") or 0),
+            ))
+        for sid, pts in pts_by_shape.items():
+            pts.sort()
+            self.shapes[sid] = ([[p[1], p[2]] for p in pts],
+                                [p[3] for p in pts])
+
+        # --- patterns: trips grouped by identical stop sequence -------------
+        # RAPTOR scans "routes" that never branch, so the unit here is the
+        # pattern (route_id + direction + exact stop sequence), with its trips
+        # sorted by departure. Frequency templates expand into one concrete
+        # trip per headway departure.
+        pattern_by_key = {}
+        self.patterns = []  # [{stop_idxs, dists, shape_id, trips, route meta}]
+        for trip_id, rows in st_by_trip.items():
+            t = trips_info.get(trip_id)
+            if not t:
+                continue
+            stop_idxs = [idx[r["stop_id"]] for r in rows if r["stop_id"] in idx]
+            if len(stop_idxs) < 2:
+                continue
+            times = [(_secs(r["arrival_time"]), _secs(r["departure_time"]))
+                     for r in rows]
+            key = (t["route_id"], t.get("direction_id", ""), tuple(stop_idxs))
+            if key not in pattern_by_key:
+                info = routes_info.get(t["route_id"], {})
+                dists = []
+                for r in rows:
+                    try:
+                        dists.append(float(r.get("shape_dist_traveled") or 0))
+                    except ValueError:
+                        dists.append(0.0)
+                pattern_by_key[key] = len(self.patterns)
+                self.patterns.append({
+                    "route_id": t["route_id"],
+                    "short_name": info.get("route_short_name", ""),
+                    "long_name": info.get("route_long_name", ""),
+                    "color": info.get("route_color", ""),
+                    "shape_id": t.get("shape_id", ""),
+                    "stop_idxs": stop_idxs,
+                    "dists": dists,
+                    "trips": [],
+                })
+            pat = self.patterns[pattern_by_key[key]]
+
+            days = service_days.get(t["service_id"], (1,) * 7)
+            headsign = t.get("trip_headsign", "")
+            base = times[0][1]
+            if trip_id in freq:  # template trip: one departure per headway
+                starts = []
+                for ws, we, hw in freq[trip_id]:
+                    x = ws
+                    while x < we:
+                        starts.append(x)
+                        x += hw
+            else:
+                starts = [base]
+            for s0 in starts:
+                off = s0 - base
+                pat["trips"].append({
+                    "days": days,
+                    "headsign": headsign,
+                    "times": [(a + off, d + off) for a, d in times],
+                })
+        for pat in self.patterns:
+            pat["trips"].sort(key=lambda tr: tr["times"][0][1])
+
+        # stop -> [(pattern_idx, earliest position)] for the route-collection
+        # step. Only the first position matters for starting a scan; later
+        # occurrences (loop terminals) are reached by the scan itself.
+        self.patterns_by_stop = [[] for _ in self.stops]
+        for pi, pat in enumerate(self.patterns):
+            seen = {}
+            for pos, s in enumerate(pat["stop_idxs"]):
+                if s not in seen:
+                    seen[s] = pos
+            for s, pos in seen.items():
+                self.patterns_by_stop[s].append((pi, pos))
+
+        # --- foot paths between nearby stops (grid-bucketed) ----------------
+        direct = [[] for _ in self.stops]
+        cell = TRANSFER_RADIUS_M / 111000.0
+        grid = {}
+        for i, s in enumerate(self.stops):
+            grid.setdefault(
+                (int(s["lat"] / cell), int(s["lon"] / cell)), []).append(i)
+        self._grid = grid
+        self._cell = cell
+        for (gy, gx), idxs in grid.items():
+            for i in idxs:
+                a = self.stops[i]
+                for dy in (-1, 0, 1):
+                    for dx in (-1, 0, 1):
+                        for j in grid.get((gy + dy, gx + dx), []):
+                            if j == i:
+                                continue
+                            b = self.stops[j]
+                            d = _haversine([a["lon"], a["lat"]],
+                                           [b["lon"], b["lat"]])
+                            if d <= TRANSFER_RADIUS_M:
+                                direct[i].append((j, _walk_secs(d)))
+
+        # RAPTOR requires the footpath graph to be transitively closed, or it
+        # misses journeys that chain short hops between rides. Close it with a
+        # per-stop Dijkstra over the direct hops, capped at TRANSFER_MAX_S.
+        self.foot = [self._foot_closure(direct, i) for i in range(len(self.stops))]
+
+    # --- helpers -------------------------------------------------------------
+
+    @staticmethod
+    def _foot_closure(direct, src):
+        """[(stop, walk secs)] reachable from src by chained hops within the
+        cap — Dijkstra over the direct-hop graph (neighbourhoods are tiny)."""
+        dist = {src: 0}
+        heap = [(0, src)]
+        while heap:
+            d, i = heapq.heappop(heap)
+            if d > dist.get(i, _INF):
+                continue
+            for j, w in direct[i]:
+                nd = d + w
+                if nd <= TRANSFER_MAX_S and nd < dist.get(j, _INF):
+                    dist[j] = nd
+                    heapq.heappush(heap, (nd, j))
+        del dist[src]
+        return sorted(dist.items())
+
+    def stop_list(self):
+        """All stops, for the client's search box."""
+        return self.stops
+
+    def _near(self, point, radius_m):
+        """[(stop_idx, dist_m)] within radius of (lon, lat), via the grid."""
+        lon, lat = point
+        span = int(radius_m / TRANSFER_RADIUS_M) + 1
+        gy, gx = int(lat / self._cell), int(lon / self._cell)
+        out = []
+        for dy in range(-span, span + 1):
+            for dx in range(-span, span + 1):
+                for i in self._grid.get((gy + dy, gx + dx), []):
+                    s = self.stops[i]
+                    d = _haversine([lon, lat], [s["lon"], s["lat"]])
+                    if d <= radius_m:
+                        out.append((i, d))
+        return out
+
+    def _stop_dist(self, i, j):
+        """Straight-line metres between two stops (for walk-leg display)."""
+        a, b = self.stops[i], self.stops[j]
+        return int(_haversine([a["lon"], a["lat"]], [b["lon"], b["lat"]]))
+
+    def _stop_json(self, i, time=None):
+        s = self.stops[i]
+        out = {"id": s["id"], "name": s["name"], "lat": s["lat"], "lon": s["lon"]}
+        if s["code"]:
+            out["code"] = s["code"]
+        if time is not None:
+            out["time"] = int(time)
+        return out
+
+    def _slice_shape(self, shape_id, d1, d2):
+        """Shape points between two along-shape distances (metres), with
+        interpolated endpoints. None when the shape can't be sliced."""
+        sh = self.shapes.get(shape_id)
+        if not sh or d2 <= d1:
+            return None
+        pts, cum = sh
+
+        def at(d):
+            i = bisect_left(cum, d)
+            if i <= 0:
+                return list(pts[0])
+            if i >= len(pts):
+                return list(pts[-1])
+            seg = cum[i] - cum[i - 1]
+            f = (d - cum[i - 1]) / seg if seg > 0 else 0.0
+            return [pts[i - 1][0] + f * (pts[i][0] - pts[i - 1][0]),
+                    pts[i - 1][1] + f * (pts[i][1] - pts[i - 1][1])]
+
+        lo = bisect_left(cum, d1)
+        hi = bisect_left(cum, d2)
+        return [at(d1)] + [list(p) for p in pts[lo:hi]] + [at(d2)]
+
+    def _ride_geometry(self, pat, bpos, apos):
+        """Polyline for a ride leg: shape slice, else stop-to-stop lines."""
+        geom = self._slice_shape(
+            pat["shape_id"], pat["dists"][bpos], pat["dists"][apos])
+        if geom and len(geom) >= 2:
+            return geom
+        return [[self.stops[i]["lon"], self.stops[i]["lat"]]
+                for i in pat["stop_idxs"][bpos:apos + 1]]
+
+    # --- RAPTOR ----------------------------------------------------------------
+
+    def plan(self, origin, dest, dep_secs, day, max_rounds=MAX_ROUNDS):
+        """Journeys from origin to dest (both (lon, lat)) departing at/after
+        dep_secs on weekday `day` (0=Mon..6=Sun). Returns a dict with the
+        Pareto set over (arrival time, number of rides): one journey per ride
+        count that arrives strictly earlier than using fewer rides."""
+        access = [(i, d) for i, d in self._near(origin, ACCESS_RADIUS_M)]
+        egress = {i: d for i, d in self._near(dest, ACCESS_RADIUS_M)}
+        direct_m = _haversine(list(origin), list(dest))
+
+        journeys = []
+        if direct_m <= MAX_DIRECT_WALK_M:
+            w = _walk_secs(direct_m)
+            journeys.append(self._walk_only(origin, dest, dep_secs, w, direct_m))
+
+        notes = []
+        if not access:
+            notes.append("no stops within walking distance of the start point")
+        if not egress:
+            notes.append("no stops within walking distance of the destination")
+        if not access or not egress:
+            return {"journeys": journeys, "notes": notes}
+
+        n = len(self.stops)
+        best = [_INF] * n            # best arrival over all rounds
+        tau_prev = [_INF] * n        # arrival with <= k-1 rides
+        parents = [dict()]           # per round: stop -> parent record
+        marked = set()
+        for i, dist in access:
+            w = _walk_secs(dist)
+            t = dep_secs + w
+            if t < tau_prev[i]:
+                tau_prev[i] = t
+                best[i] = t
+                parents[0][i] = ("origin", w, dist)
+                marked.add(i)
+        # One more walking hop from the access stops: the first boardable stop
+        # may sit just past the access radius, reached via a stop within it.
+        for i in list(marked):
+            if parents[0][i][0] != "origin":
+                continue
+            for j, w in self.foot[i]:
+                t = tau_prev[i] + w
+                if t < tau_prev[j]:
+                    tau_prev[j] = t
+                    best[j] = t
+                    parents[0][j] = ("walk", i, w)
+                    marked.add(j)
+
+        dest_best = journeys[0]["arrival"] if journeys else _INF
+        arrivals = []  # (round k, alight stop idx) per improving round
+
+        for k in range(1, max_rounds + 1):
+            tau_k = list(tau_prev)
+            parent_k = {}
+
+            # Routes (patterns) touching a marked stop, with the scan start.
+            queue = {}
+            for s in marked:
+                for pi, pos in self.patterns_by_stop[s]:
+                    if pi not in queue or pos < queue[pi]:
+                        queue[pi] = pos
+
+            improved = set()
+            for pi, pos0 in queue.items():
+                pat = self.patterns[pi]
+                sidx = pat["stop_idxs"]
+                trips = pat["trips"]
+                trip = None
+                trip_i = -1
+                bpos = -1
+                for pos in range(pos0, len(sidx)):
+                    s = sidx[pos]
+                    if trip is not None:
+                        arr = trip["times"][pos][0]
+                        if arr < best[s]:
+                            tau_k[s] = arr
+                            best[s] = arr
+                            parent_k[s] = ("ride", pi, trip_i, bpos, pos)
+                            improved.add(s)
+                    # Could we board an earlier trip here, having arrived
+                    # with one ride fewer?
+                    t_here = tau_prev[s]
+                    if t_here < _INF and (
+                        trip is None or t_here <= trip["times"][pos][1]
+                    ):
+                        for ti, tr in enumerate(trips):
+                            if tr["days"][day] and tr["times"][pos][1] >= t_here:
+                                if (trip is None
+                                        or tr["times"][pos][1]
+                                        < trip["times"][pos][1]):
+                                    trip, trip_i, bpos = tr, ti, pos
+                                break
+
+            # One walking hop from each stop a ride just improved.
+            for s in list(improved):
+                for j, w in self.foot[s]:
+                    t = tau_k[s] + w
+                    if t < best[j] and t < tau_k[j]:
+                        tau_k[j] = t
+                        best[j] = t
+                        parent_k[j] = ("walk", s, w)
+                        improved.add(j)
+
+            if not improved:
+                break
+            parents.append(parent_k)
+            marked = improved
+            tau_prev = tau_k
+
+            # Did this round reach the destination earlier?
+            round_best, round_stop = _INF, None
+            for i, dist in egress.items():
+                if tau_k[i] < _INF:
+                    t = tau_k[i] + _walk_secs(dist)
+                    if t < round_best:
+                        round_best, round_stop = t, i
+            if round_stop is not None and round_best < dest_best:
+                dest_best = round_best
+                arrivals.append((k, round_stop))
+
+        for k, alight in arrivals:
+            j = self._reconstruct(parents, k, alight, egress[alight],
+                                  origin, dest)
+            if j:
+                journeys.append(j)
+
+        journeys.sort(key=lambda j: (j["arrival"], j["transfers"]))
+        return {"journeys": journeys, "notes": notes}
+
+    def _walk_only(self, origin, dest, dep_secs, w, dist_m):
+        return {
+            "departure": int(dep_secs),
+            "arrival": int(dep_secs + w),
+            "duration": int(w),
+            "transfers": 0,
+            "walk_only": True,
+            "legs": [{
+                "type": "walk",
+                "from": {"lat": origin[1], "lon": origin[0]},
+                "to": {"lat": dest[1], "lon": dest[0]},
+                "depart": int(dep_secs),
+                "arrive": int(dep_secs + w),
+                "dist_m": int(dist_m),
+            }],
+        }
+
+    def _reconstruct(self, parents, k, alight, egress_dist, origin, dest):
+        """Walk parent pointers back from `alight` at round `k` into legs."""
+        raw = []
+        s, kk = alight, k
+        while True:
+            while s not in parents[kk]:
+                kk -= 1
+                if kk < 0:
+                    return None
+            rec = parents[kk][s]
+            if rec[0] == "origin":
+                raw.append(("access", rec[1], rec[2], s))
+                break
+            if rec[0] == "walk":
+                raw.append(("walk", rec[1], s, rec[2]))
+                s = rec[1]
+            else:  # ("ride", pattern, trip, board pos, alight pos)
+                raw.append(rec)
+                s = self.patterns[rec[1]]["stop_idxs"][rec[3]]
+                kk -= 1
+        raw.reverse()
+
+        first_ride = next((i for i, r in enumerate(raw) if r[0] == "ride"), None)
+        if first_ride is None:
+            return None  # walk-only chains are covered by the direct walk
+
+        # Walks before the first ride are anchored backwards from its
+        # departure: leave the origin just in time, not at the queried minute.
+        nxt = raw[first_ride]
+        dep0 = self.patterns[nxt[1]]["trips"][nxt[2]]["times"][nxt[3]][1]
+        prefix = []
+        anchor = dep0
+        for rec in reversed(raw[:first_ride]):
+            if rec[0] == "access":
+                _, w, dist, stop = rec
+                frm = {"lat": origin[1], "lon": origin[0]}
+                to = self._stop_json(stop)
+            else:  # ("walk", from stop, to stop, secs)
+                _, f, to_s, w = rec
+                frm = self._stop_json(f)
+                to = self._stop_json(to_s)
+                dist = self._stop_dist(f, to_s)
+            prefix.append({
+                "type": "walk",
+                "from": frm,
+                "to": to,
+                "depart": int(anchor - w),
+                "arrive": int(anchor),
+                "dist_m": int(dist),
+            })
+            anchor -= w
+        prefix.reverse()
+
+        legs = prefix
+        t = dep0        # running clock: arrival time of the previous leg
+        rides = 0
+        for rec in raw[first_ride:]:
+            if rec[0] == "ride":
+                _, pi, ti, bpos, apos = rec
+                pat = self.patterns[pi]
+                trip = pat["trips"][ti]
+                dep = trip["times"][bpos][1]
+                arr = trip["times"][apos][0]
+                rides += 1
+                legs.append({
+                    "type": "ride",
+                    "route_id": pat["route_id"],
+                    "short_name": pat["short_name"],
+                    "long_name": pat["long_name"],
+                    "color": pat["color"],
+                    "headsign": trip["headsign"],
+                    "board": self._stop_json(pat["stop_idxs"][bpos], dep),
+                    "alight": self._stop_json(pat["stop_idxs"][apos], arr),
+                    "depart": int(dep),
+                    "arrive": int(arr),
+                    "stops": [
+                        self._stop_json(pat["stop_idxs"][p],
+                                        trip["times"][p][0])
+                        for p in range(bpos, apos + 1)
+                    ],
+                    "geometry": self._ride_geometry(pat, bpos, apos),
+                })
+                t = arr
+            else:  # mid-journey walk between stops
+                _, frm, to, w = rec
+                legs.append({
+                    "type": "walk",
+                    "from": self._stop_json(frm),
+                    "to": self._stop_json(to),
+                    "depart": int(t),
+                    "arrive": int(t + w),
+                    "dist_m": self._stop_dist(frm, to),
+                })
+                t = t + w
+        w = _walk_secs(egress_dist)
+        legs.append({
+            "type": "walk",
+            "from": dict(legs[-1]["to"]) if legs[-1]["type"] == "walk"
+                else dict(legs[-1]["alight"]),
+            "to": {"lat": dest[1], "lon": dest[0]},
+            "depart": int(t),
+            "arrive": int(t + w),
+            "dist_m": int(egress_dist),
+        })
+        departure = legs[0]["depart"]
+        arrival = legs[-1]["arrive"]
+        return {
+            "departure": int(departure),
+            "arrival": int(arrival),
+            "duration": int(arrival - departure),
+            "transfers": max(0, rides - 1),
+            "legs": legs,
+        }

--- a/planner.py
+++ b/planner.py
@@ -30,6 +30,7 @@ TRANSFER_MAX_S = 900         # cap on a chained walk between rides (~15 min)
 MAX_DIRECT_WALK_M = 2000.0   # offer a walk-only journey under this
 MAX_ROUNDS = 5               # rides per journey (= 4 transfers)
 SLICE_TOL_M = 250.0          # a ride leg's drawn line must end this close to its stops
+THREAD_OFFSHAPE_M = 800.0    # threading still anchors a stop this far off the line
 
 _INF = float("inf")
 _DAY_COLS = ("monday", "tuesday", "wednesday", "thursday", "friday",
@@ -302,15 +303,112 @@ class Network:
         ai = min(range(bi + 1, len(pts)), key=lambda i: _haversine(pts[i], apt))
         return self._slice_shape(shape_id, cum[bi], cum[ai])
 
+    def _thread_by_stops(self, pat, bpos, apos):
+        """Leg geometry threaded hop-by-hop through the shape, for tracings
+        whose stop order doesn't follow the drawn line (multi-pass loops).
+
+        Each stop may sit near several passes of the line; a small DP picks
+        one pass per stop minimizing the total along-shape jump, then each
+        consecutive-stop hop is a (possibly reversed) slice between the
+        chosen passes. Stops too far off the shape entirely (the line was
+        never traced down their road) are bridged with straight hops to
+        their neighbours, and a hop whose along-shape span is implausible
+        against its straight-line distance degrades to a straight segment —
+        so bad data costs short cuts between adjacent stops, never a
+        kilometres-long one. Returns None when no stop is near the shape."""
+        sh = self.shapes.get(pat["shape_id"])
+        if not sh:
+            return None
+        pts, cum = sh
+        stop_pts = [[self.stops[i]["lon"], self.stops[i]["lat"]]
+                    for i in pat["stop_idxs"][bpos:apos + 1]]
+
+        # Candidate passes per stop: the best vertex of each near-the-stop
+        # run of consecutive vertices. A moderately off-line stop (misplaced
+        # marker or sloppy tracing) still anchors to its nearest pass so the
+        # hop can follow the road; None = the line truly never goes there.
+        cand_lists = []
+        for sp in stop_pts:
+            d = [_haversine(p, sp) for p in pts]
+            best = min(d)
+            if best > THREAD_OFFSHAPE_M:
+                cand_lists.append(None)
+                continue
+            tol = best + 60.0
+            cands = []
+            run = []
+            for i, di in enumerate(d):
+                if di <= tol:
+                    run.append(i)
+                else:
+                    if run:
+                        cands.append(min(run, key=lambda k: d[k]))
+                    run = []
+            if run:
+                cands.append(min(run, key=lambda k: d[k]))
+            cand_lists.append(cands)
+
+        on_shape = [n for n, c in enumerate(cand_lists) if c]
+        if not on_shape:
+            return None
+
+        # DP over the on-shape stops' passes: minimize the summed
+        # |along-shape jump| between consecutive ones (counts are tiny).
+        prev_cost = [0.0] * len(cand_lists[on_shape[0]])
+        back_ptr = []
+        for a, b in zip(on_shape, on_shape[1:]):
+            cost = []
+            back = []
+            for vj in cand_lists[b]:
+                best_c, best_k = float("inf"), 0
+                for k, vk in enumerate(cand_lists[a]):
+                    c = prev_cost[k] + abs(cum[vj] - cum[vk])
+                    if c < best_c:
+                        best_c, best_k = c, k
+                cost.append(best_c)
+                back.append(best_k)
+            prev_cost = cost
+            back_ptr.append(back)
+        j = min(range(len(prev_cost)), key=lambda k: prev_cost[k])
+        chosen = {}
+        for i in range(len(on_shape) - 1, 0, -1):
+            chosen[on_shape[i]] = cand_lists[on_shape[i]][j]
+            j = back_ptr[i - 1][j]
+        chosen[on_shape[0]] = cand_lists[on_shape[0]][j]
+
+        geom = []
+
+        def extend(seg):
+            for p in seg:
+                if not geom or geom[-1] != p:
+                    geom.append(p)
+
+        for n in range(len(stop_pts) - 1):
+            straight = _haversine(stop_pts[n], stop_pts[n + 1])
+            if n in chosen and (n + 1) in chosen:
+                d1, d2 = cum[chosen[n]], cum[chosen[n + 1]]
+                if abs(d2 - d1) <= max(5.0 * straight, 1000.0):
+                    seg = self._slice_shape(
+                        pat["shape_id"], min(d1, d2), max(d1, d2)) or []
+                    if d2 < d1:
+                        seg = seg[::-1]
+                else:
+                    seg = [stop_pts[n], stop_pts[n + 1]]
+            else:  # one end is off the drawn line — bridge it directly
+                seg = [stop_pts[n], stop_pts[n + 1]]
+            extend(seg)
+        return geom if len(geom) >= 2 else None
+
     def _ride_geometry(self, pat, bpos, apos):
         """Polyline for a ride leg, anchored to its board/alight stops.
 
         The feed's stop->shape projections can collapse on loop routes (a
         monotonic snap that runs ahead of the stops), leaving a slice that
         ends kilometres from the alight stop. Validate the slice, re-derive
-        it from the stops' own nearest shape vertices when it's off, and as
-        a last resort draw stop-to-stop lines. Ends are pinned to the exact
-        stop coordinates so consecutive journey legs always connect."""
+        it from the stops' own nearest shape vertices when it's off, thread
+        it stop-by-stop through the shape's passes when even that fails,
+        and as a last resort draw stop-to-stop lines. Ends are pinned to
+        the exact stop coordinates so consecutive journey legs connect."""
         board = self.stops[pat["stop_idxs"][bpos]]
         alight = self.stops[pat["stop_idxs"][apos]]
         bpt = [board["lon"], board["lat"]]
@@ -321,6 +419,8 @@ class Network:
         if not self._slice_ok(geom, bpt, apt):
             geom = self._reslice_by_stops(pat["shape_id"], bpt, apt)
         if not self._slice_ok(geom, bpt, apt):
+            geom = self._thread_by_stops(pat, bpos, apos)
+        if geom is None or len(geom) < 2:
             geom = [[self.stops[i]["lon"], self.stops[i]["lat"]]
                     for i in pat["stop_idxs"][bpos:apos + 1]]
         if geom[0] != bpt:

--- a/planner.py
+++ b/planner.py
@@ -501,6 +501,7 @@ class Network:
                 trip = None
                 trip_i = -1
                 bpos = -1
+                t_board = _INF  # tau at the chosen boarding stop
                 for pos in range(pos0, len(sidx)):
                     s = sidx[pos]
                     if trip is not None:
@@ -511,7 +512,10 @@ class Network:
                             parent_k[s] = ("ride", pi, trip_i, bpos, pos)
                             improved.add(s)
                     # Could we board an earlier trip here, having arrived
-                    # with one ride fewer?
+                    # with one ride fewer? The SAME trip also re-boards at a
+                    # stop reached sooner (less walking, typically the stop
+                    # nearest the origin/transfer): arrival is unchanged but
+                    # the journey boards where it's easiest to get to.
                     t_here = tau_prev[s]
                     if t_here < _INF and (
                         trip is None or t_here <= trip["times"][pos][1]
@@ -520,8 +524,11 @@ class Network:
                             if tr["days"][day] and tr["times"][pos][1] >= t_here:
                                 if (trip is None
                                         or tr["times"][pos][1]
-                                        < trip["times"][pos][1]):
+                                        < trip["times"][pos][1]
+                                        or (ti == trip_i
+                                            and t_here < t_board)):
                                     trip, trip_i, bpos = tr, ti, pos
+                                    t_board = t_here
                                 break
 
             # One walking hop from each stop a ride just improved.
@@ -681,6 +688,20 @@ class Network:
             "arrive": int(t + w),
             "dist_m": int(egress_dist),
         })
+        # Chained walks (origin -> stop -> stop, from round-0 footpaths)
+        # display as one walk: the intermediate stop means nothing to the
+        # rider, and the road router draws the direct path anyway.
+        merged = []
+        for leg in legs:
+            prev = merged[-1] if merged else None
+            if (leg["type"] == "walk" and prev
+                    and prev["type"] == "walk"):
+                prev["to"] = leg["to"]
+                prev["arrive"] = leg["arrive"]
+                prev["dist_m"] += leg["dist_m"]
+            else:
+                merged.append(leg)
+        legs = merged
         departure = legs[0]["depart"]
         arrival = legs[-1]["arrive"]
         return {

--- a/planner.py
+++ b/planner.py
@@ -29,6 +29,7 @@ TRANSFER_SLACK_S = 30        # buffer added to every walk between stops
 TRANSFER_MAX_S = 900         # cap on a chained walk between rides (~15 min)
 MAX_DIRECT_WALK_M = 2000.0   # offer a walk-only journey under this
 MAX_ROUNDS = 5               # rides per journey (= 4 transfers)
+SLICE_TOL_M = 250.0          # a ride leg's drawn line must end this close to its stops
 
 _INF = float("inf")
 _DAY_COLS = ("monday", "tuesday", "wednesday", "thursday", "friday",
@@ -280,14 +281,53 @@ class Network:
         hi = bisect_left(cum, d2)
         return [at(d1)] + [list(p) for p in pts[lo:hi]] + [at(d2)]
 
+    def _slice_ok(self, geom, bpt, apt):
+        """A usable ride polyline starts near the board stop and ends near
+        the alight stop."""
+        return (geom is not None and len(geom) >= 2
+                and _haversine(geom[0], bpt) <= SLICE_TOL_M
+                and _haversine(geom[-1], apt) <= SLICE_TOL_M)
+
+    def _reslice_by_stops(self, shape_id, bpt, apt):
+        """Slice between the shape vertices nearest each stop, requiring the
+        alight vertex to come after the board vertex (loop shapes pass a
+        terminal twice). Recovery path for collapsed feed projections."""
+        sh = self.shapes.get(shape_id)
+        if not sh:
+            return None
+        pts, cum = sh
+        bi = min(range(len(pts)), key=lambda i: _haversine(pts[i], bpt))
+        if bi >= len(pts) - 1:
+            return None
+        ai = min(range(bi + 1, len(pts)), key=lambda i: _haversine(pts[i], apt))
+        return self._slice_shape(shape_id, cum[bi], cum[ai])
+
     def _ride_geometry(self, pat, bpos, apos):
-        """Polyline for a ride leg: shape slice, else stop-to-stop lines."""
+        """Polyline for a ride leg, anchored to its board/alight stops.
+
+        The feed's stop->shape projections can collapse on loop routes (a
+        monotonic snap that runs ahead of the stops), leaving a slice that
+        ends kilometres from the alight stop. Validate the slice, re-derive
+        it from the stops' own nearest shape vertices when it's off, and as
+        a last resort draw stop-to-stop lines. Ends are pinned to the exact
+        stop coordinates so consecutive journey legs always connect."""
+        board = self.stops[pat["stop_idxs"][bpos]]
+        alight = self.stops[pat["stop_idxs"][apos]]
+        bpt = [board["lon"], board["lat"]]
+        apt = [alight["lon"], alight["lat"]]
+
         geom = self._slice_shape(
             pat["shape_id"], pat["dists"][bpos], pat["dists"][apos])
-        if geom and len(geom) >= 2:
-            return geom
-        return [[self.stops[i]["lon"], self.stops[i]["lat"]]
-                for i in pat["stop_idxs"][bpos:apos + 1]]
+        if not self._slice_ok(geom, bpt, apt):
+            geom = self._reslice_by_stops(pat["shape_id"], bpt, apt)
+        if not self._slice_ok(geom, bpt, apt):
+            geom = [[self.stops[i]["lon"], self.stops[i]["lat"]]
+                    for i in pat["stop_idxs"][bpos:apos + 1]]
+        if geom[0] != bpt:
+            geom.insert(0, bpt)
+        if geom[-1] != apt:
+            geom.append(apt)
+        return geom
 
     # --- RAPTOR ----------------------------------------------------------------
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1797,6 +1797,13 @@ body.guide-page {
   flex: 1 1 auto;
   width: auto;
 }
+.tp-plan-row {
+  display: flex;
+  gap: 6px;
+}
+.tp-plan-row #tpPlan {
+  flex: 1 1 auto;
+}
 #tpPlan {
   background: var(--gtfs-accent);
   border-color: #e6b94f;
@@ -1833,6 +1840,62 @@ body.guide-page {
   border-radius: 999px;
   box-shadow: 0 2px 10px rgba(29, 42, 51, 0.4);
   pointer-events: none;
+}
+
+/* Recent trips */
+.tp-trips-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.tp-trips-head a {
+  cursor: pointer;
+  font-size: 11px;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--gtfs-danger);
+}
+.tp-trips-head a:hover {
+  color: var(--gtfs-danger);
+  text-decoration: underline;
+}
+.tp-trip {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  padding: 4px 7px;
+  margin-bottom: 4px;
+  background: var(--gtfs-card);
+  border: 1px solid var(--gtfs-line);
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.tp-trip:hover {
+  border-color: var(--gtfs-ink-soft);
+}
+.tp-trip-route {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tp-trip-meta {
+  flex: 0 0 auto;
+  font-family: var(--gtfs-mono);
+  font-size: 11px;
+  color: var(--gtfs-ink-soft);
+  white-space: nowrap;
+}
+.tp-trip-del {
+  flex: 0 0 auto;
+  padding: 0 3px;
+  color: var(--gtfs-danger);
+}
+.tp-trip-del:hover {
+  color: var(--gtfs-danger);
+  text-decoration: none;
 }
 
 /* Journey result cards */

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1709,3 +1709,214 @@ body.guide-page {
   }
 }
 
+
+/* --- Trip planner (/planner) --- */
+.tp-sidebar {
+  display: flex;
+  flex-direction: column;
+}
+.tp-head {
+  flex: 0 0 auto;
+  padding: 8px 12px;
+  background: var(--gtfs-ink);
+  color: #fff;
+  font-family: var(--gtfs-display);
+  font-weight: 600;
+  font-size: 16px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.tp-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 10px 12px;
+}
+.tp-section {
+  margin-bottom: 12px;
+}
+.tp-label {
+  font-family: var(--gtfs-display);
+  font-weight: 600;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--gtfs-ink-soft);
+  margin-bottom: 4px;
+}
+.tp-source .btn.active {
+  background: var(--gtfs-ink);
+  color: var(--gtfs-accent);
+  border-color: var(--gtfs-ink);
+}
+.tp-point-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+.tp-point-row input {
+  flex: 1 1 auto;
+}
+.tp-dot {
+  flex: 0 0 22px;
+  width: 22px;
+  height: 22px;
+  line-height: 22px;
+  border-radius: 50%;
+  text-align: center;
+  color: #fff;
+  font-weight: 700;
+  font-size: 12px;
+}
+.tp-dot-a {
+  background: var(--gtfs-go);
+}
+.tp-dot-b {
+  background: var(--gtfs-danger);
+}
+.tp-when-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 6px 0 10px;
+}
+.tp-when-row label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin: 0;
+  font-weight: normal;
+  white-space: nowrap;
+}
+.tp-when-row input[type="time"] {
+  width: auto;
+  font-family: var(--gtfs-mono);
+}
+.tp-when-row select {
+  flex: 1 1 auto;
+  width: auto;
+}
+#tpPlan {
+  background: var(--gtfs-accent);
+  border-color: #e6b94f;
+  color: var(--gtfs-accent-ink);
+  font-family: var(--gtfs-display);
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+#tpPlan:hover {
+  background: #ffdd85;
+}
+.tp-status {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--gtfs-ink-soft);
+  min-height: 16px;
+}
+.tp-status.warn {
+  color: var(--gtfs-danger);
+}
+.tp-map-hint {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 900;
+  padding: 6px 16px;
+  background: var(--gtfs-ink);
+  color: var(--gtfs-accent);
+  font-family: var(--gtfs-mono);
+  font-size: 12px;
+  border-radius: 999px;
+  box-shadow: 0 2px 10px rgba(29, 42, 51, 0.4);
+  pointer-events: none;
+}
+
+/* Journey result cards */
+.tp-journey {
+  background: var(--gtfs-card);
+  border: 1px solid var(--gtfs-line);
+  border-left: 4px solid var(--gtfs-line);
+  border-radius: 6px;
+  padding: 8px 10px;
+  margin-bottom: 8px;
+  cursor: pointer;
+}
+.tp-journey:hover {
+  border-color: var(--gtfs-ink-soft);
+}
+.tp-journey.selected {
+  border-left-color: var(--gtfs-accent);
+  box-shadow: 0 1px 6px rgba(29, 42, 51, 0.15);
+}
+.tp-journey-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.tp-journey-times {
+  font-family: var(--gtfs-mono);
+  font-weight: 600;
+  font-size: 15px;
+}
+.tp-journey-meta {
+  font-size: 12px;
+  color: var(--gtfs-ink-soft);
+  white-space: nowrap;
+}
+.tp-leg {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  padding: 3px 0;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.tp-leg-walk {
+  color: var(--gtfs-ink-soft);
+}
+.tp-leg-icon {
+  flex: 0 0 20px;
+  text-align: center;
+}
+.tp-leg-chip {
+  flex: 0 0 auto;
+  min-width: 20px;
+  padding: 0 6px;
+  border-radius: 3px;
+  color: #fff;
+  font-family: var(--gtfs-mono);
+  font-weight: 600;
+  font-size: 11px;
+  text-align: center;
+}
+.tp-leg-text {
+  min-width: 0;
+}
+.tp-headsign {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--gtfs-ink-soft);
+}
+.tp-journey-ride {
+  margin-top: 6px;
+  text-align: right;
+}
+
+/* Stack sidebar over map on narrow screens, like the workbench. */
+@media (max-width: 820px) {
+  .tp-sidebar {
+    display: flex;
+    flex: none;
+    width: auto;
+    max-height: 45vh;
+    order: 3;
+    border-right: none;
+    border-top: 1px solid var(--gtfs-line);
+  }
+}

--- a/static/js/planner-page.js
+++ b/static/js/planner-page.js
@@ -1,0 +1,460 @@
+// Trip planner page (/planner): pick a data source (2016 official or the
+// user's own routes), set A/B by clicking the map or naming a stop, and plan
+// point-to-point journeys via the RAPTOR endpoint (/data/plan). Selected
+// journeys draw on the map: solid colored ride legs, dashed walk legs.
+window.APP = window.APP || {};
+
+APP.PlannerPage = class {
+  constructor() {
+    this.map = null;
+    this.baseLayer = null;
+    this.year = "2016"; // selected data source year
+    this.from = null; // {lon, lat, label}
+    this.to = null;
+    this.pick = null; // "from" | "to" | null — armed map-pick target
+    this.stops = []; // searchable stops of the current source
+    this.journeys = [];
+    this.init();
+  }
+
+  init() {
+    const view = new ol.View({
+      center: APP.MapUtils.toOL(APP.MAP_CONFIG.INITIAL_CENTER),
+      zoom: APP.MAP_CONFIG.INITIAL_ZOOM,
+      minZoom: APP.MAP_CONFIG.MIN_ZOOM,
+      maxZoom: APP.MAP_CONFIG.MAX_ZOOM,
+    });
+    this.baseLayer = APP.MAP_STYLES.osm.create();
+    this.map = new ol.Map({ target: "map", layers: [this.baseLayer], view });
+    $("#mapStyle").on("change", (e) => {
+      this.map.removeLayer(this.baseLayer);
+      this.baseLayer = APP.MAP_STYLES[e.target.value].create();
+      this.map.getLayers().insertAt(0, this.baseLayer);
+    });
+
+    this.markerSource = new ol.source.Vector();
+    this.journeySource = new ol.source.Vector();
+    this.map.addLayer(
+      new ol.layer.Vector({ source: this.journeySource, zIndex: 100 })
+    );
+    this.map.addLayer(
+      new ol.layer.Vector({ source: this.markerSource, zIndex: 200 })
+    );
+
+    this.map.on("click", (e) => this.onMapClick(e));
+
+    // Data source toggle: the shipped 2016 set, or the user's own routes.
+    $("#tpSourceMine").attr("data-year", APP.USER_ROUTE_YEAR);
+    $(".tp-source .btn").on("click", (e) => {
+      const btn = $(e.currentTarget);
+      if (btn.hasClass("active")) return;
+      $(".tp-source .btn").removeClass("active");
+      btn.addClass("active");
+      this.year = btn.attr("data-year");
+      this.loadStops();
+      this.clearResults("Source changed — plan again.");
+    });
+
+    $("#tpPickFrom").on("click", () => this.armPick("from"));
+    $("#tpPickTo").on("click", () => this.armPick("to"));
+    $("#tpSwap").on("click", () => this.swap());
+    $("#tpPlan").on("click", () => this.plan());
+    $("#tpFrom").on("change", () => this.stopTyped("from"));
+    $("#tpTo").on("change", () => this.stopTyped("to"));
+    $("#tpResults").on("click", ".tp-journey", (e) => {
+      this.selectJourney($(e.currentTarget).index());
+    });
+    // 3D ride-along preview of a planned journey (engine picked in a modal).
+    this.pendingRide = null;
+    $("#tpResults").on("click", ".tp-ride-btn", (e) => {
+      e.stopPropagation();
+      const i = $(e.currentTarget).closest(".tp-journey").index();
+      this.selectJourney(i);
+      this.pendingRide = this.journeys[i];
+      $("#engineModal").modal("show");
+    });
+    $("#engineThree").on("click", () => this.rideJourney("three"));
+    $("#engineMaplibre").on("click", () => this.rideJourney("maplibre"));
+
+    // Default travel time: now, today.
+    const now = new Date();
+    $("#tpTime").val(
+      `${String(now.getHours()).padStart(2, "0")}:${String(
+        now.getMinutes()
+      ).padStart(2, "0")}`
+    );
+    $("#tpDay").val(String((now.getDay() + 6) % 7)); // JS Sun=0 -> Mon=0
+
+    this.loadStops();
+  }
+
+  // --- Points ----------------------------------------------------------------
+
+  armPick(which) {
+    this.pick = which;
+    $("#tpMapHint")
+      .text(which === "from" ? "Click the map to set the start (A)" : "Click the map to set the destination (B)")
+      .show();
+  }
+
+  onMapClick(e) {
+    const [lon, lat] = APP.MapUtils.toNormal(e.coordinate);
+    // Explicitly armed pick wins; otherwise fill A first, then B.
+    const which = this.pick || (!this.from ? "from" : "to");
+    this.pick = null;
+    $("#tpMapHint").hide();
+    this.setPoint(which, lon, lat, `${lat.toFixed(5)}, ${lon.toFixed(5)}`);
+  }
+
+  setPoint(which, lon, lat, label) {
+    this[which === "from" ? "from" : "to"] = { lon, lat, label };
+    $(which === "from" ? "#tpFrom" : "#tpTo").val(label);
+    this.drawMarkers();
+  }
+
+  stopTyped(which) {
+    // Typing a stop name (via the datalist) pins the point to that stop.
+    const text = $(which === "from" ? "#tpFrom" : "#tpTo").val().trim();
+    const stop = this.stops.find(
+      (s) => this.stopLabel(s).toLowerCase() === text.toLowerCase()
+    ) || this.stops.find((s) => s.name.toLowerCase() === text.toLowerCase());
+    if (stop) {
+      this.setPoint(which, stop.lon, stop.lat, this.stopLabel(stop));
+    } else if (!text) {
+      this[which] = null;
+      this.drawMarkers();
+    }
+  }
+
+  swap() {
+    [this.from, this.to] = [this.to, this.from];
+    $("#tpFrom").val(this.from ? this.from.label : "");
+    $("#tpTo").val(this.to ? this.to.label : "");
+    this.drawMarkers();
+  }
+
+  stopLabel(s) {
+    return s.code ? `${s.name} (${s.code})` : s.name;
+  }
+
+  loadStops() {
+    this.stops = [];
+    fetch(`/data/planner-stops?year=${encodeURIComponent(this.year)}`)
+      .then((r) => r.json())
+      .then((d) => {
+        this.stops = d.stops || [];
+        const dl = $("#tpStopOptions").empty();
+        const seen = new Set();
+        this.stops.forEach((s) => {
+          const label = this.stopLabel(s);
+          if (seen.has(label)) return;
+          seen.add(label);
+          dl.append($("<option></option>").attr("value", label));
+        });
+        if (!this.stops.length) {
+          this.setStatus(
+            this.year === APP.USER_ROUTE_YEAR
+              ? "No plannable routes yet — draw routes with at least 2 stops in the GTFS workbench."
+              : "This source has no stops to plan over.",
+            "warn"
+          );
+        } else {
+          this.setStatus(`${this.stops.length} stops available.`);
+        }
+      })
+      .catch((e) => APP.MapUtils.handleError(e, "Loading planner stops"));
+  }
+
+  // --- Planning ----------------------------------------------------------------
+
+  setStatus(text, kind) {
+    $("#tpStatus")
+      .text(text || "")
+      .toggleClass("warn", kind === "warn");
+  }
+
+  clearResults(statusText) {
+    this.journeys = [];
+    $("#tpResults").empty();
+    this.journeySource.clear();
+    if (statusText !== undefined) this.setStatus(statusText);
+  }
+
+  plan() {
+    if (!this.from || !this.to) {
+      this.setStatus("Set both A and B first — click the map or type a stop.", "warn");
+      return;
+    }
+    const time = $("#tpTime").val() || "08:00";
+    const day = $("#tpDay").val();
+    const q = new URLSearchParams({
+      year: this.year,
+      from: `${this.from.lon},${this.from.lat}`,
+      to: `${this.to.lon},${this.to.lat}`,
+      time,
+      day,
+    });
+    this.clearResults();
+    this.setStatus("Planning…");
+    fetch(`/data/plan?${q}`)
+      .then((r) =>
+        r.json().then((d) => {
+          if (!r.ok) throw new Error(d.error || `HTTP ${r.status}`);
+          return d;
+        })
+      )
+      .then((d) => {
+        this.journeys = d.journeys || [];
+        const notes = (d.notes || []).join("; ");
+        if (!this.journeys.length) {
+          this.setStatus(notes || "No journey found — try another time or day.", "warn");
+          return;
+        }
+        this.setStatus(notes);
+        this.renderResults();
+        this.selectJourney(0);
+      })
+      .catch((e) => this.setStatus(e.message, "warn"));
+  }
+
+  // --- Results list ---------------------------------------------------------------
+
+  fmt(secs) {
+    const h = Math.floor(secs / 3600) % 24;
+    const m = Math.floor((secs % 3600) / 60);
+    return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+  }
+
+  fmtDur(secs) {
+    const m = Math.round(secs / 60);
+    return m >= 60 ? `${Math.floor(m / 60)} h ${m % 60} min` : `${m} min`;
+  }
+
+  rideColor(leg, i) {
+    return leg.color
+      ? `#${leg.color}`
+      : APP.ROUTE_COLORS[i % APP.ROUTE_COLORS.length];
+  }
+
+  renderResults() {
+    const out = $("#tpResults").empty();
+    this.journeys.forEach((j, ji) => {
+      const card = $('<div class="tp-journey"></div>');
+      const head = $('<div class="tp-journey-head"></div>');
+      head.append(
+        $('<span class="tp-journey-times"></span>').text(
+          `${this.fmt(j.departure)} → ${this.fmt(j.arrival)}`
+        )
+      );
+      const what = j.walk_only
+        ? "walk only"
+        : `${j.transfers} transfer${j.transfers === 1 ? "" : "s"}`;
+      head.append(
+        $('<span class="tp-journey-meta"></span>').text(
+          `${this.fmtDur(j.duration)} · ${what}`
+        )
+      );
+      card.append(head);
+
+      let rideIdx = 0;
+      j.legs.forEach((leg) => {
+        const row = $('<div class="tp-leg"></div>');
+        if (leg.type === "walk") {
+          const dest = leg.to.name || "destination";
+          row.addClass("tp-leg-walk").append(
+            $('<span class="tp-leg-icon">🚶</span>'),
+            $('<span class="tp-leg-text"></span>').text(
+              `${this.fmtDur(leg.arrive - leg.depart)} walk to ${dest}` +
+                (leg.dist_m ? ` (${leg.dist_m} m)` : "")
+            )
+          );
+        } else {
+          const color = this.rideColor(leg, rideIdx++);
+          const name = leg.short_name || leg.long_name || leg.route_id;
+          row.addClass("tp-leg-ride").append(
+            $('<span class="tp-leg-chip"></span>')
+              .text(name)
+              .css("background", color),
+            $('<span class="tp-leg-text"></span>').html(
+              `<b>${$("<i>").text(leg.board.name).html()}</b> ${this.fmt(
+                leg.depart
+              )} → <b>${$("<i>").text(leg.alight.name).html()}</b> ${this.fmt(
+                leg.arrive
+              )} · ${leg.stops.length - 1} stops` +
+                (leg.headsign
+                  ? ` · <span class="tp-headsign">${$("<i>")
+                      .text(leg.headsign)
+                      .html()}</span>`
+                  : "")
+            )
+          );
+        }
+        card.append(row);
+      });
+      card.append(
+        $('<div class="tp-journey-ride"></div>').append(
+          $(
+            '<button type="button" class="btn btn-default btn-xs tp-ride-btn" ' +
+              'title="Ride this journey end-to-end in 3D">🚌 3D preview</button>'
+          )
+        )
+      );
+      out.append(card);
+    });
+  }
+
+  // --- 3D ride preview --------------------------------------------------------
+
+  /** A planned journey reshaped into ride geometry ({segments, stops, bounds,
+   * name}): all legs concatenated into one continuous drive path — walks as
+   * straight hops — with the ride legs' stops as the stop markers. */
+  ridePayload(j) {
+    const path = [];
+    const stops = [];
+    const push = (lon, lat) => {
+      const last = path[path.length - 1];
+      if (!last || last[0] !== lon || last[1] !== lat) path.push([lon, lat]);
+    };
+    j.legs.forEach((leg) => {
+      if (leg.type === "walk") {
+        push(leg.from.lon, leg.from.lat);
+        push(leg.to.lon, leg.to.lat);
+      } else {
+        leg.geometry.forEach((c) => push(c[0], c[1]));
+        leg.stops.forEach((s) =>
+          stops.push({ name: s.name, lon: s.lon, lat: s.lat })
+        );
+      }
+    });
+    const lons = path.map((p) => p[0]);
+    const lats = path.map((p) => p[1]);
+    return {
+      segments: [path],
+      stops,
+      bounds: {
+        minLon: Math.min(...lons),
+        minLat: Math.min(...lats),
+        maxLon: Math.max(...lons),
+        maxLat: Math.max(...lats),
+      },
+      name: `Planned trip ${this.fmt(j.departure)} → ${this.fmt(j.arrival)}`,
+    };
+  }
+
+  rideJourney(engine) {
+    if (!this.pendingRide) return;
+    sessionStorage.setItem(
+      "trip-preview",
+      JSON.stringify(this.ridePayload(this.pendingRide))
+    );
+    window.location.href = `/ride/${engine}?route=trip-preview`;
+  }
+
+  // --- Map drawing ----------------------------------------------------------------
+
+  drawMarkers() {
+    this.markerSource.clear();
+    const add = (pt, label, color) => {
+      if (!pt) return;
+      const f = new ol.Feature(
+        new ol.geom.Point(APP.MapUtils.toOL([pt.lon, pt.lat]))
+      );
+      f.setStyle(
+        new ol.style.Style({
+          image: new ol.style.Circle({
+            radius: 11,
+            fill: new ol.style.Fill({ color }),
+            stroke: new ol.style.Stroke({ color: "#fff", width: 2.5 }),
+          }),
+          text: new ol.style.Text({
+            text: label,
+            font: "bold 12px sans-serif",
+            fill: new ol.style.Fill({ color: "#fff" }),
+          }),
+        })
+      );
+      this.markerSource.addFeature(f);
+    };
+    add(this.from, "A", "#2e7d32");
+    add(this.to, "B", "#c0392b");
+  }
+
+  selectJourney(i) {
+    const j = this.journeys[i];
+    if (!j) return;
+    $("#tpResults .tp-journey").removeClass("selected").eq(i).addClass("selected");
+    this.journeySource.clear();
+
+    let rideIdx = 0;
+    j.legs.forEach((leg) => {
+      if (leg.type === "walk") {
+        const line = new ol.Feature(
+          new ol.geom.LineString([
+            APP.MapUtils.toOL([leg.from.lon, leg.from.lat]),
+            APP.MapUtils.toOL([leg.to.lon, leg.to.lat]),
+          ])
+        );
+        line.setStyle(
+          new ol.style.Style({
+            stroke: new ol.style.Stroke({
+              color: "#5a6770",
+              width: 3,
+              lineDash: [2, 8],
+              lineCap: "round",
+            }),
+          })
+        );
+        this.journeySource.addFeature(line);
+        return;
+      }
+      const color = this.rideColor(leg, rideIdx++);
+      const coords = leg.geometry.map((c) => APP.MapUtils.toOL(c));
+      const line = new ol.Feature(new ol.geom.LineString(coords));
+      line.setStyle([
+        new ol.style.Style({
+          stroke: new ol.style.Stroke({ color: "#fff", width: 7 }),
+        }),
+        new ol.style.Style({
+          stroke: new ol.style.Stroke({ color, width: 4 }),
+        }),
+      ]);
+      this.journeySource.addFeature(line);
+      [leg.board, leg.alight].forEach((s) => {
+        const f = new ol.Feature(
+          new ol.geom.Point(APP.MapUtils.toOL([s.lon, s.lat]))
+        );
+        f.setStyle(
+          new ol.style.Style({
+            image: new ol.style.Circle({
+              radius: 6,
+              fill: new ol.style.Fill({ color: "#fff" }),
+              stroke: new ol.style.Stroke({ color, width: 3 }),
+            }),
+            text: new ol.style.Text({
+              text: s.name,
+              offsetY: -14,
+              font: "12px sans-serif",
+              fill: new ol.style.Fill({ color: "#111" }),
+              stroke: new ol.style.Stroke({ color: "#fff", width: 3 }),
+            }),
+          })
+        );
+        this.journeySource.addFeature(f);
+      });
+    });
+
+    // Fit A, B and the whole journey.
+    const ext = ol.extent.createEmpty();
+    this.journeySource.forEachFeature((f) =>
+      ol.extent.extend(ext, f.getGeometry().getExtent())
+    );
+    this.markerSource.forEachFeature((f) =>
+      ol.extent.extend(ext, f.getGeometry().getExtent())
+    );
+    if (!ol.extent.isEmpty(ext)) {
+      this.map.getView().fit(ext, { padding: [60, 60, 60, 60], maxZoom: 16, duration: 400 });
+    }
+  }
+};
+
+$(document).ready(() => new APP.PlannerPage());

--- a/static/js/planner-page.js
+++ b/static/js/planner-page.js
@@ -92,7 +92,59 @@ APP.PlannerPage = class {
     );
     $("#tpDay").val(String((now.getDay() + 6) % 7)); // JS Sun=0 -> Mon=0
 
+    // Coming back (e.g. from a 3D trip preview): restore the previous
+    // search and re-plan it, so A/B and the results survive the round trip.
+    const restored = this.restoreState();
     this.loadStops();
+    if (restored) this.plan();
+  }
+
+  // --- Session state (survives navigating to the 3D preview and back) ---------
+
+  saveState(selected) {
+    if (!this.from || !this.to) return;
+    try {
+      sessionStorage.setItem(
+        "tp-state",
+        JSON.stringify({
+          year: this.year,
+          from: this.from,
+          to: this.to,
+          time: $("#tpTime").val(),
+          day: $("#tpDay").val(),
+          selected:
+            selected != null
+              ? selected
+              : Math.max(0, $("#tpResults .tp-journey.selected").index()),
+        })
+      );
+    } catch (e) {
+      /* storage full/disabled — state just won't survive navigation */
+    }
+  }
+
+  restoreState() {
+    let s = null;
+    try {
+      s = JSON.parse(sessionStorage.getItem("tp-state"));
+    } catch (e) {
+      return false;
+    }
+    if (!s || !s.from || !s.to) return false;
+    this.year = s.year === APP.USER_ROUTE_YEAR ? s.year : "2016";
+    $(".tp-source .btn")
+      .removeClass("active")
+      .filter((_, el) => $(el).attr("data-year") === this.year)
+      .addClass("active");
+    this.from = s.from;
+    this.to = s.to;
+    $("#tpFrom").val(s.from.label || "");
+    $("#tpTo").val(s.to.label || "");
+    if (s.time) $("#tpTime").val(s.time);
+    if (s.day != null) $("#tpDay").val(s.day);
+    this.drawMarkers();
+    this._restoreSelected = s.selected;
+    return true;
   }
 
   // --- Points ----------------------------------------------------------------
@@ -219,7 +271,14 @@ APP.PlannerPage = class {
         }
         this.setStatus(notes);
         this.renderResults();
-        this.selectJourney(0);
+        // Restoring a previous session re-selects the journey it had open.
+        const sel =
+          this._restoreSelected != null
+            ? Math.min(this._restoreSelected, this.journeys.length - 1)
+            : 0;
+        this._restoreSelected = null;
+        this.selectJourney(sel);
+        this.saveState(sel);
         this.routeWalkLegs(this._planSeq);
       })
       .catch((e) => this.setStatus(e.message, "warn"));
@@ -538,6 +597,7 @@ APP.PlannerPage = class {
     const j = this.journeys[i];
     if (!j) return;
     $("#tpResults .tp-journey").removeClass("selected").eq(i).addClass("selected");
+    this.saveState(i);
     this.journeySource.clear();
 
     let rideIdx = 0;
@@ -616,4 +676,4 @@ APP.PlannerPage = class {
   }
 };
 
-$(document).ready(() => new APP.PlannerPage());
+$(document).ready(() => (APP.plannerPage = new APP.PlannerPage()));

--- a/static/js/planner-page.js
+++ b/static/js/planner-page.js
@@ -368,50 +368,86 @@ APP.PlannerPage = class {
    * walks along their routed road path when available — with the ride legs'
    * stops as the stop markers. `phases` marks which stretches of the path are
    * walked vs ridden, as fractions of total length, so the 3D engines can
-   * swap the bus for a pedestrian. */
+   * swap the bus for a pedestrian.
+   *
+   * Leg junctions don't meet exactly (ride lines pin to the stop, routed
+   * walks end at the nearest road point), which would leave short
+   * out-and-back spurs that flip the 3D heading — so tight reversals are
+   * dropped as the path is assembled. */
   ridePayload(j) {
+    const M_PER_DEG = 111320;
+    const kx = Math.cos((j.legs[0].from.lat * Math.PI) / 180);
+    const dist = (a, b) =>
+      Math.hypot((b[0] - a[0]) * kx, b[1] - a[1]) * M_PER_DEG;
+
     const path = [];
-    const stops = [];
-    const ranges = []; // {mode, start, end} index spans into path
-    const push = (lon, lat) => {
+    const legOf = []; // owning leg index per path point (for phase spans)
+    const add = (c, li) => {
+      const p = [c[0], c[1]];
       const last = path[path.length - 1];
-      if (!last || last[0] !== lon || last[1] !== lat) path.push([lon, lat]);
-    };
-    j.legs.forEach((leg) => {
-      const start = Math.max(0, path.length - 1);
-      if (leg.type === "walk") {
-        if (leg.geometry && leg.geometry.length >= 2) {
-          leg.geometry.forEach((c) => push(c[0], c[1]));
+      if (last && last[0] === p[0] && last[1] === p[1]) return;
+      path.push(p);
+      legOf.push(li);
+      // De-spike: while the last three points double back within a short
+      // hop (turn sharper than ~120° with a side under 300 m), drop the
+      // middle one — these are junction artifacts, not the route.
+      while (path.length >= 3) {
+        const a = path[path.length - 3];
+        const b = path[path.length - 2];
+        const c2 = path[path.length - 1];
+        const v1 = [(b[0] - a[0]) * kx, b[1] - a[1]];
+        const v2 = [(c2[0] - b[0]) * kx, c2[1] - b[1]];
+        const l1 = Math.hypot(v1[0], v1[1]);
+        const l2 = Math.hypot(v2[0], v2[1]);
+        if (!l1 || !l2) break;
+        const cos = (v1[0] * v2[0] + v1[1] * v2[1]) / (l1 * l2);
+        if (cos < -0.5 && Math.min(l1, l2) * M_PER_DEG < 300) {
+          path.splice(path.length - 2, 1);
+          legOf.splice(legOf.length - 2, 1);
         } else {
-          push(leg.from.lon, leg.from.lat);
-          push(leg.to.lon, leg.to.lat);
+          break;
         }
+      }
+    };
+
+    const stops = [];
+    j.legs.forEach((leg, li) => {
+      if (leg.type === "walk") {
+        // True endpoints around the routed road path, so walks connect to
+        // the A/B markers and the stops they serve.
+        add([leg.from.lon, leg.from.lat], li);
+        (leg.geometry || []).forEach((c) => add(c, li));
+        add([leg.to.lon, leg.to.lat], li);
       } else {
-        leg.geometry.forEach((c) => push(c[0], c[1]));
+        leg.geometry.forEach((c) => add(c, li));
         leg.stops.forEach((s) =>
           stops.push({ name: s.name, lon: s.lon, lat: s.lat })
         );
       }
-      ranges.push({
-        mode: leg.type === "walk" ? "walk" : "ride",
-        start,
-        end: path.length - 1,
-      });
     });
-    // Index spans -> fractions of path length (planar, cos-scaled — the same
-    // approximation the ride HUD uses; only relative position matters).
-    const kx = Math.cos((path[0][1] * Math.PI) / 180);
+
+    // Surviving per-leg spans -> fractions of total path length.
     const cum = [0];
     for (let i = 1; i < path.length; i++) {
-      cum.push(
-        cum[i - 1] +
-          Math.hypot((path[i][0] - path[i - 1][0]) * kx, path[i][1] - path[i - 1][1])
-      );
+      cum.push(cum[i - 1] + dist(path[i - 1], path[i]));
     }
     const total = cum[cum.length - 1] || 1;
-    const phases = ranges
-      .filter((r) => r.end > r.start)
-      .map((r) => ({ mode: r.mode, t0: cum[r.start] / total, t1: cum[r.end] / total }));
+    const first = {};
+    const last = {};
+    legOf.forEach((li, i) => {
+      if (first[li] == null) first[li] = i;
+      last[li] = i;
+    });
+    const phases = [];
+    j.legs.forEach((leg, li) => {
+      if (first[li] == null || last[li] <= first[li]) return; // leg despiked away
+      phases.push({
+        mode: leg.type === "walk" ? "walk" : "ride",
+        t0: cum[first[li]] / total,
+        t1: cum[last[li]] / total,
+      });
+    });
+
     const lons = path.map((p) => p[0]);
     const lats = path.map((p) => p[1]);
     return {
@@ -475,14 +511,13 @@ APP.PlannerPage = class {
     let rideIdx = 0;
     j.legs.forEach((leg) => {
       if (leg.type === "walk") {
-        // Road-following path when the foot router supplied one.
-        const pts =
-          leg.geometry && leg.geometry.length >= 2
-            ? leg.geometry
-            : [
-                [leg.from.lon, leg.from.lat],
-                [leg.to.lon, leg.to.lat],
-              ];
+        // Road-following path when the foot router supplied one, tied to the
+        // leg's true endpoints (the router snaps to the nearest road).
+        const pts = [
+          [leg.from.lon, leg.from.lat],
+          ...(leg.geometry || []),
+          [leg.to.lon, leg.to.lat],
+        ];
         const line = new ol.Feature(
           new ol.geom.LineString(pts.map((c) => APP.MapUtils.toOL(c)))
         );

--- a/static/js/planner-page.js
+++ b/static/js/planner-page.js
@@ -4,6 +4,11 @@
 // journeys draw on the map: solid colored ride legs, dashed walk legs.
 window.APP = window.APP || {};
 
+// Pedestrian routing for walk legs (the OSRM instance behind osm.org's foot
+// directions): turns straight A→B hops into road-following paths. Purely a
+// display upgrade — journey times still come from the planner.
+const FOOT_ROUTER = "https://routing.openstreetmap.de/routed-foot/route/v1/foot";
+
 APP.PlannerPage = class {
   constructor() {
     this.map = null;
@@ -14,6 +19,8 @@ APP.PlannerPage = class {
     this.pick = null; // "from" | "to" | null — armed map-pick target
     this.stops = []; // searchable stops of the current source
     this.journeys = [];
+    this._planSeq = 0; // invalidates in-flight walk routing on replan
+    this._walkCache = new Map(); // "lon,lat,lon,lat" -> Promise<route|null>
     this.init();
   }
 
@@ -213,8 +220,58 @@ APP.PlannerPage = class {
         this.setStatus(notes);
         this.renderResults();
         this.selectJourney(0);
+        this.routeWalkLegs(this._planSeq);
       })
       .catch((e) => this.setStatus(e.message, "warn"));
+  }
+
+  // --- Walk legs along real roads ---------------------------------------------
+
+  /** Upgrade every walk leg of the current journeys to a road-following path,
+   * then redraw. Straight lines remain wherever routing fails. */
+  routeWalkLegs(seq) {
+    const legs = [];
+    this.journeys.forEach((j) =>
+      j.legs.forEach((l) => l.type === "walk" && legs.push(l))
+    );
+    Promise.allSettled(legs.map((l) => this.routeWalkLeg(l))).then(() => {
+      if (seq !== this._planSeq) return; // results were replaced meanwhile
+      const sel = $("#tpResults .tp-journey.selected").index();
+      this.renderResults();
+      this.selectJourney(sel >= 0 ? sel : 0);
+    });
+  }
+
+  routeWalkLeg(leg) {
+    const key = [leg.from.lon, leg.from.lat, leg.to.lon, leg.to.lat]
+      .map((v) => v.toFixed(5))
+      .join(",");
+    if (!this._walkCache.has(key)) {
+      const url =
+        `${FOOT_ROUTER}/${leg.from.lon},${leg.from.lat};` +
+        `${leg.to.lon},${leg.to.lat}?overview=full&geometries=geojson`;
+      this._walkCache.set(
+        key,
+        fetch(url, { signal: AbortSignal.timeout(8000) })
+          .then((r) => (r.ok ? r.json() : null))
+          .then((d) => {
+            const rt = d && d.routes && d.routes[0];
+            return rt && rt.geometry && rt.geometry.coordinates.length >= 2
+              ? {
+                  coords: rt.geometry.coordinates,
+                  dist: Math.round(rt.distance),
+                }
+              : null;
+          })
+          .catch(() => null)
+      );
+    }
+    return this._walkCache.get(key).then((r) => {
+      if (r) {
+        leg.geometry = r.coords;
+        leg.road_dist_m = r.dist;
+      }
+    });
   }
 
   // --- Results list ---------------------------------------------------------------
@@ -261,11 +318,12 @@ APP.PlannerPage = class {
         const row = $('<div class="tp-leg"></div>');
         if (leg.type === "walk") {
           const dest = leg.to.name || "destination";
+          const dist = leg.road_dist_m || leg.dist_m;
           row.addClass("tp-leg-walk").append(
             $('<span class="tp-leg-icon">🚶</span>'),
             $('<span class="tp-leg-text"></span>').text(
               `${this.fmtDur(leg.arrive - leg.depart)} walk to ${dest}` +
-                (leg.dist_m ? ` (${leg.dist_m} m)` : "")
+                (dist ? ` (${dist} m)` : "")
             )
           );
         } else {
@@ -306,26 +364,54 @@ APP.PlannerPage = class {
   // --- 3D ride preview --------------------------------------------------------
 
   /** A planned journey reshaped into ride geometry ({segments, stops, bounds,
-   * name}): all legs concatenated into one continuous drive path — walks as
-   * straight hops — with the ride legs' stops as the stop markers. */
+   * phases, name}): all legs concatenated into one continuous drive path —
+   * walks along their routed road path when available — with the ride legs'
+   * stops as the stop markers. `phases` marks which stretches of the path are
+   * walked vs ridden, as fractions of total length, so the 3D engines can
+   * swap the bus for a pedestrian. */
   ridePayload(j) {
     const path = [];
     const stops = [];
+    const ranges = []; // {mode, start, end} index spans into path
     const push = (lon, lat) => {
       const last = path[path.length - 1];
       if (!last || last[0] !== lon || last[1] !== lat) path.push([lon, lat]);
     };
     j.legs.forEach((leg) => {
+      const start = Math.max(0, path.length - 1);
       if (leg.type === "walk") {
-        push(leg.from.lon, leg.from.lat);
-        push(leg.to.lon, leg.to.lat);
+        if (leg.geometry && leg.geometry.length >= 2) {
+          leg.geometry.forEach((c) => push(c[0], c[1]));
+        } else {
+          push(leg.from.lon, leg.from.lat);
+          push(leg.to.lon, leg.to.lat);
+        }
       } else {
         leg.geometry.forEach((c) => push(c[0], c[1]));
         leg.stops.forEach((s) =>
           stops.push({ name: s.name, lon: s.lon, lat: s.lat })
         );
       }
+      ranges.push({
+        mode: leg.type === "walk" ? "walk" : "ride",
+        start,
+        end: path.length - 1,
+      });
     });
+    // Index spans -> fractions of path length (planar, cos-scaled — the same
+    // approximation the ride HUD uses; only relative position matters).
+    const kx = Math.cos((path[0][1] * Math.PI) / 180);
+    const cum = [0];
+    for (let i = 1; i < path.length; i++) {
+      cum.push(
+        cum[i - 1] +
+          Math.hypot((path[i][0] - path[i - 1][0]) * kx, path[i][1] - path[i - 1][1])
+      );
+    }
+    const total = cum[cum.length - 1] || 1;
+    const phases = ranges
+      .filter((r) => r.end > r.start)
+      .map((r) => ({ mode: r.mode, t0: cum[r.start] / total, t1: cum[r.end] / total }));
     const lons = path.map((p) => p[0]);
     const lats = path.map((p) => p[1]);
     return {
@@ -337,6 +423,7 @@ APP.PlannerPage = class {
         maxLon: Math.max(...lons),
         maxLat: Math.max(...lats),
       },
+      phases,
       name: `Planned trip ${this.fmt(j.departure)} → ${this.fmt(j.arrival)}`,
     };
   }
@@ -388,11 +475,16 @@ APP.PlannerPage = class {
     let rideIdx = 0;
     j.legs.forEach((leg) => {
       if (leg.type === "walk") {
+        // Road-following path when the foot router supplied one.
+        const pts =
+          leg.geometry && leg.geometry.length >= 2
+            ? leg.geometry
+            : [
+                [leg.from.lon, leg.from.lat],
+                [leg.to.lon, leg.to.lat],
+              ];
         const line = new ol.Feature(
-          new ol.geom.LineString([
-            APP.MapUtils.toOL([leg.from.lon, leg.from.lat]),
-            APP.MapUtils.toOL([leg.to.lon, leg.to.lat]),
-          ])
+          new ol.geom.LineString(pts.map((c) => APP.MapUtils.toOL(c)))
         );
         line.setStyle(
           new ol.style.Style({

--- a/static/js/planner-page.js
+++ b/static/js/planner-page.js
@@ -293,6 +293,38 @@ APP.PlannerPage = class {
       : APP.ROUTE_COLORS[i % APP.ROUTE_COLORS.length];
   }
 
+  /** Remove short out-and-back spurs from a [lon,lat] polyline (turns
+   * sharper than ~120° with a side under 300 m) — junction artifacts where
+   * stop pins and road-snapped endpoints don't quite meet. */
+  despike(pts) {
+    if (pts.length < 3) return pts;
+    const M_PER_DEG = 111320;
+    const kx = Math.cos((pts[0][1] * Math.PI) / 180);
+    const out = [];
+    for (const p of pts) {
+      const last = out[out.length - 1];
+      if (last && last[0] === p[0] && last[1] === p[1]) continue;
+      out.push(p);
+      while (out.length >= 3) {
+        const a = out[out.length - 3];
+        const b = out[out.length - 2];
+        const c = out[out.length - 1];
+        const v1 = [(b[0] - a[0]) * kx, b[1] - a[1]];
+        const v2 = [(c[0] - b[0]) * kx, c[1] - b[1]];
+        const l1 = Math.hypot(v1[0], v1[1]);
+        const l2 = Math.hypot(v2[0], v2[1]);
+        if (!l1 || !l2) break;
+        const cos = (v1[0] * v2[0] + v1[1] * v2[1]) / (l1 * l2);
+        if (cos < -0.5 && Math.min(l1, l2) * M_PER_DEG < 300) {
+          out.splice(out.length - 2, 1);
+        } else {
+          break;
+        }
+      }
+    }
+    return out;
+  }
+
   renderResults() {
     const out = $("#tpResults").empty();
     this.journeys.forEach((j, ji) => {
@@ -513,11 +545,11 @@ APP.PlannerPage = class {
       if (leg.type === "walk") {
         // Road-following path when the foot router supplied one, tied to the
         // leg's true endpoints (the router snaps to the nearest road).
-        const pts = [
+        const pts = this.despike([
           [leg.from.lon, leg.from.lat],
           ...(leg.geometry || []),
           [leg.to.lon, leg.to.lat],
-        ];
+        ]);
         const line = new ol.Feature(
           new ol.geom.LineString(pts.map((c) => APP.MapUtils.toOL(c)))
         );
@@ -535,7 +567,7 @@ APP.PlannerPage = class {
         return;
       }
       const color = this.rideColor(leg, rideIdx++);
-      const coords = leg.geometry.map((c) => APP.MapUtils.toOL(c));
+      const coords = this.despike(leg.geometry).map((c) => APP.MapUtils.toOL(c));
       const line = new ol.Feature(new ol.geom.LineString(coords));
       line.setStyle([
         new ol.style.Style({

--- a/static/js/planner-page.js
+++ b/static/js/planner-page.js
@@ -66,6 +66,24 @@ APP.PlannerPage = class {
     $("#tpPickTo").on("click", () => this.armPick("to"));
     $("#tpSwap").on("click", () => this.swap());
     $("#tpPlan").on("click", () => this.plan());
+    $("#tpClearPlan").on("click", () => this.clearPlan());
+
+    // Recent trips: click to make a saved search the active one; ✕ removes it.
+    $("#tpTripsClear").on("click", () => {
+      this._saveTrips([]);
+      this.renderTrips();
+    });
+    $("#tpTrips").on("click", ".tp-trip", (e) => {
+      if ($(e.target).closest(".tp-trip-del").length) return;
+      this.loadTrip($(e.currentTarget).index());
+    });
+    $("#tpTrips").on("click", ".tp-trip-del", (e) => {
+      e.stopPropagation();
+      const trips = this._loadTrips();
+      trips.splice($(e.currentTarget).closest(".tp-trip").index(), 1);
+      this._saveTrips(trips);
+      this.renderTrips();
+    });
     $("#tpFrom").on("change", () => this.stopTyped("from"));
     $("#tpTo").on("change", () => this.stopTyped("to"));
     $("#tpResults").on("click", ".tp-journey", (e) => {
@@ -96,7 +114,111 @@ APP.PlannerPage = class {
     // search and re-plan it, so A/B and the results survive the round trip.
     const restored = this.restoreState();
     this.loadStops();
+    this.renderTrips();
     if (restored) this.plan();
+  }
+
+  // --- Recent trips (persist across sessions in localStorage) -----------------
+
+  _loadTrips() {
+    try {
+      const a = JSON.parse(localStorage.getItem("tp-trips"));
+      return Array.isArray(a) ? a : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  _saveTrips(trips) {
+    try {
+      localStorage.setItem("tp-trips", JSON.stringify(trips));
+    } catch (e) {
+      /* storage full/disabled — trips just won't persist */
+    }
+  }
+
+  _tripKey(t) {
+    return [t.year, t.from.lon, t.from.lat, t.to.lon, t.to.lat, t.time, t.day]
+      .join("|");
+  }
+
+  /** Put the current search at the top of the recent list (deduped, capped). */
+  addTrip() {
+    if (!this.from || !this.to) return;
+    const t = {
+      year: this.year,
+      from: this.from,
+      to: this.to,
+      time: $("#tpTime").val(),
+      day: $("#tpDay").val(),
+    };
+    const trips = this._loadTrips().filter(
+      (x) => this._tripKey(x) !== this._tripKey(t)
+    );
+    trips.unshift(t);
+    this._saveTrips(trips.slice(0, 8));
+    this.renderTrips();
+  }
+
+  renderTrips() {
+    const trips = this._loadTrips();
+    $("#tpTripsSection").toggle(trips.length > 0);
+    const out = $("#tpTrips").empty();
+    const days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+    trips.forEach((t) => {
+      out.append(
+        $('<div class="tp-trip" title="Load this trip"></div>').append(
+          $('<span class="tp-trip-route"></span>').text(
+            `${t.from.label || "A"} → ${t.to.label || "B"}`
+          ),
+          $('<span class="tp-trip-meta"></span>').text(
+            `${t.time} ${days[+t.day] || ""} · ` +
+              (t.year === APP.USER_ROUTE_YEAR ? "my routes" : t.year)
+          ),
+          $('<a class="tp-trip-del" title="Remove this trip">✕</a>')
+        )
+      );
+    });
+  }
+
+  /** Make a saved trip the active one: restore its form and re-plan. */
+  loadTrip(i) {
+    const t = this._loadTrips()[i];
+    if (!t) return;
+    const year = t.year === APP.USER_ROUTE_YEAR ? t.year : "2016";
+    if (year !== this.year) {
+      this.year = year;
+      $(".tp-source .btn")
+        .removeClass("active")
+        .filter((_, el) => $(el).attr("data-year") === year)
+        .addClass("active");
+      this.loadStops();
+    }
+    this.from = t.from;
+    this.to = t.to;
+    $("#tpFrom").val(t.from.label || "");
+    $("#tpTo").val(t.to.label || "");
+    if (t.time) $("#tpTime").val(t.time);
+    if (t.day != null) $("#tpDay").val(t.day);
+    this.drawMarkers();
+    this.plan();
+  }
+
+  /** Reset the current plan: points, results, drawn journey, session state.
+   * The recent-trips list is untouched (it has its own remove controls). */
+  clearPlan() {
+    this._planSeq++;
+    this.from = null;
+    this.to = null;
+    $("#tpFrom").val("");
+    $("#tpTo").val("");
+    this.drawMarkers();
+    this.clearResults("");
+    try {
+      sessionStorage.removeItem("tp-state");
+    } catch (e) {
+      /* nothing to clear */
+    }
   }
 
   // --- Session state (survives navigating to the 3D preview and back) ---------
@@ -279,6 +401,7 @@ APP.PlannerPage = class {
         this._restoreSelected = null;
         this.selectJourney(sel);
         this.saveState(sel);
+        this.addTrip();
         this.routeWalkLegs(this._planSeq);
       })
       .catch((e) => this.setStatus(e.message, "warn"));

--- a/static/js/ride/maplibre-ride.js
+++ b/static/js/ride/maplibre-ride.js
@@ -113,6 +113,17 @@
     busEl.style.background = color;
     const busMarker = new maplibregl.Marker({ element: busEl }).setLngLat(start);
 
+    // On a planned-trip preview, walked stretches show a pedestrian instead.
+    let markerMode = "ride";
+    function setMarkerMode(mode) {
+      if (mode === markerMode) return;
+      markerMode = mode;
+      const walking = mode === "walk";
+      busEl.classList.toggle("walking", walking);
+      busEl.textContent = walking ? "🚶" : "";
+      busEl.style.background = walking ? "none" : color;
+    }
+
     // Ride state
     // Real km/h simulation speed; 'total' is in km, so km/h / 3600 = km/s.
     let speedKmh = parseFloat(els.speed.value) || 40;
@@ -224,6 +235,7 @@
       const heading = sampleHeading(traveled);
       const busCoord = busPt.geometry.coordinates;
 
+      setMarkerMode(RP.modeAt(geo.phases, total > 0 ? traveled / total : 0));
       busMarker.setLngLat(busCoord);
       map.jumpTo({
         center: camPt.geometry.coordinates,

--- a/static/js/ride/maplibre-ride.js
+++ b/static/js/ride/maplibre-ride.js
@@ -53,6 +53,11 @@
       return;
     }
 
+    // A planned-trip preview returns to the planner, not the route map.
+    if (routeFile === RP.TRIP_PREVIEW) {
+      document.getElementById("exit").href = "/planner";
+    }
+
     let geo;
     try {
       geo = await RP.fetchGeometry(routeFile);

--- a/static/js/ride/ride-music.js
+++ b/static/js/ride/ride-music.js
@@ -201,7 +201,9 @@ APP.RideMusic = class {
     const t0 = performance.now();
     const step = (t) => {
       if (token !== this._fadeToken) return; // superseded by a manual change
-      const k = Math.min(1, (t - t0) / 800);
+      // The first rAF timestamp can predate t0 (it's stamped at frame start),
+      // so clamp both ends or volume goes negative and throws.
+      const k = Math.min(1, Math.max(0, (t - t0) / 800));
       this.audio.volume = target * k;
       if (k < 1) requestAnimationFrame(step);
     };

--- a/static/js/ride/route-path.js
+++ b/static/js/ride/route-path.js
@@ -175,6 +175,22 @@ APP.RidePath = {
   },
 
   /**
+   * Travel mode at progress fraction u, from a trip preview's phases
+   * ([{mode: "walk"|"ride", t0, t1}] over 0..1). Plain routes have no
+   * phases — everything is ridden.
+   * @param {{mode:string, t0:number, t1:number}[]|undefined} phases
+   * @param {number} u - progress fraction (0..1)
+   * @returns {"walk"|"ride"}
+   */
+  modeAt(phases, u) {
+    if (!Array.isArray(phases) || !phases.length) return "ride";
+    for (const p of phases) {
+      if (u <= p.t1) return p.mode;
+    }
+    return phases[phases.length - 1].mode;
+  },
+
+  /**
    * Pick a stable color for a route from the shared palette, keyed by its
    * leading number so it matches the 2D map's coloring.
    * @param {string} routeFile

--- a/static/js/ride/route-path.js
+++ b/static/js/ride/route-path.js
@@ -15,12 +15,24 @@ APP.RidePath = {
     return new URLSearchParams(window.location.search).get("route");
   },
 
+  // Pseudo-route name + sessionStorage key for riding a journey planned on
+  // /planner: the planner stores ride-shaped geometry, then navigates here.
+  TRIP_PREVIEW: "trip-preview",
+
   /**
-   * Fetch parsed route geometry from the backend.
+   * Fetch parsed route geometry from the backend (or, for the planner's
+   * trip preview, from sessionStorage).
    * @param {string} routeFile - KML filename
    * @returns {Promise<{segments:number[][][], stops:object[], bounds:object, name:string}>}
    */
   async fetchGeometry(routeFile) {
+    if (routeFile === this.TRIP_PREVIEW) {
+      const raw = sessionStorage.getItem(this.TRIP_PREVIEW);
+      if (!raw) {
+        throw new Error("No planned trip to preview");
+      }
+      return JSON.parse(raw);
+    }
     const year = new URLSearchParams(window.location.search).get("year");
     const yq = year ? `?year=${encodeURIComponent(year)}` : "";
     const res = await fetch(

--- a/static/js/ride/three-ride.js
+++ b/static/js/ride/three-ride.js
@@ -274,6 +274,11 @@ async function main() {
     return;
   }
 
+  // A planned-trip preview returns to the planner, not the route map.
+  if (routeFile === RP.TRIP_PREVIEW) {
+    document.getElementById("exit").href = "/planner";
+  }
+
   let geo;
   try {
     geo = await RP.fetchGeometry(routeFile);

--- a/static/js/ride/three-ride.js
+++ b/static/js/ride/three-ride.js
@@ -217,6 +217,40 @@ function buildBus(color) {
   return bus;
 }
 
+// Low-poly pedestrian for the walked stretches of a planned-trip preview.
+// Slightly larger than life so it reads from the chase camera; limbs pivot
+// at hip/shoulder so the walk cycle can swing them.
+function buildPerson() {
+  const g = new THREE.Group();
+  const skin = new THREE.MeshLambertMaterial({ color: 0xf1c27d });
+  const shirt = new THREE.MeshLambertMaterial({ color: 0x2e86c1 });
+  const pants = new THREE.MeshLambertMaterial({ color: 0x34495e });
+  const torso = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.5, 0.42, 1.4, 10),
+    shirt
+  );
+  torso.position.y = 2.1;
+  g.add(torso);
+  const head = new THREE.Mesh(new THREE.SphereGeometry(0.4, 12, 10), skin);
+  head.position.y = 3.15;
+  g.add(head);
+  const legGeo = new THREE.CylinderGeometry(0.15, 0.13, 1.4, 8);
+  legGeo.translate(0, -0.7, 0); // pivot at the hip
+  const armGeo = new THREE.CylinderGeometry(0.11, 0.1, 1.1, 8);
+  armGeo.translate(0, -0.55, 0); // pivot at the shoulder
+  const legL = new THREE.Mesh(legGeo, pants);
+  legL.position.set(-0.22, 1.4, 0);
+  const legR = new THREE.Mesh(legGeo, pants);
+  legR.position.set(0.22, 1.4, 0);
+  const armL = new THREE.Mesh(armGeo, skin);
+  armL.position.set(-0.62, 2.7, 0);
+  const armR = new THREE.Mesh(armGeo, skin);
+  armR.position.set(0.62, 2.7, 0);
+  g.add(legL, legR, armL, armR);
+  g.userData.limbs = { legL, legR, armL, armR };
+  return g;
+}
+
 function buildStops(stops, origin) {
   const group = new THREE.Group();
   const positions = [];
@@ -300,6 +334,15 @@ async function main() {
   scene.add(buildRoad(pts, color));
   const bus = buildBus(color);
   scene.add(bus);
+  // Planned-trip previews carry walk/ride phases: walked stretches swap the
+  // bus for a pedestrian.
+  const person = (geo.phases || []).some((p) => p.mode === "walk")
+    ? buildPerson()
+    : null;
+  if (person) {
+    person.visible = false;
+    scene.add(person);
+  }
   const { group: stopGroup, positions: stopPositions } = buildStops(
     geo.stops,
     origin
@@ -331,6 +374,22 @@ async function main() {
     const tan = curve.getTangentAt(clamped).normalize();
     bus.position.set(p.x, 0, p.z);
     bus.rotation.y = Math.atan2(tan.x, tan.z);
+    if (person) {
+      const walking = RP.modeAt(geo.phases, clamped) === "walk";
+      person.visible = walking;
+      bus.visible = !walking;
+      person.position.copy(bus.position);
+      person.rotation.y = bus.rotation.y;
+      // Walk cycle keyed to distance, so the stride tracks ground speed.
+      const swing = walking
+        ? Math.sin(clamped * totalLength * 2.0) * 0.55
+        : 0;
+      const { legL, legR, armL, armR } = person.userData.limbs;
+      legL.rotation.x = swing;
+      legR.rotation.x = -swing;
+      armL.rotation.x = -swing * 0.7;
+      armR.rotation.x = swing * 0.7;
+    }
     const desired = new THREE.Vector3(
       p.x - tan.x * 17,
       9,

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -103,6 +103,13 @@
           🗺 Map
         </a>
         <a
+          href="/planner"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          title="Trip planner: point-to-point journeys with transfers"
+        >
+          🧭 Planner
+        </a>
+        <a
           href="/gtfs/guide"
           target="_blank"
           rel="noopener"

--- a/templates/index.html
+++ b/templates/index.html
@@ -72,6 +72,13 @@
         >
           🕐 GTFS
         </a>
+        <a
+          href="/planner"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          title="Trip planner: point-to-point journeys with transfers"
+        >
+          🧭 Planner
+        </a>
       </div>
     </nav>
 

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -11,7 +11,7 @@
     <link rel="shortcut icon" type="image/png" href="/favicon.png" />
     <link
       rel="stylesheet"
-      href="{{ url_for('static', filename='css/bootstrap.min.css') }}"
+      href="{{ url_for('static', filename='css/bootstrap.min.css', v=asset_v) }}"
     />
     <link
       rel="stylesheet"
@@ -25,10 +25,10 @@
     />
     <link
       rel="stylesheet"
-      href="{{ url_for('static', filename='css/styles.css') }}"
+      href="{{ url_for('static', filename='css/styles.css', v=asset_v) }}"
     />
     <script src="https://cdn.jsdelivr.net/npm/ol@v8.1.0/dist/ol.js"></script>
-    <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/jquery.min.js', v=asset_v) }}"></script>
   </head>
   <body class="gtfs-page planner-page">
     <nav class="navbar navbar-fixed-top navbar-inverse">
@@ -149,9 +149,9 @@
       </div>
     </div>
 
-    <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/config.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/planner-page.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/bootstrap.min.js', v=asset_v) }}"></script>
+    <script src="{{ url_for('static', filename='js/config.js', v=asset_v) }}"></script>
+    <script src="{{ url_for('static', filename='js/utils.js', v=asset_v) }}"></script>
+    <script src="{{ url_for('static', filename='js/planner-page.js', v=asset_v) }}"></script>
   </body>
 </html>

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -107,10 +107,23 @@
                 <option value="6">Sunday</option>
               </select>
             </div>
-            <button type="button" class="btn btn-primary btn-block" id="tpPlan">
-              Plan trip
-            </button>
+            <div class="tp-plan-row">
+              <button type="button" class="btn btn-primary" id="tpPlan">
+                Plan trip
+              </button>
+              <button type="button" class="btn btn-default" id="tpClearPlan"
+                title="Clear the current trip — points, results and the drawn journey">✕</button>
+            </div>
             <div id="tpStatus" class="tp-status"></div>
+          </div>
+          <!-- Recent trips: every planned search is kept (newest first, one
+               active at a time) so frequent journeys are one click away. -->
+          <div class="tp-section" id="tpTripsSection" style="display: none">
+            <div class="tp-label tp-trips-head">
+              Recent trips
+              <a id="tpTripsClear" title="Remove all saved trips">clear all</a>
+            </div>
+            <div id="tpTrips"></div>
           </div>
           <div id="tpResults" class="tp-results"></div>
         </div>

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Brunei Bus Routes — trip planner" />
+    <title>Trip planner — Brunei Bus Routes</title>
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="apple-touch-icon" href="/favicon.png" />
+    <link rel="shortcut icon" type="image/png" href="/favicon.png" />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/bootstrap.min.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/ol@v8.1.0/ol.css"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&family=IBM+Plex+Mono:wght@400;600&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/ol@v8.1.0/dist/ol.js"></script>
+    <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
+  </head>
+  <body class="gtfs-page planner-page">
+    <nav class="navbar navbar-fixed-top navbar-inverse">
+      <div class="container-fluid">
+        <div class="navbar-header">
+          <a class="navbar-brand" href="/">Brunei Bus Routes <span class="gtfs-brand-tag">PLANNER</span></a>
+        </div>
+        <ul class="nav navbar-nav">
+          <li>
+            <select id="mapStyle" class="form-control">
+              <option value="osm">OpenStreetMap</option>
+              <option value="satellite">Satellite</option>
+              <option value="terrain">Terrain</option>
+              <option value="dark">Dark</option>
+            </select>
+          </li>
+        </ul>
+        <a
+          href="/gtfs"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          title="GTFS workbench: edit schedules &amp; route geometry"
+        >
+          🕐 GTFS
+        </a>
+        <a
+          href="/"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          title="Back to the route map"
+        >
+          🗺 Map
+        </a>
+      </div>
+    </nav>
+
+    <div class="gtfs-layout">
+      <div class="gtfs-sidebar tp-sidebar">
+        <div class="tp-head">🧭 Trip planner</div>
+        <div class="tp-body">
+          <div class="tp-section">
+            <div class="tp-label">Data source</div>
+            <!-- Exactly two sources: the shipped 2016 dataset, or the routes
+                 drawn & scheduled in the GTFS workbench. -->
+            <div class="btn-group btn-group-justified tp-source" role="group">
+              <a class="btn btn-default active" id="tpSource2016" data-year="2016">2016 official</a>
+              <a class="btn btn-default" id="tpSourceMine">My routes</a>
+            </div>
+          </div>
+          <div class="tp-section">
+            <div class="tp-point-row">
+              <span class="tp-dot tp-dot-a">A</span>
+              <input type="text" id="tpFrom" class="form-control input-sm"
+                list="tpStopOptions" autocomplete="off"
+                placeholder="From — click the map or type a stop" />
+              <button type="button" class="btn btn-default btn-sm tp-pick" id="tpPickFrom"
+                title="Pick the start point on the map">📍</button>
+            </div>
+            <div class="tp-point-row">
+              <span class="tp-dot tp-dot-b">B</span>
+              <input type="text" id="tpTo" class="form-control input-sm"
+                list="tpStopOptions" autocomplete="off"
+                placeholder="To — click the map or type a stop" />
+              <button type="button" class="btn btn-default btn-sm tp-pick" id="tpPickTo"
+                title="Pick the destination on the map">📍</button>
+            </div>
+            <div class="tp-when-row">
+              <button type="button" class="btn btn-default btn-sm" id="tpSwap"
+                title="Swap start and destination">⇅</button>
+              <label>Depart <input type="time" id="tpTime" class="form-control input-sm" /></label>
+              <select id="tpDay" class="form-control input-sm" title="Day of travel">
+                <option value="0">Monday</option>
+                <option value="1">Tuesday</option>
+                <option value="2">Wednesday</option>
+                <option value="3">Thursday</option>
+                <option value="4">Friday</option>
+                <option value="5">Saturday</option>
+                <option value="6">Sunday</option>
+              </select>
+            </div>
+            <button type="button" class="btn btn-primary btn-block" id="tpPlan">
+              Plan trip
+            </button>
+            <div id="tpStatus" class="tp-status"></div>
+          </div>
+          <div id="tpResults" class="tp-results"></div>
+        </div>
+      </div>
+
+      <div class="gtfs-map-col">
+        <div id="map"></div>
+        <div id="tpMapHint" class="tp-map-hint" style="display: none"></div>
+      </div>
+    </div>
+
+    <datalist id="tpStopOptions"></datalist>
+
+    <!-- 3D ride engine chooser for the journey preview -->
+    <div class="modal fade" id="engineModal" tabindex="-1" role="dialog">
+      <div class="modal-dialog modal-sm" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">
+              &times;
+            </button>
+            <h4 class="modal-title">🚌 Ride this trip</h4>
+          </div>
+          <div class="modal-body">
+            <p>Choose a 3D engine:</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" id="engineThree" data-dismiss="modal">
+              Three.js
+            </button>
+            <button type="button" class="btn btn-info" id="engineMaplibre" data-dismiss="modal">
+              MapLibre
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/config.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/planner-page.js') }}"></script>
+  </body>
+</html>

--- a/templates/ride_maplibre.html
+++ b/templates/ride_maplibre.html
@@ -33,15 +33,18 @@
         background: rgba(255, 255, 255, 0.7);
         border-radius: 2px;
       }
-      /* Walked stretches of a planned-trip preview: pedestrian, not bus. */
+      /* Walked stretches of a planned-trip preview: pedestrian, not bus.
+         Size stays fixed — MapLibre markers aren't shrink-wrapped, so
+         width:auto would stretch the element across the whole map. */
       .bus-marker.walking {
-        width: auto;
-        height: auto;
+        width: 28px;
+        height: 30px;
         border: none;
         border-radius: 0;
         box-shadow: none;
-        font-size: 26px;
-        line-height: 1;
+        font-size: 24px;
+        line-height: 30px;
+        text-align: center;
         text-shadow: 0 0 4px #fff, 0 1px 3px rgba(0, 0, 0, 0.6);
       }
       .bus-marker.walking::after {

--- a/templates/ride_maplibre.html
+++ b/templates/ride_maplibre.html
@@ -33,6 +33,20 @@
         background: rgba(255, 255, 255, 0.7);
         border-radius: 2px;
       }
+      /* Walked stretches of a planned-trip preview: pedestrian, not bus. */
+      .bus-marker.walking {
+        width: auto;
+        height: auto;
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+        font-size: 26px;
+        line-height: 1;
+        text-shadow: 0 0 4px #fff, 0 1px 3px rgba(0, 0, 0, 0.6);
+      }
+      .bus-marker.walking::after {
+        display: none;
+      }
     </style>
   </head>
   <body>

--- a/templates/ride_maplibre.html
+++ b/templates/ride_maplibre.html
@@ -11,7 +11,7 @@
     />
     <link
       rel="stylesheet"
-      href="{{ url_for('static', filename='css/ride.css') }}"
+      href="{{ url_for('static', filename='css/ride.css', v=asset_v) }}"
     />
     <style>
       /* simple top-down bus marker (map rotates so travel dir is "up") */
@@ -102,10 +102,10 @@
 
     <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
     <script src="https://unpkg.com/@turf/turf@7.1.0/turf.min.js"></script>
-    <script src="{{ url_for('static', filename='js/config.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/ride/route-path.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/ride/minimap.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/ride/ride-music.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/ride/maplibre-ride.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/config.js', v=asset_v) }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/route-path.js', v=asset_v) }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/minimap.js', v=asset_v) }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/ride-music.js', v=asset_v) }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/maplibre-ride.js', v=asset_v) }}"></script>
   </body>
 </html>

--- a/templates/ride_three.html
+++ b/templates/ride_three.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link
       rel="stylesheet"
-      href="{{ url_for('static', filename='css/ride.css') }}"
+      href="{{ url_for('static', filename='css/ride.css', v=asset_v) }}"
     />
   </head>
   <body>
@@ -62,10 +62,10 @@
     </div>
 
     <!-- Shared config (ROUTE_COLORS) + geometry helper, then the ES module -->
-    <script src="{{ url_for('static', filename='js/config.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/ride/route-path.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/ride/minimap.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/ride/ride-music.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/config.js', v=asset_v) }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/route-path.js', v=asset_v) }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/minimap.js', v=asset_v) }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/ride-music.js', v=asset_v) }}"></script>
     <script type="importmap">
       {
         "imports": {
@@ -75,7 +75,7 @@
     </script>
     <script
       type="module"
-      src="{{ url_for('static', filename='js/ride/three-ride.js') }}"
+      src="{{ url_for('static', filename='js/ride/three-ride.js', v=asset_v) }}"
     ></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Adds a point-to-point **trip planner** (`/planner`, 🧭 in the navbar) that answers "how do I get from A to B" — where to board, which routes to ride, where to transfer — with a source selector for exactly two datasets: the **2016 official** routes or **My routes** (drawn & scheduled in the GTFS workbench).

### Planner core
- `planner.py`: RAPTOR over the same in-memory GTFS feed the export emits, so planned journeys match what any feed consumer would compute. Frequency trips expand into explicit departures; footpaths are transitively closed (a RAPTOR precondition); results are the Pareto set over arrival vs transfers. Verified against a brute-force connection-scan oracle (0 mismatches across random query sweeps, ~10 ms/query).
- Boards each trip at the stop that's **easiest to reach** (least walking), not the algorithm's earliest catchable position; chained access walks merge into one leg.
- Network cached per year, invalidated by a DB change stamp.

### UI
- A/B by map click or stop-name search, departure time + day, journey cards with per-leg detail drawn on the map.
- Walk legs follow real roads via the public OSM foot router (straight-line fallback offline).
- **Recent trips** list (localStorage): click to re-activate, per-trip ✕, clear-all; plus a clear button for the current search. State survives navigating to the 3D preview and back.

### 3D ride preview
- 🚌 3D preview rides a planned journey end-to-end in either engine; walked stretches swap the bus for an animated 3D person (Three.js) / 🚶 marker (MapLibre), and exit returns to the planner.
- Ride-leg geometry is validated, anchored to its stops, and threaded hop-by-hop through multi-pass shapes whose stop order doesn't follow the drawn line — no more multi-km straight cuts.

Headless-Edge E2E tests covered the marker swap, state restore round-trip, and recent-trips flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)