### PR TITLE
Replit-ready: persistent Postgres storage, write rate limiting, and a gated editor

### DIFF
--- a/.replit
+++ b/.replit
@@ -6,6 +6,9 @@
 #    every redeploy and does not share between instances.
 #  - The dev workspace "Run" button starts the Flask dev server; the deployment
 #    serves through gunicorn.
+#  - To protect editing, set two Secrets (Tools -> Secrets): EDITOR_PASSWORD (the
+#    shared editor password) and SECRET_KEY (a long random string for the session
+#    cookie). Without EDITOR_PASSWORD the editor is left open. See auth.py / README.
 
 modules = ["python-3.11"]
 

--- a/.replit
+++ b/.replit
@@ -6,9 +6,10 @@
 #    every redeploy and does not share between instances.
 #  - The dev workspace "Run" button starts the Flask dev server; the deployment
 #    serves through gunicorn.
-#  - To protect editing, set two Secrets (Tools -> Secrets): EDITOR_PASSWORD (the
+#  - To enable editing, set two Secrets (Tools -> Secrets): EDITOR_PASSWORD (the
 #    shared editor password) and SECRET_KEY (a long random string for the session
-#    cookie). Without EDITOR_PASSWORD the editor is left open. See auth.py / README.
+#    cookie). Fail-closed: without EDITOR_PASSWORD, editing is locked (no one can
+#    log in). See auth.py / README.
 
 modules = ["python-3.11"]
 

--- a/.replit
+++ b/.replit
@@ -1,0 +1,24 @@
+# Replit configuration. Hosting notes:
+#  - Add the PostgreSQL tool to the Repl (Tools -> "PostgreSQL"). Replit then
+#    injects DATABASE_URL, and db.py uses Postgres automatically. Route edits
+#    persist across redeploys and across autoscale instances. Without it the app
+#    falls back to a local SQLite file, which an Autoscale Deployment wipes on
+#    every redeploy and does not share between instances.
+#  - The dev workspace "Run" button starts the Flask dev server; the deployment
+#    serves through gunicorn.
+
+modules = ["python-3.11"]
+
+# Dev workspace.
+run = "python app.py"
+
+[env]
+PORT = "8080"
+
+[deployment]
+deploymentTarget = "autoscale"
+run = ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "2", "app:app"]
+
+[[ports]]
+localPort = 8080
+externalPort = 80

--- a/README.md
+++ b/README.md
@@ -157,8 +157,9 @@ requires logging in with a single shared password (`auth.py`).
 
 Set two secrets (Repl → Tools → Secrets):
 
-- `EDITOR_PASSWORD` — the editor password. **If unset, editing is left open** (as
-  it was before) and a warning is logged at startup, so set it in production.
+- `EDITOR_PASSWORD` — the editor password. **Fail-closed: if unset, editing is
+  locked** (no one can log in) and a warning is logged at startup. Set it to
+  enable the editor — locally and in production alike.
 - `SECRET_KEY` — a long random string that signs the session cookie. Required so
   the login stays valid across gunicorn workers and autoscale instances; locally
   it falls back to a random per-process value (sessions reset on restart).

--- a/README.md
+++ b/README.md
@@ -121,6 +121,34 @@ python -m venv .venv
 Then open http://localhost:8000 in your browser. To stop the server, press
 Ctrl+C in the terminal.
 
+## Hosting on Replit
+
+The app runs on Replit as-is, but route edits need a persistent home. Edits are
+stored in a database whose backend is chosen at runtime (see `db.py`):
+
+- **No `DATABASE_URL`** → a local SQLite file (`instance/edits.db`). Fine for
+  local dev, but a Replit Autoscale Deployment has an **ephemeral filesystem**:
+  the file is wiped on every redeploy and is not shared between instances, so
+  saved edits would be lost.
+- **`DATABASE_URL` set** → PostgreSQL, which lives outside that filesystem and
+  persists across redeploys and instances.
+
+To host with persistence:
+
+1. Add the **PostgreSQL** tool to your Repl (Tools → PostgreSQL). Replit injects
+   `DATABASE_URL` automatically; the app picks it up with no code changes.
+2. Deploy. The included `.replit` runs the app under gunicorn for Autoscale.
+3. (Optional) Carry over existing local edits — with `DATABASE_URL` pointing at
+   the Postgres target, run:
+
+   ```bash
+   python scripts/migrate_sqlite_to_pg.py   # copies instance/edits.db into Postgres
+   ```
+
+The git-tracked route data and stop images travel with the repo, and the
+client-side bits (recent trips, ride-music settings) live in browser
+`localStorage` — neither is affected by the host.
+
 ## Usage
 
 - Use the sidebar to toggle different bus routes on/off

--- a/README.md
+++ b/README.md
@@ -149,6 +149,24 @@ The git-tracked route data and stop images travel with the repo, and the
 client-side bits (recent trips, ride-music settings) live in browser
 `localStorage` — neither is affected by the host.
 
+### Editor login
+
+The map, planner, and ride pages are public and read-only. **Editing** — route
+geometry, schedules, notes, the `/gtfs` workbench, and all write endpoints —
+requires logging in with a single shared password (`auth.py`).
+
+Set two secrets (Repl → Tools → Secrets):
+
+- `EDITOR_PASSWORD` — the editor password. **If unset, editing is left open** (as
+  it was before) and a warning is logged at startup, so set it in production.
+- `SECRET_KEY` — a long random string that signs the session cookie. Required so
+  the login stays valid across gunicorn workers and autoscale instances; locally
+  it falls back to a random per-process value (sessions reset on restart).
+
+Log in via the **✎ Log in** button (or visit `/login`). The session cookie is
+`HttpOnly`, `SameSite=Lax`, and `Secure` in production. Login attempts are rate
+limited to slow password guessing.
+
 ### Rate limiting
 
 The data-entry (write) endpoints are rate limited per client IP to stop

--- a/README.md
+++ b/README.md
@@ -149,6 +149,20 @@ The git-tracked route data and stop images travel with the repo, and the
 client-side bits (recent trips, ride-music settings) live in browser
 `localStorage` — neither is affected by the host.
 
+### Rate limiting
+
+The data-entry (write) endpoints are rate limited per client IP to stop
+automated flooding of the edits DB. Defaults are **30 writes / 10s** and
+**100 writes / 60s** — far above human editing (autosaves debounce at ~0.6–0.8s),
+but enough to cut off a script within seconds. Over-limit requests get `429` with
+a `Retry-After` header. Counters live in the app DB (`ratelimit.py`), so limits
+hold across gunicorn workers and autoscale instances. Reads are not limited.
+
+Tune without code changes via env vars: `RATE_LIMIT_WRITE="30/10,100/60"`
+(hits/seconds, comma-separated) or `RATE_LIMIT_DISABLED=1` to turn it off. The app
+trusts one proxy hop (`X-Forwarded-For`) so the real client IP is used behind
+Replit's proxy.
+
 ## Usage
 
 - Use the sidebar to toggle different bus routes on/off

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 from flask import (
     Flask, render_template, send_from_directory, jsonify, json, request, Response,
-    url_for,
+    url_for, session, redirect,
 )
 import csv
 import datetime
@@ -16,6 +16,7 @@ import db
 import gtfs
 import planner
 import ratelimit
+import auth
 
 # Prefer defusedxml to guard against XXE / entity-expansion attacks; fall back
 # to the stdlib parser (our KML files are trusted, shipped-in-repo assets).
@@ -37,6 +38,20 @@ app = Flask(
 from werkzeug.middleware.proxy_fix import ProxyFix  # noqa: E402
 
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1)
+
+# Signed-cookie sessions back the editor login (see auth.py). SECRET_KEY must be
+# set in production so the cookie validates across gunicorn workers and autoscale
+# instances (same rationale as DATABASE_URL); the random fallback is dev-only and
+# resets sessions on restart. SameSite=Lax is the CSRF baseline — the cookie isn't
+# sent on cross-site POST/DELETE/fetch — and the write endpoints already require
+# JSON. Secure is on only when SECRET_KEY is set, so local http login still works.
+app.secret_key = os.environ.get("SECRET_KEY") or os.urandom(32)
+app.config.update(
+    SESSION_COOKIE_HTTPONLY=True,
+    SESSION_COOKIE_SAMESITE="Lax",
+    SESSION_COOKIE_SECURE=bool(os.environ.get("SECRET_KEY")),
+    PERMANENT_SESSION_LIFETIME=datetime.timedelta(days=14),
+)
 
 # The route data is segregated by year so new datasets live alongside the repo
 # owner's original 2016 set (under sibling folders, e.g. data/2026). DATA_YEAR is
@@ -798,6 +813,7 @@ def get_gtfs_meta():
 
 
 @app.route("/data/gtfs-meta", methods=["POST"])
+@auth.login_required(api=True)
 @ratelimit.rate_limited()
 def save_gtfs_meta():
     payload = request.get_json(silent=True) or {}
@@ -859,6 +875,7 @@ def get_gtfs_config():
 
 
 @app.route("/data/gtfs-config", methods=["POST"])
+@auth.login_required(api=True)
 @ratelimit.rate_limited()
 def save_gtfs_config():
     payload = request.get_json(silent=True) or {}
@@ -1101,12 +1118,46 @@ def plan_trip():
     return jsonify(result)
 
 
+@app.route("/login")
+def login_page():
+    # Shared-password gate for the editor. Already in? Skip straight through.
+    if auth.is_authed():
+        return redirect(auth.safe_next(request.args.get("next")) or url_for("gtfs_page"))
+    return render_template("login.html", next=request.args.get("next", ""), error=False)
+
+
+@app.route("/login", methods=["POST"])
+@ratelimit.rate_limited(limits=[(5, 60), (20, 3600)], scope="login")
+def login_submit():
+    # Tight rate tiers above slow password brute-forcing.
+    if auth.check_password(request.form.get("password")):
+        session.permanent = True
+        session["authed"] = True
+        return redirect(auth.safe_next(request.form.get("next")) or url_for("gtfs_page"))
+    return render_template(
+        "login.html", next=request.form.get("next", ""), error=True
+    ), 401
+
+
+@app.route("/logout", methods=["POST"])
+def logout():
+    session.clear()
+    return redirect(url_for("index"))
+
+
+@app.route("/auth/status")
+def auth_status():
+    # Lets the frontend decide whether to show editor controls.
+    return jsonify({"authed": auth.is_authed()})
+
+
 @app.route("/")
 def index():
-    return render_template("index.html")
+    return render_template("index.html", authed=auth.is_authed())
 
 
 @app.route("/gtfs")
+@auth.login_required()
 def gtfs_page():
     # Dedicated GTFS workbench: route list + geometry editor + schedule forms.
     return render_template("gtfs.html")
@@ -1316,6 +1367,7 @@ def get_route_note():
 
 
 @app.route("/data/route-note", methods=["POST"])
+@auth.login_required(api=True)
 @ratelimit.rate_limited()
 def save_route_note():
     payload = request.get_json(silent=True) or {}
@@ -1331,6 +1383,7 @@ def save_route_note():
 
 
 @app.route("/data/edit/<path:filename>", methods=["POST"])
+@auth.login_required(api=True)
 @ratelimit.rate_limited()
 def save_edit(filename):
     # Save a new edited version of a route's geometry into the SQLite store.
@@ -1382,6 +1435,7 @@ def user_routes():
 
 
 @app.route("/data/create", methods=["POST"])
+@auth.login_required(api=True)
 @ratelimit.rate_limited()
 def create_route():
     # Create a brand-new (file-less) route — allowed only for USER_ROUTE_YEAR.
@@ -1407,6 +1461,7 @@ def create_route():
 
 
 @app.route("/data/edit/<path:filename>", methods=["DELETE"])
+@auth.login_required(api=True)
 @ratelimit.rate_limited()
 def delete_edit(filename):
     # Revert to original: drop all saved versions so serving falls back to disk.
@@ -1416,6 +1471,7 @@ def delete_edit(filename):
 
 
 @app.route("/data/edit/<path:filename>/restore", methods=["POST"])
+@auth.login_required(api=True)
 @ratelimit.rate_limited()
 def restore_edit(filename):
     # Append a copy of version N as a new latest version (history stays forward).

--- a/app.py
+++ b/app.py
@@ -70,12 +70,13 @@ GTFS_PARAMS = {
     "feed_lang": "ms",
 }
 
-# Route data is segregated by year so new datasets live alongside the repo
-# Route edits live in a SQLite DB under Flask's instance folder (gitignored), so
-# the shipped route files are never modified. Init at import time so it runs
-# under both `flask run` and `python app.py`.
+# Route edits live in a versioned DB, so the shipped route files are never
+# modified. Backend is chosen at runtime (see db.py): Postgres when DATABASE_URL
+# is set (e.g. Replit's managed Postgres, which survives redeploys), otherwise a
+# local SQLite file under Flask's instance folder (gitignored). Init at import
+# time so it runs under `flask run`, `python app.py`, and gunicorn alike.
 os.makedirs(app.instance_path, exist_ok=True)
-db.init_db(os.path.join(app.instance_path, "edits.db"))
+db.init_db(db_path=os.path.join(app.instance_path, "edits.db"))
 
 
 @app.context_processor
@@ -1449,4 +1450,7 @@ def favicon():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, host="0.0.0.0", port=8000)
+    # PORT is honoured for parity with hosts that inject it (Replit etc.); the
+    # dev server is for local use — production runs under gunicorn (see .replit).
+    port = int(os.environ.get("PORT", 8000))
+    app.run(debug=True, host="0.0.0.0", port=port)

--- a/app.py
+++ b/app.py
@@ -1154,7 +1154,7 @@ def auth_status():
 @app.route("/")
 def index():
     return render_template(
-        "index.html", authed=auth.is_authed(), auth_enforced=auth.enforced()
+        "index.html", authed=auth.is_authed(), auth_configured=auth.configured()
     )
 
 

--- a/app.py
+++ b/app.py
@@ -1153,7 +1153,9 @@ def auth_status():
 
 @app.route("/")
 def index():
-    return render_template("index.html", authed=auth.is_authed())
+    return render_template(
+        "index.html", authed=auth.is_authed(), auth_enforced=auth.enforced()
+    )
 
 
 @app.route("/gtfs")

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from xml.sax.saxutils import escape as _xml_escape
 import db
 import gtfs
 import planner
+import ratelimit
 
 # Prefer defusedxml to guard against XXE / entity-expansion attacks; fall back
 # to the stdlib parser (our KML files are trusted, shipped-in-repo assets).
@@ -28,6 +29,14 @@ app = Flask(
     static_folder="static",
     template_folder="templates",
 )
+
+# On Replit (and most PaaS) the app sits behind one reverse proxy, so the real
+# client IP arrives in X-Forwarded-For. Trust exactly one hop so request.remote_addr
+# reflects the client — rate limiting keys on it. Locally there's no such header,
+# so remote_addr stays the loopback address. See ratelimit.py.
+from werkzeug.middleware.proxy_fix import ProxyFix  # noqa: E402
+
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1)
 
 # The route data is segregated by year so new datasets live alongside the repo
 # owner's original 2016 set (under sibling folders, e.g. data/2026). DATA_YEAR is
@@ -789,6 +798,7 @@ def get_gtfs_meta():
 
 
 @app.route("/data/gtfs-meta", methods=["POST"])
+@ratelimit.rate_limited()
 def save_gtfs_meta():
     payload = request.get_json(silent=True) or {}
     year = _resolve_year(payload.get("year"))
@@ -849,6 +859,7 @@ def get_gtfs_config():
 
 
 @app.route("/data/gtfs-config", methods=["POST"])
+@ratelimit.rate_limited()
 def save_gtfs_config():
     payload = request.get_json(silent=True) or {}
     year = _resolve_year(payload.get("year"))
@@ -1305,6 +1316,7 @@ def get_route_note():
 
 
 @app.route("/data/route-note", methods=["POST"])
+@ratelimit.rate_limited()
 def save_route_note():
     payload = request.get_json(silent=True) or {}
     year = _resolve_year(payload.get("year"))
@@ -1319,6 +1331,7 @@ def save_route_note():
 
 
 @app.route("/data/edit/<path:filename>", methods=["POST"])
+@ratelimit.rate_limited()
 def save_edit(filename):
     # Save a new edited version of a route's geometry into the SQLite store.
     year = _resolve_year(request.args.get("year"))
@@ -1369,6 +1382,7 @@ def user_routes():
 
 
 @app.route("/data/create", methods=["POST"])
+@ratelimit.rate_limited()
 def create_route():
     # Create a brand-new (file-less) route — allowed only for USER_ROUTE_YEAR.
     year = _resolve_year(request.args.get("year"))
@@ -1393,6 +1407,7 @@ def create_route():
 
 
 @app.route("/data/edit/<path:filename>", methods=["DELETE"])
+@ratelimit.rate_limited()
 def delete_edit(filename):
     # Revert to original: drop all saved versions so serving falls back to disk.
     year = _resolve_year(request.args.get("year"))
@@ -1401,6 +1416,7 @@ def delete_edit(filename):
 
 
 @app.route("/data/edit/<path:filename>/restore", methods=["POST"])
+@ratelimit.rate_limited()
 def restore_edit(filename):
     # Append a copy of version N as a new latest version (history stays forward).
     year = _resolve_year(request.args.get("year"))

--- a/auth.py
+++ b/auth.py
@@ -8,10 +8,9 @@ cookie hardening (HttpOnly, SameSite=Lax, Secure) and SECRET_KEY wiring.
 The security boundary is the login_required decorator on the server. Frontend code
 only hides controls for anonymous visitors; it is not relied on for enforcement.
 
-If EDITOR_PASSWORD is unset, the gate is a no-op (editing stays open, as before)
-and a warning is logged at import — convenient for local dev. Production must set
-it. For fail-closed behaviour instead, make _enforced() return True unconditionally
-and have check_password() reject when no password is configured.
+Fail-closed: if EDITOR_PASSWORD is unset, no one can log in, so every write endpoint
+and the /gtfs workbench stay locked (a warning is logged at import). Set
+EDITOR_PASSWORD to enable editing — the same locally and in production.
 """
 import hmac
 import logging
@@ -25,19 +24,22 @@ _PASSWORD = os.environ.get("EDITOR_PASSWORD", "")
 
 if not _PASSWORD:
     logging.getLogger(__name__).warning(
-        "EDITOR_PASSWORD is not set — the editor is UNPROTECTED (anyone can write). "
-        "Set EDITOR_PASSWORD (and SECRET_KEY) to require login before editing."
+        "EDITOR_PASSWORD is not set — editing is LOCKED (no one can log in). "
+        "Set EDITOR_PASSWORD (and SECRET_KEY) to enable the editor."
     )
 
 
-def enforced():
-    """Auth is enforced only when a password is configured (EDITOR_PASSWORD set)."""
+def configured():
+    """True when an editor password is set. With none, login is impossible and
+    the editor stays locked (fail-closed)."""
     return bool(_PASSWORD)
 
 
 def is_authed():
-    """True if the current session has logged in (or auth isn't enforced)."""
-    return not enforced() or bool(session.get("authed"))
+    """True only for a session that has logged in. Fail-closed: with no
+    EDITOR_PASSWORD set, check_password() always fails, so this never becomes
+    True and the editor stays locked."""
+    return bool(session.get("authed"))
 
 
 def check_password(candidate):

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,81 @@
+"""Shared-password gate for the editor.
+
+One password (the EDITOR_PASSWORD env var, set as a Replit secret) protects every
+write endpoint and the /gtfs workbench; the map/planner/ride pages stay public and
+read-only. A signed session cookie keeps the editor logged in — see app.py for the
+cookie hardening (HttpOnly, SameSite=Lax, Secure) and SECRET_KEY wiring.
+
+The security boundary is the login_required decorator on the server. Frontend code
+only hides controls for anonymous visitors; it is not relied on for enforcement.
+
+If EDITOR_PASSWORD is unset, the gate is a no-op (editing stays open, as before)
+and a warning is logged at import — convenient for local dev. Production must set
+it. For fail-closed behaviour instead, make _enforced() return True unconditionally
+and have check_password() reject when no password is configured.
+"""
+import hmac
+import logging
+import os
+from functools import wraps
+from urllib.parse import urlparse
+
+from flask import jsonify, redirect, request, session, url_for
+
+_PASSWORD = os.environ.get("EDITOR_PASSWORD", "")
+
+if not _PASSWORD:
+    logging.getLogger(__name__).warning(
+        "EDITOR_PASSWORD is not set — the editor is UNPROTECTED (anyone can write). "
+        "Set EDITOR_PASSWORD (and SECRET_KEY) to require login before editing."
+    )
+
+
+def _enforced():
+    """Auth is enforced only when a password is configured."""
+    return bool(_PASSWORD)
+
+
+def is_authed():
+    """True if the current session has logged in (or auth isn't enforced)."""
+    return not _enforced() or bool(session.get("authed"))
+
+
+def check_password(candidate):
+    """Constant-time check of a submitted password against EDITOR_PASSWORD."""
+    if not _PASSWORD:
+        return False
+    return hmac.compare_digest(str(candidate or ""), _PASSWORD)
+
+
+def safe_next(target):
+    """Return target only if it's a local path (open-redirect guard), else None.
+
+    Rejects absolute URLs and scheme-relative '//host' values; accepts only paths
+    beginning with a single '/'."""
+    if not target or not target.startswith("/") or target.startswith("//"):
+        return None
+    parts = urlparse(target)
+    if parts.scheme or parts.netloc:
+        return None
+    return target
+
+
+def login_required(api=False):
+    """Decorator: require a logged-in session.
+
+    api=True  -> respond 401 JSON (for fetch/XHR write endpoints).
+    api=False -> redirect to the login page with ?next= (for HTML pages).
+
+    Place directly under @app.route and above @ratelimit.rate_limited so an
+    unauthenticated caller is rejected before consuming limiter budget.
+    """
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            if is_authed():
+                return fn(*args, **kwargs)
+            if api:
+                return jsonify({"error": "login required"}), 401
+            return redirect(url_for("login_page", next=request.path))
+        return wrapper
+    return decorator

--- a/auth.py
+++ b/auth.py
@@ -30,14 +30,14 @@ if not _PASSWORD:
     )
 
 
-def _enforced():
-    """Auth is enforced only when a password is configured."""
+def enforced():
+    """Auth is enforced only when a password is configured (EDITOR_PASSWORD set)."""
     return bool(_PASSWORD)
 
 
 def is_authed():
     """True if the current session has logged in (or auth isn't enforced)."""
-    return not _enforced() or bool(session.get("authed"))
+    return not enforced() or bool(session.get("authed"))
 
 
 def check_password(candidate):

--- a/db.py
+++ b/db.py
@@ -1,99 +1,177 @@
-"""SQLite store for route edits (full version history).
+"""Versioned store for route edits — SQLite locally, PostgreSQL on Replit.
+
+The backend is chosen at init_db(): a connection string (explicit dsn, or the
+DATABASE_URL env var that Replit's managed Postgres injects) selects PostgreSQL;
+otherwise a local SQLite file. This matters for hosting — Replit Deployments have
+an ephemeral filesystem, so a SQLite file there is wiped on every redeploy and
+not shared across autoscale instances. Postgres lives outside that filesystem
+and persists. Local dev keeps using SQLite with no setup.
+
+Every function below is backend-agnostic: the small dialect differences (the
+parameter marker `?` and `datetime('now')`) are translated for Postgres in _q(),
+and the schema's column types are emitted per-backend in _schema().
 
 Originals on disk are never modified. Each Save appends an immutable version
 row keyed by (year, filename); the highest version is the active one. Reverting
 to the original simply deletes all rows for a route so callers fall back to disk.
-
-Pure stdlib (sqlite3) — framework-agnostic; the DB path is injected by app.py.
 """
+import contextlib
 import json
+import os
 import sqlite3
 
-_DB_PATH = None
+try:
+    import psycopg
+    from psycopg.rows import dict_row
+    from psycopg import errors as _pg_errors
+    _HAVE_PSYCOPG = True
+except ImportError:  # SQLite-only environments don't need the Postgres driver
+    _HAVE_PSYCOPG = False
+
+_BACKEND = None   # "sqlite" | "postgres", set by init_db
+_DB_PATH = None   # SQLite file path
+_DSN = None       # Postgres connection string
+
+# UNIQUE-violation classes differ by backend; add_version catches both.
+_INTEGRITY_ERRORS = (sqlite3.IntegrityError,)
+if _HAVE_PSYCOPG:
+    _INTEGRITY_ERRORS = (sqlite3.IntegrityError, _pg_errors.UniqueViolation)
 
 
-def init_db(db_path):
-    """Remember the DB path and create the schema if needed (idempotent)."""
-    global _DB_PATH
-    _DB_PATH = db_path
-    with _connect() as conn:
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS route_versions (
-                id         INTEGER PRIMARY KEY AUTOINCREMENT,
-                year       TEXT    NOT NULL,
-                filename   TEXT    NOT NULL,
-                version    INTEGER NOT NULL,
-                geometry   TEXT    NOT NULL,
-                label      TEXT,
-                created_at TEXT    NOT NULL DEFAULT (datetime('now')),
-                UNIQUE (year, filename, version)
+def init_db(db_path=None, dsn=None):
+    """Choose the backend and create the schema if needed (idempotent).
+
+    Pass dsn — or set the DATABASE_URL env var (Replit's managed Postgres) — to
+    use PostgreSQL; otherwise db_path selects a local SQLite file. app.py passes
+    db_path and lets the environment decide which backend wins.
+    """
+    global _BACKEND, _DB_PATH, _DSN
+    dsn = dsn or os.environ.get("DATABASE_URL")
+    if dsn:
+        if not _HAVE_PSYCOPG:
+            raise RuntimeError(
+                "DATABASE_URL is set but psycopg is not installed; "
+                "add 'psycopg[binary]' to requirements.txt"
             )
-            """
+        # Some platforms hand out the legacy postgres:// scheme; psycopg wants
+        # postgresql://. SQLAlchemy does the same normalisation.
+        if dsn.startswith("postgres://"):
+            dsn = "postgresql://" + dsn[len("postgres://"):]
+        _BACKEND = "postgres"
+        _DSN = dsn
+    else:
+        _BACKEND = "sqlite"
+        _DB_PATH = db_path
+    with _connect() as conn:
+        for stmt in _schema():
+            conn.execute(stmt)
+
+
+@contextlib.contextmanager
+def _connect():
+    """Yield a connection, committing on clean exit and always closing.
+
+    Both backends expose conn.execute(sql, params) -> cursor and dict-style row
+    access (sqlite3.Row / psycopg dict_row), so the query functions below don't
+    care which one they got.
+    """
+    if _BACKEND is None:
+        raise RuntimeError("db.init_db(...) must be called before use")
+    if _BACKEND == "postgres":
+        conn = psycopg.connect(_DSN, row_factory=dict_row)
+    else:
+        conn = sqlite3.connect(_DB_PATH)
+        conn.row_factory = sqlite3.Row
+        # WAL keeps reads non-blocking against the occasional write.
+        conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _q(sql):
+    """Translate our SQLite-flavoured SQL to the active backend.
+
+    `?` placeholders become `%s`, and inline datetime('now') becomes the Postgres
+    equivalent. Both tokens appear only as SQL syntax here, never inside literals.
+    """
+    if _BACKEND == "postgres":
+        return sql.replace("?", "%s").replace("datetime('now')", "(now())::text")
+    return sql
+
+
+def _schema():
+    """CREATE statements for the active backend (column types differ; SQL shared)."""
+    if _BACKEND == "postgres":
+        idpk = "BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY"
+        now = "((now())::text)"
+    else:
+        idpk = "INTEGER PRIMARY KEY AUTOINCREMENT"
+        now = "(datetime('now'))"
+    return [
+        f"""
+        CREATE TABLE IF NOT EXISTS route_versions (
+            id         {idpk},
+            year       TEXT    NOT NULL,
+            filename   TEXT    NOT NULL,
+            version    INTEGER NOT NULL,
+            geometry   TEXT    NOT NULL,
+            label      TEXT,
+            created_at TEXT    NOT NULL DEFAULT {now},
+            UNIQUE (year, filename, version)
         )
-        conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_route_versions_route
-            ON route_versions (year, filename, version DESC)
-            """
-        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_route_versions_route
+        ON route_versions (year, filename, version DESC)
+        """,
         # Free-text triage notes, one per route (year, route key). Independent of
         # the version history above — notes are about a route, not a geometry edit.
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS route_notes (
-                year       TEXT NOT NULL,
-                route      TEXT NOT NULL,
-                note       TEXT NOT NULL DEFAULT '',
-                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-                PRIMARY KEY (year, route)
-            )
-            """
+        f"""
+        CREATE TABLE IF NOT EXISTS route_notes (
+            year       TEXT NOT NULL,
+            route      TEXT NOT NULL,
+            note       TEXT NOT NULL DEFAULT '',
+            updated_at TEXT NOT NULL DEFAULT {now},
+            PRIMARY KEY (year, route)
         )
+        """,
         # GTFS metadata overrides as JSON blobs. `key` is a route filename for
         # per-route data (schedule, names, color) or '_feed' for feed-level
         # settings (agency, fare). Upsert-only, like route_notes.
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS gtfs_meta (
-                year       TEXT NOT NULL,
-                key        TEXT NOT NULL,
-                data       TEXT NOT NULL DEFAULT '{}',
-                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-                PRIMARY KEY (year, key)
-            )
-            """
+        f"""
+        CREATE TABLE IF NOT EXISTS gtfs_meta (
+            year       TEXT NOT NULL,
+            key        TEXT NOT NULL,
+            data       TEXT NOT NULL DEFAULT '{{}}',
+            updated_at TEXT NOT NULL DEFAULT {now},
+            PRIMARY KEY (year, key)
         )
+        """,
         # Every overwritten gtfs_meta value is archived here, so a bad
         # autosave is recoverable (via SQL; no UI). Append-only.
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS gtfs_meta_history (
-                id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                year        TEXT NOT NULL,
-                key         TEXT NOT NULL,
-                data        TEXT NOT NULL,
-                replaced_at TEXT NOT NULL DEFAULT (datetime('now'))
-            )
-            """
+        f"""
+        CREATE TABLE IF NOT EXISTS gtfs_meta_history (
+            id          {idpk},
+            year        TEXT NOT NULL,
+            key         TEXT NOT NULL,
+            data        TEXT NOT NULL,
+            replaced_at TEXT NOT NULL DEFAULT {now}
         )
-
-
-def _connect():
-    if _DB_PATH is None:
-        raise RuntimeError("db.init_db(path) must be called before use")
-    conn = sqlite3.connect(_DB_PATH)
-    conn.row_factory = sqlite3.Row
-    # WAL keeps reads non-blocking against the occasional write.
-    conn.execute("PRAGMA journal_mode=WAL")
-    return conn
+        """,
+    ]
 
 
 def latest_version(year, filename):
     """Highest version number for a route, or None if it has no edits."""
     with _connect() as conn:
         row = conn.execute(
-            "SELECT MAX(version) AS v FROM route_versions WHERE year=? AND filename=?",
+            _q("SELECT MAX(version) AS v FROM route_versions WHERE year=? AND filename=?"),
             (year, filename),
         ).fetchone()
     return row["v"] if row and row["v"] is not None else None
@@ -103,11 +181,13 @@ def latest_geometry(year, filename):
     """Parsed geometry dict of the active (highest) version, or None."""
     with _connect() as conn:
         row = conn.execute(
-            """
-            SELECT geometry FROM route_versions
-            WHERE year=? AND filename=?
-            ORDER BY version DESC LIMIT 1
-            """,
+            _q(
+                """
+                SELECT geometry FROM route_versions
+                WHERE year=? AND filename=?
+                ORDER BY version DESC LIMIT 1
+                """
+            ),
             (year, filename),
         ).fetchone()
     return json.loads(row["geometry"]) if row else None
@@ -117,7 +197,7 @@ def distinct_files(year):
     """All distinct route filenames that have at least one saved version."""
     with _connect() as conn:
         rows = conn.execute(
-            "SELECT DISTINCT filename FROM route_versions WHERE year=?",
+            _q("SELECT DISTINCT filename FROM route_versions WHERE year=?"),
             (year,),
         ).fetchall()
     return [r["filename"] for r in rows]
@@ -128,14 +208,16 @@ def latest_names(year):
     out = {}
     with _connect() as conn:
         rows = conn.execute(
-            """
-            SELECT rv.filename AS filename, rv.geometry AS geometry
-            FROM route_versions rv
-            WHERE rv.year = ? AND rv.version = (
-                SELECT MAX(version) FROM route_versions
-                WHERE year = rv.year AND filename = rv.filename
-            )
-            """,
+            _q(
+                """
+                SELECT rv.filename AS filename, rv.geometry AS geometry
+                FROM route_versions rv
+                WHERE rv.year = ? AND rv.version = (
+                    SELECT MAX(version) FROM route_versions
+                    WHERE year = rv.year AND filename = rv.filename
+                )
+                """
+            ),
             (year,),
         ).fetchall()
     for r in rows:
@@ -152,11 +234,13 @@ def list_versions(year, filename):
     """Version metadata (no geometry blob), newest first."""
     with _connect() as conn:
         rows = conn.execute(
-            """
-            SELECT version, created_at, label FROM route_versions
-            WHERE year=? AND filename=?
-            ORDER BY version DESC
-            """,
+            _q(
+                """
+                SELECT version, created_at, label FROM route_versions
+                WHERE year=? AND filename=?
+                ORDER BY version DESC
+                """
+            ),
             (year, filename),
         ).fetchall()
     return [dict(r) for r in rows]
@@ -166,7 +250,7 @@ def get_version(year, filename, version):
     """Parsed geometry dict for a specific version, or None."""
     with _connect() as conn:
         row = conn.execute(
-            "SELECT geometry FROM route_versions WHERE year=? AND filename=? AND version=?",
+            _q("SELECT geometry FROM route_versions WHERE year=? AND filename=? AND version=?"),
             (year, filename, version),
         ).fetchone()
     return json.loads(row["geometry"]) if row else None
@@ -178,21 +262,24 @@ def add_version(year, filename, geometry, label=None):
     for _attempt in range(2):  # UNIQUE constraint is a race backstop; retry once
         with _connect() as conn:
             row = conn.execute(
-                "SELECT MAX(version) AS v FROM route_versions WHERE year=? AND filename=?",
+                _q("SELECT MAX(version) AS v FROM route_versions WHERE year=? AND filename=?"),
                 (year, filename),
             ).fetchone()
             nxt = (row["v"] or 0) + 1
             try:
                 conn.execute(
-                    """
-                    INSERT INTO route_versions (year, filename, version, geometry, label)
-                    VALUES (?, ?, ?, ?, ?)
-                    """,
+                    _q(
+                        """
+                        INSERT INTO route_versions (year, filename, version, geometry, label)
+                        VALUES (?, ?, ?, ?, ?)
+                        """
+                    ),
                     (year, filename, nxt, payload, label),
                 )
-                conn.commit()
-                return nxt
-            except sqlite3.IntegrityError:
+                return nxt  # context manager commits on the way out
+            except _INTEGRITY_ERRORS:
+                # Postgres aborts the txn on error; roll back before the retry.
+                conn.rollback()
                 continue
     raise sqlite3.IntegrityError("could not allocate a version number")
 
@@ -201,7 +288,7 @@ def get_note(year, route):
     """Free-text note for a route, or '' if none."""
     with _connect() as conn:
         row = conn.execute(
-            "SELECT note FROM route_notes WHERE year=? AND route=?",
+            _q("SELECT note FROM route_notes WHERE year=? AND route=?"),
             (year, route),
         ).fetchone()
     return row["note"] if row else ""
@@ -211,15 +298,16 @@ def set_note(year, route, note):
     """Upsert a route's note. Returns the saved text."""
     with _connect() as conn:
         conn.execute(
-            """
-            INSERT INTO route_notes (year, route, note, updated_at)
-            VALUES (?, ?, ?, datetime('now'))
-            ON CONFLICT(year, route) DO UPDATE SET
-                note = excluded.note, updated_at = excluded.updated_at
-            """,
+            _q(
+                """
+                INSERT INTO route_notes (year, route, note, updated_at)
+                VALUES (?, ?, ?, datetime('now'))
+                ON CONFLICT (year, route) DO UPDATE SET
+                    note = excluded.note, updated_at = excluded.updated_at
+                """
+            ),
             (year, route, note),
         )
-        conn.commit()
     return note
 
 
@@ -227,7 +315,7 @@ def get_gtfs_meta(year, key):
     """GTFS metadata dict for a route filename (or '_feed'), or {} if none."""
     with _connect() as conn:
         row = conn.execute(
-            "SELECT data FROM gtfs_meta WHERE year=? AND key=?",
+            _q("SELECT data FROM gtfs_meta WHERE year=? AND key=?"),
             (year, key),
         ).fetchone()
     if not row:
@@ -245,23 +333,24 @@ def set_gtfs_meta(year, key, data):
     payload = json.dumps(data, ensure_ascii=False)
     with _connect() as conn:
         row = conn.execute(
-            "SELECT data FROM gtfs_meta WHERE year=? AND key=?", (year, key)
+            _q("SELECT data FROM gtfs_meta WHERE year=? AND key=?"), (year, key)
         ).fetchone()
         if row and row["data"] != payload:
             conn.execute(
-                "INSERT INTO gtfs_meta_history (year, key, data) VALUES (?, ?, ?)",
+                _q("INSERT INTO gtfs_meta_history (year, key, data) VALUES (?, ?, ?)"),
                 (year, key, row["data"]),
             )
         conn.execute(
-            """
-            INSERT INTO gtfs_meta (year, key, data, updated_at)
-            VALUES (?, ?, ?, datetime('now'))
-            ON CONFLICT(year, key) DO UPDATE SET
-                data = excluded.data, updated_at = excluded.updated_at
-            """,
+            _q(
+                """
+                INSERT INTO gtfs_meta (year, key, data, updated_at)
+                VALUES (?, ?, ?, datetime('now'))
+                ON CONFLICT (year, key) DO UPDATE SET
+                    data = excluded.data, updated_at = excluded.updated_at
+                """
+            ),
             (year, key, payload),
         )
-        conn.commit()
     return data
 
 
@@ -270,7 +359,7 @@ def all_gtfs_meta(year):
     out = {}
     with _connect() as conn:
         rows = conn.execute(
-            "SELECT key, data FROM gtfs_meta WHERE year=?", (year,)
+            _q("SELECT key, data FROM gtfs_meta WHERE year=?"), (year,)
         ).fetchall()
     for r in rows:
         try:
@@ -287,27 +376,26 @@ def change_stamp(year):
     whenever route geometry or GTFS metadata is saved, replaced, or deleted."""
     with _connect() as conn:
         rv = conn.execute(
-            "SELECT COUNT(*), COALESCE(MAX(id), 0) FROM route_versions WHERE year=?",
+            _q("SELECT COUNT(*) AS c, COALESCE(MAX(id), 0) AS m FROM route_versions WHERE year=?"),
             (year,),
         ).fetchone()
         gm = conn.execute(
-            "SELECT COUNT(*), COALESCE(MAX(updated_at), '') FROM gtfs_meta WHERE year=?",
+            _q("SELECT COUNT(*) AS c, COALESCE(MAX(updated_at), '') AS m FROM gtfs_meta WHERE year=?"),
             (year,),
         ).fetchone()
         # History grows on every overwrite, catching same-second meta updates.
         gh = conn.execute(
-            "SELECT COALESCE(MAX(id), 0) FROM gtfs_meta_history WHERE year=?",
+            _q("SELECT COALESCE(MAX(id), 0) AS m FROM gtfs_meta_history WHERE year=?"),
             (year,),
         ).fetchone()
-    return (rv[0], rv[1], gm[0], gm[1], gh[0])
+    return (rv["c"], rv["m"], gm["c"], gm["m"], gh["m"])
 
 
 def delete_all(year, filename):
     """Remove every version for a route (revert to original). Returns rows deleted."""
     with _connect() as conn:
         cur = conn.execute(
-            "DELETE FROM route_versions WHERE year=? AND filename=?",
+            _q("DELETE FROM route_versions WHERE year=? AND filename=?"),
             (year, filename),
         )
-        conn.commit()
         return cur.rowcount

--- a/db.py
+++ b/db.py
@@ -164,6 +164,17 @@ def _schema():
             replaced_at TEXT NOT NULL DEFAULT {now}
         )
         """,
+        # Fixed-window request counters for rate limiting (see ratelimit.py).
+        # Shared through the DB so limits hold across gunicorn workers and
+        # autoscale instances, where in-memory counters would not.
+        """
+        CREATE TABLE IF NOT EXISTS rate_limits (
+            bucket       TEXT    NOT NULL,
+            window_start BIGINT  NOT NULL,
+            hits         INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (bucket, window_start)
+        )
+        """,
     ]
 
 
@@ -389,6 +400,35 @@ def change_stamp(year):
             (year,),
         ).fetchone()
     return (rv["c"], rv["m"], gm["c"], gm["m"], gh["m"])
+
+
+def rate_limit_hit(bucket, window_start, prune_before=None):
+    """Atomically count one request in a fixed window and return the running
+    total for (bucket, window_start). Optionally drop the bucket's older windows
+    to keep the table small. Backend-shared, so counts hold across gunicorn
+    workers and autoscale instances. Used by ratelimit.py."""
+    with _connect() as conn:
+        conn.execute(
+            _q(
+                """
+                INSERT INTO rate_limits (bucket, window_start, hits)
+                VALUES (?, ?, 1)
+                ON CONFLICT (bucket, window_start)
+                DO UPDATE SET hits = rate_limits.hits + 1
+                """
+            ),
+            (bucket, window_start),
+        )
+        row = conn.execute(
+            _q("SELECT hits FROM rate_limits WHERE bucket=? AND window_start=?"),
+            (bucket, window_start),
+        ).fetchone()
+        if prune_before is not None:
+            conn.execute(
+                _q("DELETE FROM rate_limits WHERE bucket=? AND window_start<?"),
+                (bucket, prune_before),
+            )
+    return row["hits"]
 
 
 def delete_all(year, filename):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+# Local Postgres that mirrors the managed database the app uses on Replit, so
+# the Postgres backend in db.py can be exercised without deploying. Start it with
+#   docker compose up -d
+# then point the app at it:
+#   DATABASE_URL=postgresql://brunei:brunei@localhost:5432/brunei_bus python app.py
+# Data persists in the named volume across restarts; `docker compose down -v`
+# wipes it. This file is for local dev/testing only — Replit provisions its own
+# Postgres and injects DATABASE_URL.
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: brunei_bus_pg
+    environment:
+      POSTGRES_USER: brunei
+      POSTGRES_PASSWORD: brunei
+      POSTGRES_DB: brunei_bus
+    ports:
+      - "5432:5432"
+    volumes:
+      - brunei_bus_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U brunei -d brunei_bus"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  brunei_bus_pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,11 @@
 # the Postgres backend in db.py can be exercised without deploying. Start it with
 #   docker compose up -d
 # then point the app at it:
-#   DATABASE_URL=postgresql://brunei:brunei@localhost:5432/brunei_bus python app.py
+#   DATABASE_URL=postgresql://brunei:5ef5698f3195f7effabb1dbeb822b568@localhost:5432/brunei_bus python app.py
 # Data persists in the named volume across restarts; `docker compose down -v`
 # wipes it. This file is for local dev/testing only — Replit provisions its own
-# Postgres and injects DATABASE_URL.
+# Postgres and injects DATABASE_URL. The password below is a throwaway dev
+# credential; rotate it freely (recreate the container with `down -v` after).
 
 services:
   postgres:
@@ -13,7 +14,7 @@ services:
     container_name: brunei_bus_pg
     environment:
       POSTGRES_USER: brunei
-      POSTGRES_PASSWORD: brunei
+      POSTGRES_PASSWORD: 5ef5698f3195f7effabb1dbeb822b568
       POSTGRES_DB: brunei_bus
     ports:
       - "5432:5432"

--- a/ratelimit.py
+++ b/ratelimit.py
@@ -1,0 +1,88 @@
+"""Per-client rate limiting for data-entry (write) endpoints.
+
+Goal: stop a script from flooding the edits DB with automated writes, without
+getting in the way of a human editing routes (autosaves debounce at ~0.6-0.8s,
+so real sustained write rates stay well under 2/sec).
+
+Counters are fixed-window and live in the app DB (see db.rate_limit_hit), so the
+limits hold across gunicorn workers and Replit autoscale instances — in-memory
+counters would be per-process and trivially bypassed once the app scales out.
+
+Each protected endpoint is checked against every tier in WRITE_LIMITS; exceeding
+any tier returns 429 with a Retry-After header. Tune without code changes via
+the RATE_LIMIT_WRITE env var, e.g. "30/10,100/60" (hits/seconds, comma-separated),
+or set RATE_LIMIT_DISABLED=1 to turn it off entirely.
+"""
+import os
+import time
+from functools import wraps
+
+from flask import jsonify, request
+
+import db
+
+# Defaults: 30 writes / 10s (burst) and 100 writes / 60s (sustained), per client.
+# Both sit far above human editing yet cut off automated flooding within seconds.
+_DEFAULT_WRITE_LIMITS = [(30, 10), (100, 60)]
+
+
+def _parse_limits(spec):
+    """Parse "hits/seconds,hits/seconds" into [(hits, seconds), ...]."""
+    out = []
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        hits, _, window = part.partition("/")
+        out.append((int(hits), int(window)))
+    return out
+
+
+_env = os.environ.get("RATE_LIMIT_WRITE", "").strip()
+WRITE_LIMITS = _parse_limits(_env) if _env else _DEFAULT_WRITE_LIMITS
+_DISABLED = os.environ.get("RATE_LIMIT_DISABLED", "").strip() in ("1", "true", "True")
+
+
+def _client_id():
+    """Identify the caller. Behind Replit's proxy, ProxyFix (configured in
+    app.py) rewrites remote_addr from the trusted X-Forwarded-For entry, so this
+    is the real client IP, not the proxy's."""
+    return request.remote_addr or "unknown"
+
+
+def rate_limited(limits=None, scope="write"):
+    """Decorator: reject a request that exceeds any configured rate tier.
+
+    Place it directly under @app.route so the route registers the wrapped view:
+        @app.route("/data/edit/<path:filename>", methods=["POST"])
+        @rate_limited()
+        def save_route(...): ...
+    """
+    tiers = limits if limits is not None else WRITE_LIMITS
+
+    def decorator(fn):
+        if _DISABLED or not tiers:
+            return fn
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            now = int(time.time())
+            ident = _client_id()
+            retry_after = 0
+            for max_hits, window in tiers:
+                window_start = now - (now % window)
+                bucket = f"{scope}:{window}:{ident}"
+                # Prune this bucket's earlier windows as we go (self-cleaning).
+                hits = db.rate_limit_hit(bucket, window_start, prune_before=window_start)
+                if hits > max_hits:
+                    retry_after = max(retry_after, window - (now % window))
+            if retry_after:
+                resp = jsonify({"error": "Too many requests — slow down and retry."})
+                resp.status_code = 429
+                resp.headers["Retry-After"] = str(retry_after)
+                return resp
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
 Flask==3.1.3
 defusedxml==0.7.1
+# Postgres driver — only used when DATABASE_URL is set (e.g. on Replit). The
+# [binary] extra ships precompiled wheels so no libpq build step is needed.
+psycopg[binary]==3.2.3
+# Production WSGI server for deployment (the Flask dev server is local-only).
+gunicorn==23.0.0

--- a/scripts/migrate_sqlite_to_pg.py
+++ b/scripts/migrate_sqlite_to_pg.py
@@ -1,0 +1,89 @@
+"""One-time copy of local SQLite route edits into PostgreSQL.
+
+Use this when moving an existing instance/edits.db to Replit's managed Postgres
+(or any Postgres). It reads every row from the SQLite file and inserts it into
+the target, preserving versions, notes, GTFS metadata, history, and timestamps.
+Identity ids are NOT copied — Postgres assigns fresh ones (nothing references id).
+
+The target schema is created via db.init_db() if missing, so this is safe to run
+against a brand-new database.
+
+Usage:
+    # DATABASE_URL points at the Postgres target (Replit injects this in the Repl
+    # shell once the PostgreSQL tool is added; set it manually elsewhere).
+    python scripts/migrate_sqlite_to_pg.py
+    python scripts/migrate_sqlite_to_pg.py --sqlite instance/edits.db
+
+The script is append-only and refuses to run if the target already has route
+versions, so it won't silently double-insert. Pass --force to override.
+"""
+import argparse
+import os
+import sqlite3
+import sys
+
+# Import the project's db module so we reuse its schema + Postgres wiring.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import db  # noqa: E402
+
+# (table, columns to copy in order). id columns are intentionally omitted so
+# Postgres' IDENTITY assigns fresh values.
+_TABLES = [
+    ("route_versions", ["year", "filename", "version", "geometry", "label", "created_at"]),
+    ("route_notes", ["year", "route", "note", "updated_at"]),
+    ("gtfs_meta", ["year", "key", "data", "updated_at"]),
+    ("gtfs_meta_history", ["year", "key", "data", "replaced_at"]),
+]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--sqlite",
+        default=os.path.join("instance", "edits.db"),
+        help="path to the source SQLite file (default: instance/edits.db)",
+    )
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="insert even if the target already has route versions",
+    )
+    args = ap.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        sys.exit("DATABASE_URL is not set — point it at the Postgres target first.")
+    if not os.path.exists(args.sqlite):
+        sys.exit(f"source SQLite file not found: {args.sqlite}")
+
+    # Configure db for Postgres (creates the schema if needed).
+    db.init_db(dsn=dsn)
+
+    with db._connect() as pg:
+        existing = pg.execute("SELECT COUNT(*) AS c FROM route_versions").fetchone()["c"]
+        if existing and not args.force:
+            sys.exit(
+                f"target already has {existing} route version row(s); "
+                "re-run with --force to insert anyway."
+            )
+
+        src = sqlite3.connect(args.sqlite)
+        src.row_factory = sqlite3.Row
+        try:
+            for table, cols in _TABLES:
+                rows = src.execute(f"SELECT {', '.join(cols)} FROM {table}").fetchall()
+                if not rows:
+                    print(f"{table}: 0 rows")
+                    continue
+                placeholders = ", ".join(["%s"] * len(cols))
+                sql = f"INSERT INTO {table} ({', '.join(cols)}) VALUES ({placeholders})"
+                for r in rows:
+                    pg.execute(sql, tuple(r[c] for c in cols))
+                print(f"{table}: copied {len(rows)} row(s)")
+        finally:
+            src.close()
+    print("Done. The target Postgres now holds the local edits.")
+
+
+if __name__ == "__main__":
+    main()

--- a/static/js/editor-manager.js
+++ b/static/js/editor-manager.js
@@ -86,6 +86,10 @@ APP.EditorManager = class {
 
   enter(file, kind, year) {
     if (!file) return;
+    // Editing is for logged-in editors only. The public map sets APP_AUTHED to
+    // false; the server-gated /gtfs workbench leaves it unset (so editing works
+    // there). Either way the server enforces auth on every write.
+    if (window.APP_AUTHED === false) return;
     if (this.active) {
       if (this.file === file && this.kind === kind) return;
       if (!confirm("Finish editing the current route first? Unsaved in-session changes will be lost.")) {
@@ -121,6 +125,7 @@ APP.EditorManager = class {
    * @param {string} [defaultName] pre-fills the name prompt (e.g. a route number
    *   when launched from the official-stops reference panel). */
   createNew(defaultName) {
+    if (window.APP_AUTHED === false) return;  // logged-in editors only (see enter())
     if (this.active) {
       if (!confirm("Finish the current edit first? Unsaved changes will be lost.")) {
         return;

--- a/static/js/ride/ride-music.js
+++ b/static/js/ride/ride-music.js
@@ -281,7 +281,7 @@ APP.RideMusic = class {
     } catch (_) {
       /* localStorage unavailable */
     }
-    return 0.5;
+    return 0.2;
   }
 
   _loadMuted() {

--- a/static/js/route-manager.js
+++ b/static/js/route-manager.js
@@ -219,16 +219,8 @@ APP.RouteManager = class {
     if (isRouteLike) {
       label.append($('<a class="route-ride-btn" title="3D ride">🚌</a>').attr(attrs));
     }
-    if (isUser) {
-      // Only the user's own routes are editable.
-      label.append($('<a class="route-edit-btn" title="Edit">✎</a>').attr(attrs));
-      label.append($('<a class="route-del-btn" title="Delete route">✕</a>').attr(attrs));
-    } else if (isRouteLike && this.canCreateUserRoutes) {
-      // Shipped routes are read-only — offer to copy into an editable route.
-      label.append(
-        $('<a class="route-copy-btn" title="Copy to my routes">📋</a>').attr(attrs)
-      );
-    }
+    // Editing actions (edit/delete user routes, copy shipped routes) live in the
+    // GTFS workbench, not the homepage list — the homepage stays view-only.
     return label;
   }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -65,6 +65,7 @@
         >
           ☰ Routes
         </button>
+        {% if authed %}
         <a
           href="/gtfs"
           class="btn btn-default btn-sm navbar-btn navbar-right"
@@ -72,6 +73,18 @@
         >
           🕐 GTFS
         </a>
+        <form method="POST" action="{{ url_for('logout') }}" class="navbar-right" style="display:inline">
+          <button type="submit" class="btn btn-default btn-sm navbar-btn" title="Log out of the editor">Log out</button>
+        </form>
+        {% else %}
+        <a
+          href="{{ url_for('login_page') }}"
+          class="btn btn-default btn-sm navbar-btn navbar-right"
+          title="Log in to edit routes and schedules"
+        >
+          ✎ Log in
+        </a>
+        {% endif %}
         <a
           href="/planner"
           class="btn btn-default btn-sm navbar-btn navbar-right"
@@ -195,6 +208,9 @@
     <script src="{{ url_for('static', filename='js/location-tracker.js') }}"></script>
     <script src="{{ url_for('static', filename='js/route-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/info-manager.js') }}"></script>
+    <!-- Editor controls are revealed only for a logged-in editor; the server
+         enforces this on every write endpoint regardless of this flag. -->
+    <script>window.APP_AUTHED = {{ authed|tojson }};</script>
     <script src="{{ url_for('static', filename='js/editor-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
     <script src="{{ url_for('static', filename='js/ride/launcher.js') }}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -73,12 +73,10 @@
         >
           🕐 GTFS
         </a>
-        {% if auth_enforced %}
         <form method="POST" action="{{ url_for('logout') }}" class="navbar-right" style="display:inline">
           <button type="submit" class="btn btn-default btn-sm navbar-btn" title="Log out of the editor">Log out</button>
         </form>
-        {% endif %}
-        {% else %}
+        {% elif auth_configured %}
         <a
           href="{{ url_for('login_page') }}"
           class="btn btn-default btn-sm navbar-btn navbar-right"

--- a/templates/index.html
+++ b/templates/index.html
@@ -73,9 +73,11 @@
         >
           🕐 GTFS
         </a>
+        {% if auth_enforced %}
         <form method="POST" action="{{ url_for('logout') }}" class="navbar-right" style="display:inline">
           <button type="submit" class="btn btn-default btn-sm navbar-btn" title="Log out of the editor">Log out</button>
         </form>
+        {% endif %}
         {% else %}
         <a
           href="{{ url_for('login_page') }}"

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Editor login — Brunei Bus Routes</title>
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/bootstrap.min.css') }}"
+    />
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/styles.css') }}"
+    />
+    <style>
+      .login-wrap { max-width: 360px; margin: 12vh auto; padding: 0 16px; }
+      .login-wrap h1 { font-size: 22px; margin-bottom: 4px; }
+      .login-wrap .muted { color: #888; margin-bottom: 20px; }
+    </style>
+  </head>
+  <body>
+    <div class="login-wrap">
+      <h1>✎ Editor login</h1>
+      <p class="muted">Enter the editor password to make changes. Viewing the map needs no login.</p>
+      {% if error %}
+      <div class="alert alert-danger" role="alert">Incorrect password.</div>
+      {% endif %}
+      <form method="POST" action="{{ url_for('login_submit') }}">
+        <input type="hidden" name="next" value="{{ next }}" />
+        <div class="form-group">
+          <label for="password">Password</label>
+          <input
+            type="password"
+            class="form-control"
+            id="password"
+            name="password"
+            autocomplete="current-password"
+            autofocus
+            required
+          />
+        </div>
+        <button type="submit" class="btn btn-primary btn-block">Log in</button>
+      </form>
+      <p style="margin-top: 16px">
+        <a href="{{ url_for('index') }}">← Back to the map</a>
+      </p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Prepares the app for public hosting on Replit. Three layers of work, each tested end-to-end (SQLite + Postgres).

## Storage — survives Replit's ephemeral filesystem
`db.py` is now dual-backend behind its existing API: **Postgres** when `DATABASE_URL` is set (Replit's managed DB, persists across redeploys/autoscale instances), otherwise the local **SQLite** file. Adds `psycopg[binary]` + `gunicorn`, a `.replit` Autoscale config, and `scripts/migrate_sqlite_to_pg.py` to carry existing edits over. Local dev is unchanged.

## Rate limiting — blocks automated write floods
Per-client-IP fixed-window limits on the 7 write endpoints (30/10s burst + 100/60s sustained), stored in the shared DB so they hold across gunicorn workers and autoscale instances. Over-limit → `429` + `Retry-After`. Reads are untouched. `ProxyFix` is wired so limits key on the real client IP behind Replit's proxy.

## Editor login — public viewing, gated editing
Single shared password (`EDITOR_PASSWORD` secret) gates all write endpoints and the `/gtfs` workbench; the map/planner/ride pages stay public and read-only. Signed session cookie (`HttpOnly` + `SameSite=Lax` + `Secure` in prod), login brute-force throttle, open-redirect-safe `next`. **Fail-closed:** with no password set, no one can log in and editing stays locked.

## Hardening + UX
- Randomized the throwaway dev Postgres password in `docker-compose.yml`.
- Homepage sidebar is view-only — edit/delete/copy buttons moved to the `/gtfs` workbench only.
- Ride music defaults to 20% volume.

## Deploy notes
Set `EDITOR_PASSWORD` and `SECRET_KEY` as Replit Secrets and add the PostgreSQL tool. Without `EDITOR_PASSWORD`, editing is locked (fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)