### PR TITLE
Make the trip planner the homepage

### DIFF
--- a/app.py
+++ b/app.py
@@ -1066,8 +1066,8 @@ def _planner_network(year):
 
 @app.route("/planner")
 def planner_page():
-    # Trip planner: point-to-point journeys over a chosen dataset year.
-    return render_template("planner.html")
+    # Old URL kept for bookmarks and ride-exit links; the planner is now "/".
+    return redirect(url_for("index"))
 
 
 @app.route("/data/planner-stops")
@@ -1153,6 +1153,13 @@ def auth_status():
 
 @app.route("/")
 def index():
+    # The trip planner is the homepage.
+    return render_template("planner.html")
+
+
+@app.route("/map")
+def map_page():
+    # The route map (formerly the homepage). Editor controls are gated by auth.
     return render_template(
         "index.html", authed=auth.is_authed(), auth_configured=auth.configured()
     )

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -96,7 +96,7 @@
           🕐 Timing
         </button>
         <a
-          href="/"
+          href="/map"
           class="btn btn-default btn-sm navbar-btn navbar-right"
           title="Back to the route map"
         >

--- a/templates/login.html
+++ b/templates/login.html
@@ -43,7 +43,7 @@
         <button type="submit" class="btn btn-primary btn-block">Log in</button>
       </form>
       <p style="margin-top: 16px">
-        <a href="{{ url_for('index') }}">← Back to the map</a>
+        <a href="{{ url_for('map_page') }}">← Back to the map</a>
       </p>
     </div>
   </body>

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -54,7 +54,7 @@
           🕐 GTFS
         </a>
         <a
-          href="/"
+          href="/map"
           class="btn btn-default btn-sm navbar-btn navbar-right"
           title="Back to the route map"
         >

--- a/templates/ride_maplibre.html
+++ b/templates/ride_maplibre.html
@@ -59,7 +59,7 @@
       <span class="route-title" id="route-title">Loading…</span>
       <span class="engine-badge">MapLibre</span>
       <span class="spacer"></span>
-      <a id="exit" href="/">✕ Exit</a>
+      <a id="exit" href="/map">✕ Exit</a>
     </div>
 
     <div id="stop-banner"></div>

--- a/templates/ride_three.html
+++ b/templates/ride_three.html
@@ -17,7 +17,7 @@
       <span class="route-title" id="route-title">Loading…</span>
       <span class="engine-badge">Three.js</span>
       <span class="spacer"></span>
-      <a id="exit" href="/">✕ Exit</a>
+      <a id="exit" href="/map">✕ Exit</a>
     </div>
 
     <div id="stop-banner"></div>


### PR DESCRIPTION
The trip planner now serves at `/`. The route map moves to `/map` (carrying the editor auth context), and `/planner` redirects to `/` so existing bookmarks and ride-exit links keep working.

- Repointed the "🗺 Map" navbar buttons (planner + GTFS), login's "← Back to the map" link, and both ride-mode "✕ Exit" links to `/map`.
- Planner-launched ride previews still exit back to the planner.
- Navbar brand links go to `/` (home).

Verified: `/` → planner (200), `/map` → map (200), `/planner` → 302 to `/`, `/gtfs` still login-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)