### PR TITLE
GTFS workbench 3D-ride button + ride-along map types

### DIFF
--- a/static/css/ride.css
+++ b/static/css/ride.css
@@ -432,6 +432,21 @@ body {
   color: #111;
 }
 
+/* Map-type picker — matches the toggles; options dark for native dropdowns. */
+#ride-controls .ride-style {
+  height: 36px;
+  padding: 0 8px;
+  border: none;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.28);
+  color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+}
+#ride-controls .ride-style option {
+  color: #111;
+}
+
 #ride-controls .speed {
   display: flex;
   align-items: center;

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -760,6 +760,10 @@ body.editing .gtfs-routes-scroll {
   color: var(--gtfs-danger);
   text-decoration: none;
 }
+.gtfs-route-ride {
+  margin-left: 0; /* the row's flex gap handles spacing */
+  opacity: 0.6;
+}
 
 /* --- Map column ------------------------------------------------------- */
 .gtfs-map-col {

--- a/static/js/config.js
+++ b/static/js/config.js
@@ -44,6 +44,57 @@ APP.MAP_STYLES = {
   },
 };
 
+// Raster tile sources for the 3D ride-along (ground texture, minimap, and the
+// MapLibre base), keyed to the same four map types as the 2D map's style picker.
+// `fallback` is the colour shown under not-yet-loaded tiles / the scene backdrop.
+APP.RIDE_TILES = {
+  osm: {
+    url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    subdomains: ["a", "b", "c"],
+    maxZoom: 19,
+    fallback: "#e2e5e9",
+  },
+  satellite: {
+    url: "https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+    subdomains: [],
+    maxZoom: 19,
+    fallback: "#26331f",
+  },
+  terrain: {
+    url: "https://tile.opentopomap.org/{z}/{x}/{y}.png",
+    subdomains: [],
+    maxZoom: 17,
+    fallback: "#dfe3e8",
+  },
+  dark: {
+    url: "https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png",
+    subdomains: ["a", "b", "c", "d"],
+    maxZoom: 19,
+    fallback: "#16161a",
+  },
+};
+
+// A concrete tile URL for canvas consumers (Three.js ground, minimap).
+APP.rideTileUrl = function (style, z, x, y) {
+  const t = APP.RIDE_TILES[style] || APP.RIDE_TILES.osm;
+  const s = t.subdomains.length
+    ? t.subdomains[Math.abs(x + y) % t.subdomains.length]
+    : "";
+  return t.url
+    .replace("{s}", s)
+    .replace("{z}", z)
+    .replace("{x}", x)
+    .replace("{y}", y);
+};
+
+// A MapLibre `tiles` array (subdomains expanded into separate URLs).
+APP.rideTileList = function (style) {
+  const t = APP.RIDE_TILES[style] || APP.RIDE_TILES.osm;
+  return t.subdomains.length
+    ? t.subdomains.map((s) => t.url.replace("{s}", s))
+    : [t.url];
+};
+
 // Dataset year that owns user-created/editable routes. Shipped routes from
 // other years are read-only and can only be copied into this year for editing.
 // Must match USER_ROUTE_YEAR in app.py.

--- a/static/js/gtfs-page.js
+++ b/static/js/gtfs-page.js
@@ -64,7 +64,7 @@ APP.GtfsPage = class {
     );
     const list = $("#gtfsRouteList");
     list.on("click", ".gtfs-route-row", (e) => {
-      if ($(e.target).closest(".gtfs-route-del").length) return;
+      if ($(e.target).closest(".gtfs-route-del, .route-ride-btn").length) return;
       const el = $(e.currentTarget);
       this.select(el.attr("data-year"), el.attr("data-file"));
     });
@@ -193,6 +193,14 @@ APP.GtfsPage = class {
     // Every schedulable route shows its transcription meter up front (all-off
     // until the meta summary fills it in). Paths can't carry GTFS meta.
     if (kind !== "geojson") row.append(this._meterEl());
+    // 3D ride-along, so editors can preview the route they're working on.
+    row.append(
+      $('<a class="route-ride-btn gtfs-route-ride" title="3D ride along">🚌</a>').attr({
+        "data-file": file,
+        "data-year": year,
+        "data-name": display,
+      })
+    );
     if (isUser) {
       row.append($('<a class="gtfs-route-del" title="Delete route">✕</a>'));
     }

--- a/static/js/ride/launcher.js
+++ b/static/js/ride/launcher.js
@@ -5,12 +5,16 @@ window.APP = window.APP || {};
 $(document).ready(function () {
   let pendingRide = null;
 
-  $("#routes").on("click", ".route-ride-btn", (e) => {
+  // Delegated on document so it works wherever a .route-ride-btn appears — the
+  // home map's route list and the GTFS workbench's route list alike.
+  $(document).on("click", ".route-ride-btn", (e) => {
     e.preventDefault();
     e.stopPropagation();
     const el = $(e.currentTarget);
     pendingRide = { file: el.attr("data-file"), year: el.attr("data-year") };
-    $("#engineRouteName").text(el.closest("label").find(".route-name").text());
+    $("#engineRouteName").text(
+      el.attr("data-name") || el.closest("label").find(".route-name").text()
+    );
     $("#engineModal").modal("show");
   });
 
@@ -19,8 +23,10 @@ $(document).ready(function () {
     const yq = pendingRide.year
       ? `&year=${encodeURIComponent(pendingRide.year)}`
       : "";
+    // Launched from the GTFS workbench? Tag it so the ride exits back there.
+    const from = location.pathname === "/gtfs" ? "&from=gtfs" : "";
     window.location.href =
-      `/ride/${engine}?route=${encodeURIComponent(pendingRide.file)}${yq}`;
+      `/ride/${engine}?route=${encodeURIComponent(pendingRide.file)}${yq}${from}`;
   };
 
   $("#engineThree").on("click", () => rideEngine("three"));

--- a/static/js/ride/maplibre-ride.js
+++ b/static/js/ride/maplibre-ride.js
@@ -23,6 +23,7 @@
     toggleMinimap: document.getElementById("toggle-minimap"),
     minimap: document.getElementById("minimap"),
     legs: document.getElementById("ride-legs"),
+    mapStyle: document.getElementById("mapStyle"),
   };
 
   function showError(msg) {
@@ -56,9 +57,12 @@
       return;
     }
 
-    // A planned-trip preview returns to the planner, not the route map.
+    // Exit target: a planned-trip preview returns to the planner, a GTFS-launched
+    // ride to the workbench; otherwise the route map (template default).
     if (routeFile === RP.TRIP_PREVIEW) {
       document.getElementById("exit").href = "/planner";
+    } else if (new URLSearchParams(location.search).get("from") === "gtfs") {
+      document.getElementById("exit").href = "/gtfs";
     }
 
     let geo;
@@ -340,6 +344,14 @@
       els.toggleMinimap.classList.toggle("active", visible);
       els.toggleMinimap.setAttribute("aria-pressed", String(visible));
     });
+    if (els.mapStyle) {
+      els.mapStyle.addEventListener("change", () => {
+        const style = els.mapStyle.value;
+        const src = map.getSource("osm");
+        if (src && src.setTiles) src.setTiles(APP.rideTileList(style));
+        minimap.setStyle(style);
+      });
+    }
 
     // Scrub: click or drag along the progress bar to jump anywhere in the ride.
     // The frame loop reads `traveled` every tick, so the bus/camera/minimap

--- a/static/js/ride/minimap.js
+++ b/static/js/ride/minimap.js
@@ -26,7 +26,8 @@ APP.Minimap = class {
     this.H = 180;
     this.heading = 0;
     this.lastLonLat = null;
-    this.tiles = new Map(); // "z/x/y" -> Image (tile cache across frames/zooms)
+    this.style = "osm"; // map type; switched via setStyle()
+    this.tiles = new Map(); // "style/z/x/y" -> Image (tile cache across frames)
     this._rafPending = false;
     this._routeKey = null;
 
@@ -224,6 +225,21 @@ APP.Minimap = class {
     this.resetBtn.classList.toggle("hidden", this.zoom === this.defaultZoom);
   }
 
+  // Switch the base map type (osm/satellite/terrain/dark): swap the tile source,
+  // drop cached tiles, clamp to the style's max zoom, and redraw.
+  setStyle(style) {
+    if (!APP.RIDE_TILES[style] || style === this.style) return;
+    this.style = style;
+    this.maxZoom = APP.RIDE_TILES[style].maxZoom;
+    if (this.zoom > this.maxZoom) {
+      this.zoom = this.maxZoom;
+      this._updateResetBtn();
+    }
+    this.tiles.clear();
+    this._routeKey = null;
+    this._render();
+  }
+
   /**
    * Move the bus marker. Heading is derived from movement unless provided.
    * @param {number[]} lonLat - [lon, lat]
@@ -264,7 +280,7 @@ APP.Minimap = class {
     const oX = this._originX;
     const oY = this._originY;
     ctx.setTransform(this.ratio, 0, 0, this.ratio, 0, 0);
-    ctx.fillStyle = "#dfe3e8";
+    ctx.fillStyle = (APP.RIDE_TILES[this.style] || {}).fallback || "#dfe3e8";
     ctx.fillRect(0, 0, this.W, this.H);
 
     const tilesPerSide = 2 ** Z;
@@ -272,7 +288,6 @@ APP.Minimap = class {
     const x1 = Math.floor((oX + this.W) / 256);
     const y0 = Math.floor(oY / 256);
     const y1 = Math.floor((oY + this.H) / 256);
-    const subs = ["a", "b", "c"];
 
     for (let x = x0; x <= x1; x++) {
       for (let y = y0; y <= y1; y++) {
@@ -280,7 +295,7 @@ APP.Minimap = class {
         const tx = ((x % tilesPerSide) + tilesPerSide) % tilesPerSide; // wrap lon
         const dx = x * 256 - oX;
         const dy = y * 256 - oY;
-        const key = `${Z}/${tx}/${y}`;
+        const key = `${this.style}/${Z}/${tx}/${y}`;
         let img = this.tiles.get(key);
         if (!img) {
           img = new Image();
@@ -288,7 +303,7 @@ APP.Minimap = class {
           // Redraw once it arrives (next frame would also catch it, but this
           // keeps a paused/overview view from waiting on the ride loop).
           img.onload = () => this._scheduleDraw();
-          img.src = `https://${subs[(tx + y) % 3]}.tile.openstreetmap.org/${Z}/${tx}/${y}.png`;
+          img.src = APP.rideTileUrl(this.style, Z, tx, y);
           this.tiles.set(key, img);
         }
         if (img.complete && img.naturalWidth) {

--- a/static/js/ride/three-ride.js
+++ b/static/js/ride/three-ride.js
@@ -24,6 +24,7 @@ const els = {
   toggleMinimap: document.getElementById("toggle-minimap"),
   minimap: document.getElementById("minimap"),
   legs: document.getElementById("ride-legs"),
+  mapStyle: document.getElementById("mapStyle"),
 };
 
 function showError(msg) {
@@ -58,7 +59,7 @@ function chooseZoom(b, maxPerSide) {
   return 12;
 }
 
-async function buildGround(bounds, origin) {
+async function buildGround(bounds, origin, style) {
   // Pad the route bbox so we see a bit of surroundings.
   const padLon = (bounds.maxLon - bounds.minLon) * 0.15 + 0.002;
   const padLat = (bounds.maxLat - bounds.minLat) * 0.15 + 0.002;
@@ -80,16 +81,15 @@ async function buildGround(bounds, origin) {
   canvas.width = cols * 256;
   canvas.height = rows * 256;
   const ctx = canvas.getContext("2d");
-  ctx.fillStyle = "#e2e5e9";
+  ctx.fillStyle = (APP.RIDE_TILES[style] || {}).fallback || "#e2e5e9";
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-  const subs = ["a", "b", "c"];
   const loads = [];
   for (let x = x0; x <= x1; x++) {
     for (let y = y0; y <= y1; y++) {
       const dx = (x - x0) * 256;
       const dy = (y - y0) * 256;
-      const url = `https://${subs[(x + y) % 3]}.tile.openstreetmap.org/${z}/${x}/${y}.png`;
+      const url = APP.rideTileUrl(style, z, x, y);
       loads.push(
         new Promise((resolve) => {
           const img = new Image();
@@ -287,9 +287,12 @@ async function main() {
     return;
   }
 
-  // A planned-trip preview returns to the planner, not the route map.
+  // Exit target: a planned-trip preview returns to the planner, a GTFS-launched
+  // ride to the workbench; otherwise the route map (template default).
   if (routeFile === RP.TRIP_PREVIEW) {
     document.getElementById("exit").href = "/planner";
+  } else if (new URLSearchParams(location.search).get("from") === "gtfs") {
+    document.getElementById("exit").href = "/gtfs";
   }
 
   let geo;
@@ -350,7 +353,8 @@ async function main() {
   );
 
   els.statusSub.textContent = "Loading map tiles…";
-  const ground = await buildGround(geo.bounds, origin);
+  let mapStyle = "osm";
+  let ground = await buildGround(geo.bounds, origin, mapStyle);
   scene.add(ground);
   scene.add(buildRoad(pts, color, geo.pathColors));
   const bus = buildBus(color);
@@ -497,6 +501,23 @@ async function main() {
     els.toggleMinimap.classList.toggle("active", visible);
     els.toggleMinimap.setAttribute("aria-pressed", String(visible));
   });
+  if (els.mapStyle) {
+    // Change the base map type: re-texture the ground, retint sky/fog, sync minimap.
+    els.mapStyle.addEventListener("change", async () => {
+      mapStyle = els.mapStyle.value;
+      const sky = mapStyle === "dark" ? 0x15151a : 0x87ceeb;
+      scene.background = new THREE.Color(sky);
+      scene.fog = new THREE.Fog(sky, 400, 1600);
+      minimap.setStyle(mapStyle);
+      const prev = ground;
+      ground = await buildGround(geo.bounds, origin, mapStyle);
+      scene.add(ground);
+      scene.remove(prev);
+      prev.geometry.dispose();
+      if (prev.material.map) prev.material.map.dispose();
+      prev.material.dispose();
+    });
+  }
 
   // Jump the ride to a fraction f (0..1) of the route and refresh every readout.
   function seekTo(f) {

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -412,6 +412,31 @@
       </div>
     </div>
 
+    <!-- 3D ride engine chooser (shared launcher.js drives it) -->
+    <div class="modal fade" id="engineModal" tabindex="-1" role="dialog">
+      <div class="modal-dialog modal-sm" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">
+              &times;
+            </button>
+            <h4 class="modal-title">🚌 Ride <span id="engineRouteName"></span></h4>
+          </div>
+          <div class="modal-body">
+            <p>Choose a 3D engine:</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" id="engineThree" data-dismiss="modal">
+              Three.js
+            </button>
+            <button type="button" class="btn btn-info" id="engineMaplibre" data-dismiss="modal">
+              MapLibre
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/config.js') }}"></script>
     <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
@@ -420,5 +445,6 @@
     <script src="{{ url_for('static', filename='js/stop-image-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/gtfs-editor-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/gtfs-page.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/launcher.js') }}"></script>
   </body>
 </html>

--- a/templates/ride_maplibre.html
+++ b/templates/ride_maplibre.html
@@ -96,6 +96,12 @@
       <button id="next-stop" title="Next stop">⏭</button>
       <button id="toggle-stops" class="toggle-btn active" title="Show/hide stops" aria-pressed="true">🚏 Stops</button>
       <button id="toggle-minimap" class="toggle-btn active" title="Show/hide minimap" aria-pressed="true">🗺 Map</button>
+      <select id="mapStyle" class="ride-style" title="Map type">
+        <option value="osm">OpenStreetMap</option>
+        <option value="satellite">Satellite</option>
+        <option value="terrain">Terrain</option>
+        <option value="dark">Dark</option>
+      </select>
       <div class="speed">
         <span>Speed</span>
         <input id="speed" type="range" min="10" max="120" step="5" value="40" />

--- a/templates/ride_three.html
+++ b/templates/ride_three.html
@@ -54,6 +54,12 @@
       <button id="next-stop" title="Next stop">⏭</button>
       <button id="toggle-stops" class="toggle-btn active" title="Show/hide stops" aria-pressed="true">🚏 Stops</button>
       <button id="toggle-minimap" class="toggle-btn active" title="Show/hide minimap" aria-pressed="true">🗺 Map</button>
+      <select id="mapStyle" class="ride-style" title="Map type">
+        <option value="osm">OpenStreetMap</option>
+        <option value="satellite">Satellite</option>
+        <option value="terrain">Terrain</option>
+        <option value="dark">Dark</option>
+      </select>
       <div class="speed">
         <span>Speed</span>
         <input id="speed" type="range" min="10" max="120" step="5" value="40" />


### PR DESCRIPTION
## GTFS workbench
- **🚌 3D ride button** on every route *and* path row in the GTFS workbench, so editors can preview what they're editing.
- The shared launcher is generalised (document-level delegation + `data-name` fallback) to drive both the home map and the workbench lists.

## 3D ride-along
- **Map-type picker** (OpenStreetMap / Satellite / Terrain / Dark) in the ride control bar, sharing the 2D map's four styles via a new `APP.RIDE_TILES` config. MapLibre swaps the raster source, Three.js re-textures the ground + retints sky/fog, and the minimap swaps its tiles — clamped to each style's max zoom.
- **Context-aware exit**: a planned-trip preview returns to the planner, a GTFS-launched ride to the workbench, otherwise the route map.

Verified at the code level (JS syntax incl. ES modules, served assets/markup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)