### PR TITLE
3D ride polish: camera, heading-flip fix, arrival card

### DIFF
--- a/static/css/ride.css
+++ b/static/css/ride.css
@@ -447,6 +447,79 @@ body {
   color: #111;
 }
 
+/* Arrival card — shown at the destination (centred, dismissible). */
+#arrival-card {
+  position: absolute;
+  top: 46%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 20;
+  min-width: 230px;
+  padding: 20px 24px 18px;
+  background: rgba(20, 20, 24, 0.88);
+  border-radius: 16px;
+  color: #fff;
+  text-align: center;
+  box-shadow: 0 10px 36px rgba(0, 0, 0, 0.5);
+}
+#arrival-card.hidden {
+  display: none;
+}
+#arrival-card .arrival-title {
+  font-size: 24px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+#arrival-card .arrival-sub {
+  font-size: 13px;
+  opacity: 0.72;
+  margin: 2px 0 16px;
+}
+#arrival-card .arrival-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+#arrival-card .arrival-actions button,
+#arrival-card .arrival-actions a {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 9px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+}
+#arrival-card #arrival-replay {
+  background: #ffd166;
+  color: #111;
+}
+#arrival-card #arrival-exit {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+#arrival-card #arrival-exit:hover {
+  background: rgba(255, 255, 255, 0.28);
+}
+#arrival-card .arrival-x {
+  position: absolute;
+  top: 7px;
+  right: 10px;
+  padding: 0;
+  background: none;
+  border: none;
+  color: #fff;
+  opacity: 0.5;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+#arrival-card .arrival-x:hover {
+  opacity: 1;
+}
+
 #ride-controls .speed {
   display: flex;
   align-items: center;

--- a/static/js/ride/arrival.js
+++ b/static/js/ride/arrival.js
@@ -1,0 +1,39 @@
+// Arrival card for the 3D ride-along, shared by both engines. Shown when the
+// ride reaches its destination; offers Replay / Exit and is dismissible so the
+// rider can look around the destination. Never exits on its own.
+window.APP = window.APP || {};
+
+APP.Arrival = {
+  /** Wire the card. opts: { summary, onReplay }. The Exit link mirrors the
+   *  top-bar ✕ Exit, so it returns to wherever the ride was launched from. */
+  init(opts) {
+    opts = opts || {};
+    this.card = document.getElementById("arrival-card");
+    if (!this.card) return;
+
+    const sub = document.getElementById("arrival-sub");
+    if (sub) sub.textContent = opts.summary || "";
+
+    const exit = document.getElementById("arrival-exit");
+    const topExit = document.getElementById("exit");
+    if (exit && topExit) exit.href = topExit.href;
+
+    const replay = document.getElementById("arrival-replay");
+    if (replay) {
+      replay.addEventListener("click", () => {
+        this.hide();
+        if (opts.onReplay) opts.onReplay();
+      });
+    }
+    const dismiss = document.getElementById("arrival-dismiss");
+    if (dismiss) dismiss.addEventListener("click", () => this.hide());
+  },
+
+  show() {
+    if (this.card) this.card.classList.remove("hidden");
+  },
+
+  hide() {
+    if (this.card) this.card.classList.add("hidden");
+  },
+};

--- a/static/js/ride/maplibre-ride.js
+++ b/static/js/ride/maplibre-ride.js
@@ -262,6 +262,7 @@
         if (traveled >= total) {
           playing = false;
           els.playpause.textContent = "↻";
+          APP.Arrival.show();
         }
       }
 
@@ -313,10 +314,19 @@
       if (traveled >= total) {
         traveled = 0;
         playing = true;
+        APP.Arrival.hide();
       } else {
         playing = !playing;
       }
       els.playpause.textContent = playing ? "⏸" : "▶";
+    });
+    APP.Arrival.init({
+      summary: routeName,
+      onReplay: () => {
+        traveled = 0;
+        playing = true;
+        els.playpause.textContent = "⏸";
+      },
     });
     els.speed.addEventListener("input", () => {
       speedKmh = parseFloat(els.speed.value);
@@ -363,6 +373,7 @@
       els.progress.style.width = `${(f * 100).toFixed(1)}%`;
       if (traveled < total) {
         els.playpause.textContent = playing ? "⏸" : "▶";
+        APP.Arrival.hide();
       }
     }
     // Skip to the previous / next stop along the route (dir -1 / +1). The
@@ -385,7 +396,10 @@
       }
       traveled = Math.min(1, Math.max(0, target)) * total;
       els.progress.style.width = `${((traveled / total) * 100).toFixed(1)}%`;
-      if (traveled < total) els.playpause.textContent = playing ? "⏸" : "▶";
+      if (traveled < total) {
+        els.playpause.textContent = playing ? "⏸" : "▶";
+        APP.Arrival.hide();
+      }
     }
     els.prevStop.addEventListener("click", () => jumpStop(-1));
     els.nextStop.addEventListener("click", () => jumpStop(1));

--- a/static/js/ride/three-ride.js
+++ b/static/js/ride/three-ride.js
@@ -382,6 +382,20 @@ async function main() {
   curve.arcLengthDivisions = Math.max(400, pts.length * 2);
   const totalLength = curve.getLength();
 
+  // Heading over a short window rather than the instantaneous tangent. The raw
+  // tangent flips 180° at sub-metre back-and-forth artifacts in the geometry
+  // (the line still looks straight), which would snap the model around and back.
+  // A centred look-ahead/behind direction stays stable through those.
+  const HEADING_WINDOW = 4; // metres
+  function headingDir(u) {
+    const du = HEADING_WINDOW / totalLength;
+    const a = curve.getPointAt(Math.min(1, u + du));
+    const b = curve.getPointAt(Math.max(0, u - du));
+    const dir = new THREE.Vector3().subVectors(a, b);
+    if (dir.lengthSq() < 1e-6) return curve.getTangentAt(u).normalize();
+    return dir.normalize();
+  }
+
   // Ride state. Speed is a real km/h value (from the slider) so every route
   // moves at the same actual speed regardless of length — a true simulation.
   const kmhToMs = (k) => (k * 1000) / 3600;
@@ -393,10 +407,14 @@ async function main() {
   let stopsVisible = true;
   let scrubbing = false;
 
+  // Chase camera: higher up and further back for a roomier 3rd-person view.
+  const CAM_BACK = 34; // metres behind the bus
+  const CAM_HEIGHT = 21; // metres above the ground
+
   function placeAt(u) {
     const clamped = Math.min(Math.max(u, 0), 1);
     const p = curve.getPointAt(clamped);
-    const tan = curve.getTangentAt(clamped).normalize();
+    const tan = headingDir(clamped);
     bus.position.set(p.x, 0, p.z);
     bus.rotation.y = Math.atan2(tan.x, tan.z);
     if (person) {
@@ -416,12 +434,12 @@ async function main() {
       armR.rotation.x = swing * 0.7;
     }
     const desired = new THREE.Vector3(
-      p.x - tan.x * 17,
-      9,
-      p.z - tan.z * 17
+      p.x - tan.x * CAM_BACK,
+      CAM_HEIGHT,
+      p.z - tan.z * CAM_BACK
     );
     camera.position.lerp(desired, 0.1);
-    camera.lookAt(p.x + tan.x * 8, 2.5, p.z + tan.z * 8);
+    camera.lookAt(p.x + tan.x * 8, 3, p.z + tan.z * 8);
     return p;
   }
 
@@ -461,12 +479,13 @@ async function main() {
   }
 
   // Position camera instantly before first frame so we don't fly in from origin
-  camera.position.set(pts[0].x, 9, pts[0].z + 20);
+  camera.position.set(pts[0].x, CAM_HEIGHT, pts[0].z + CAM_BACK);
   placeAt(0);
+  const d0 = headingDir(0);
   camera.position.set(
-    pts[0].x - curve.getTangentAt(0).x * 17,
-    9,
-    pts[0].z - curve.getTangentAt(0).z * 17
+    pts[0].x - d0.x * CAM_BACK,
+    CAM_HEIGHT,
+    pts[0].z - d0.z * CAM_BACK
   );
 
   els.status.classList.add("hidden");
@@ -476,10 +495,19 @@ async function main() {
     if (traveled >= totalLength) {
       traveled = 0; // replay
       playing = true;
+      APP.Arrival.hide();
     } else {
       playing = !playing;
     }
     els.playpause.textContent = playing ? "⏸" : "▶";
+  });
+  APP.Arrival.init({
+    summary: routeName,
+    onReplay: () => {
+      traveled = 0;
+      playing = true;
+      els.playpause.textContent = "⏸";
+    },
   });
   els.speed.addEventListener("input", () => {
     speedKmh = parseFloat(els.speed.value);
@@ -527,6 +555,7 @@ async function main() {
     // Leaving the end clears the "replay" state so the icon reflects play/pause.
     if (traveled < totalLength) {
       els.playpause.textContent = playing ? "⏸" : "▶";
+      APP.Arrival.hide();
     }
     const busPos = placeAt(f);
     updateStopBanner(busPos);
@@ -596,6 +625,7 @@ async function main() {
       if (traveled >= totalLength) {
         playing = false;
         els.playpause.textContent = "↻";
+        APP.Arrival.show();
       }
     }
     const u = totalLength > 0 ? traveled / totalLength : 0;

--- a/templates/ride_maplibre.html
+++ b/templates/ride_maplibre.html
@@ -79,6 +79,17 @@
     <!-- Planned-trip legs (hidden for plain routes); active leg highlights as you ride. -->
     <div id="ride-legs" class="hidden"></div>
 
+    <!-- Arrival card: shown at the destination; replay / exit, dismissible. -->
+    <div id="arrival-card" class="hidden">
+      <button id="arrival-dismiss" class="arrival-x" title="Look around" aria-label="Dismiss">×</button>
+      <div class="arrival-title">🏁 Arrived</div>
+      <div class="arrival-sub" id="arrival-sub"></div>
+      <div class="arrival-actions">
+        <button type="button" id="arrival-replay">↻ Replay</button>
+        <a id="arrival-exit" href="/map">Exit</a>
+      </div>
+    </div>
+
     <div id="minimap"></div>
 
     <!-- Minimal music controls live inside the now-playing credit pill. -->
@@ -120,6 +131,7 @@
     <script src="{{ url_for('static', filename='js/config.js', v=asset_v) }}"></script>
     <script src="{{ url_for('static', filename='js/ride/route-path.js', v=asset_v) }}"></script>
     <script src="{{ url_for('static', filename='js/ride/ride-legs.js', v=asset_v) }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/arrival.js', v=asset_v) }}"></script>
     <script src="{{ url_for('static', filename='js/ride/minimap.js', v=asset_v) }}"></script>
     <script src="{{ url_for('static', filename='js/ride/ride-music.js', v=asset_v) }}"></script>
     <script src="{{ url_for('static', filename='js/ride/maplibre-ride.js', v=asset_v) }}"></script>

--- a/templates/ride_three.html
+++ b/templates/ride_three.html
@@ -37,6 +37,17 @@
     <!-- Planned-trip legs (hidden for plain routes); active leg highlights as you ride. -->
     <div id="ride-legs" class="hidden"></div>
 
+    <!-- Arrival card: shown at the destination; replay / exit, dismissible. -->
+    <div id="arrival-card" class="hidden">
+      <button id="arrival-dismiss" class="arrival-x" title="Look around" aria-label="Dismiss">×</button>
+      <div class="arrival-title">🏁 Arrived</div>
+      <div class="arrival-sub" id="arrival-sub"></div>
+      <div class="arrival-actions">
+        <button type="button" id="arrival-replay">↻ Replay</button>
+        <a id="arrival-exit" href="/map">Exit</a>
+      </div>
+    </div>
+
     <div id="minimap"></div>
 
     <!-- Minimal music controls live inside the now-playing credit pill. -->
@@ -77,6 +88,7 @@
     <script src="{{ url_for('static', filename='js/config.js', v=asset_v) }}"></script>
     <script src="{{ url_for('static', filename='js/ride/route-path.js', v=asset_v) }}"></script>
     <script src="{{ url_for('static', filename='js/ride/ride-legs.js', v=asset_v) }}"></script>
+    <script src="{{ url_for('static', filename='js/ride/arrival.js', v=asset_v) }}"></script>
     <script src="{{ url_for('static', filename='js/ride/minimap.js', v=asset_v) }}"></script>
     <script src="{{ url_for('static', filename='js/ride/ride-music.js', v=asset_v) }}"></script>
     <script type="importmap">


### PR DESCRIPTION
Polish for the 3D ride-along.

- **Higher / further chase camera** for a roomier 3rd-person view (Three.js).
- **Fixed the 180° heading flicker**: heading now comes from a centred ±4m window instead of the instantaneous tangent, which flipped (and snapped back) at sub-metre back-and-forth artifacts in the route geometry.
- **Arrival card** at the destination — 🏁 Arrived + journey summary, with Replay / Exit, dismissible, no auto-exit. Shared module driving both engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)