### PR TITLE
Planner: fold circular-route direction transfers + 2016/KML data caveat

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -16,6 +16,7 @@ Pure stdlib; no Flask imports.
 import csv
 import heapq
 import io
+import re
 import zipfile
 from bisect import bisect_left
 
@@ -45,6 +46,23 @@ def _secs(t):
 
 def _walk_secs(dist_m):
     return int(dist_m / WALK_SPEED) + TRANSFER_SLACK_S
+
+
+def _route_family(long_name):
+    """A route's name with a trailing '(X)' direction suffix stripped, e.g.
+    'BSB Circular (A)' -> 'BSB Circular'. Returns None when there is no such
+    suffix, so only genuine direction variants of one route get grouped."""
+    m = re.match(r"^(.*?)\s*\([A-Za-z]\)\s*$", long_name or "")
+    return m.group(1).strip() if m else None
+
+
+def _same_route(a, b):
+    """True if two ride legs are the same route, or two direction variants of
+    one route (e.g. a circular line's clockwise/anticlockwise loops)."""
+    if a["route_id"] == b["route_id"]:
+        return True
+    fam = _route_family(a.get("long_name"))
+    return fam is not None and fam == _route_family(b.get("long_name"))
 
 
 def _read(zf, name):
@@ -711,27 +729,36 @@ class Network:
                 merged.append(leg)
         legs = merged
 
-        # A short walk between two legs of the SAME route is a loop shortcut
-        # (one-way loops make travelling a little "backwards" mean riding part
-        # way, cutting across on foot, and catching the route again) — not a
-        # real transfer. Fold such ride -> walk -> ride runs into one continuous
-        # ride leg so it doesn't read as a pointless transfer to itself.
+        # A short walk between two legs of the SAME route — or between the two
+        # directions of one circular route (e.g. "BSB Circular (A)" anticlockwise
+        # and "(C)" clockwise) — is a loop shortcut, not a real transfer: the
+        # rider just stays on / picks the circular line. Fold such ride -> walk
+        # -> ride runs into one continuous leg, relabelled to the shared route
+        # name when the two folded directions differ.
         collapsed = []
         i = 0
         while i < len(legs):
             leg = legs[i]
             if leg["type"] == "ride":
                 leg = dict(leg)
+                family = _route_family(leg.get("long_name"))
+                crossed = False
                 while (i + 2 < len(legs)
                        and legs[i + 1]["type"] == "walk"
                        and legs[i + 2]["type"] == "ride"
-                       and legs[i + 2]["route_id"] == leg["route_id"]):
+                       and _same_route(leg, legs[i + 2])):
                     nxt = legs[i + 2]
+                    if nxt["route_id"] != leg["route_id"]:
+                        crossed = True
                     leg["alight"] = nxt["alight"]
                     leg["arrive"] = nxt["arrive"]
                     leg["stops"] = leg["stops"] + nxt["stops"]
                     leg["geometry"] = leg["geometry"] + nxt["geometry"]
                     i += 2
+                if crossed and family:  # folded across directions -> shared name
+                    leg["route_id"] = family
+                    leg["long_name"] = family
+                    leg["short_name"] = ""
                 collapsed.append(leg)
             else:
                 collapsed.append(leg)

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1753,6 +1753,16 @@ body.guide-page {
   color: var(--gtfs-accent);
   border-color: var(--gtfs-ink);
 }
+.tp-data-note {
+  margin: 7px 0 0;
+  padding: 7px 9px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--gtfs-ink-soft);
+  background: rgba(255, 209, 102, 0.16);
+  border-left: 3px solid var(--gtfs-accent);
+  border-radius: 4px;
+}
 .tp-point-row {
   display: flex;
   align-items: center;

--- a/static/js/planner-page.js
+++ b/static/js/planner-page.js
@@ -58,6 +58,8 @@ APP.PlannerPage = class {
       $(".tp-source .btn").removeClass("active");
       btn.addClass("active");
       this.year = btn.attr("data-year");
+      // The incomplete-coverage caveat applies to the shipped 2016 dataset.
+      $("#tpDataNote").toggle(this.year === "2016");
       this.loadStops();
       this.clearResults("Source changed — plan again.");
     });

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -75,6 +75,15 @@
               <a class="btn btn-default active" id="tpSource2016" data-year="2016">2016 official</a>
               <a class="btn btn-default" id="tpSourceMine">My routes</a>
             </div>
+            <p class="tp-data-note" id="tpDataNote">
+              ⚠ The 2016 routes and their stops are derived from KML files, and
+              the coverage is incomplete — some KMLs don't span the route's full
+              length or are
+              missing stops along it. Where a route lacks stops near your start
+              or end, the planner can't board/alight there and routes around the
+              gap, so journeys may show extra transfers or detours that the real
+              (often hail-and-ride) bus wouldn't need.
+            </p>
           </div>
           <div class="tp-section">
             <div class="tp-point-row">


### PR DESCRIPTION
## What

Two related trip-planner improvements.

### 1. Fold cross-direction circular-route walk transfers into one leg
A trip like `4.97291, 115.02894 -> 4.88775, 114.97410` was picking up *both* directions of the BSB Circular loop — "BSB Circular (A)" (anticlockwise) and "(C)" (clockwise) — chained by a short walk, and showing it as a transfer. That's a loop shortcut, not a real transfer.

The fold logic in `_reconstruct` now detects two direction variants of one route (by stripping the trailing ` (X)` suffix to get the shared route family) and folds `ride -> walk -> ride` runs across directions into a single continuous leg, relabelled to the shared route name. Single-direction usage of a directional route keeps its full name. Test trip drops 4 -> 3 transfers with the spurious self-transfer gone.

### 2. 2016/KML data-coverage disclaimer
The shipped 2016 routes and stops are derived from KML files whose coverage is incomplete — some don't span a route's full length, or are missing stops along it. Where a route lacks stops near the start or end, the planner can't board/alight there and routes around the gap, so journeys can show extra transfers or detours the real (often hail-and-ride) bus wouldn't need. Added a caveat note under the data-source toggle, shown only for the 2016 dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)