### PR TITLE
Planner: dismissable 2016 data-coverage notice + trimmed text

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1754,14 +1754,47 @@ body.guide-page {
   border-color: var(--gtfs-ink);
 }
 .tp-data-note {
+  position: relative;
   margin: 7px 0 0;
-  padding: 7px 9px;
+  padding: 7px 24px 7px 9px;
   font-size: 11px;
   line-height: 1.4;
   color: var(--gtfs-ink-soft);
   background: rgba(255, 209, 102, 0.16);
   border-left: 3px solid var(--gtfs-accent);
   border-radius: 4px;
+}
+.tp-data-note-dismiss {
+  position: absolute;
+  top: 3px;
+  right: 4px;
+  padding: 0 4px;
+  border: 0;
+  background: transparent;
+  color: var(--gtfs-ink-soft);
+  font-size: 12px;
+  line-height: 1.4;
+  cursor: pointer;
+  opacity: 0.6;
+}
+.tp-data-note-dismiss:hover {
+  opacity: 1;
+}
+.tp-data-note-show {
+  display: none;
+  margin: 7px 0 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--gtfs-ink-soft);
+  font-size: 11px;
+  line-height: 1.4;
+  cursor: pointer;
+  opacity: 0.7;
+}
+.tp-data-note-show:hover {
+  opacity: 1;
+  text-decoration: underline;
 }
 .tp-point-row {
   display: flex;

--- a/static/js/planner-page.js
+++ b/static/js/planner-page.js
@@ -58,11 +58,16 @@ APP.PlannerPage = class {
       $(".tp-source .btn").removeClass("active");
       btn.addClass("active");
       this.year = btn.attr("data-year");
-      // The incomplete-coverage caveat applies to the shipped 2016 dataset.
-      $("#tpDataNote").toggle(this.year === "2016");
+      this.updateDataNote();
       this.loadStops();
       this.clearResults("Source changed — plan again.");
     });
+
+    // The incomplete-coverage caveat applies to the shipped 2016 dataset; the
+    // dismissed/shown choice persists across sessions.
+    $("#tpDataNoteDismiss").on("click", () => this.setDataNoteDismissed(true));
+    $("#tpDataNoteShow").on("click", () => this.setDataNoteDismissed(false));
+    this.updateDataNote();
 
     $("#tpPickFrom").on("click", () => this.armPick("from"));
     $("#tpPickTo").on("click", () => this.armPick("to"));
@@ -114,6 +119,33 @@ APP.PlannerPage = class {
     this.loadStops();
     this.renderTrips();
     if (restored) this.plan();
+  }
+
+  /**
+   * Show the coverage caveat only for the 2016 dataset. When dismissed it
+   * collapses to a small "show notice" link so the user can bring it back.
+   */
+  updateDataNote() {
+    let dismissed = false;
+    try {
+      dismissed = localStorage.getItem("tp-data-note-dismissed") === "1";
+    } catch (e) {
+      /* storage disabled — treat as not dismissed */
+    }
+    const is2016 = this.year === "2016";
+    $("#tpDataNote").toggle(is2016 && !dismissed);
+    $("#tpDataNoteShow").toggle(is2016 && dismissed);
+  }
+
+  /** Persist the dismissed/shown state of the coverage caveat, then re-render it. */
+  setDataNoteDismissed(dismissed) {
+    try {
+      if (dismissed) localStorage.setItem("tp-data-note-dismissed", "1");
+      else localStorage.removeItem("tp-data-note-dismissed");
+    } catch (e) {
+      /* storage full/disabled — the choice just won't persist */
+    }
+    this.updateDataNote();
   }
 
   // --- Recent trips (persist across sessions in localStorage) -----------------
@@ -190,6 +222,7 @@ APP.PlannerPage = class {
         .removeClass("active")
         .filter((_, el) => $(el).attr("data-year") === year)
         .addClass("active");
+      this.updateDataNote();
       this.loadStops();
     }
     this.from = t.from;

--- a/templates/planner.html
+++ b/templates/planner.html
@@ -75,15 +75,17 @@
               <a class="btn btn-default active" id="tpSource2016" data-year="2016">2016 official</a>
               <a class="btn btn-default" id="tpSourceMine">My routes</a>
             </div>
-            <p class="tp-data-note" id="tpDataNote">
-              ⚠ The 2016 routes and their stops are derived from KML files, and
-              the coverage is incomplete — some KMLs don't span the route's full
-              length or are
-              missing stops along it. Where a route lacks stops near your start
-              or end, the planner can't board/alight there and routes around the
-              gap, so journeys may show extra transfers or detours that the real
-              (often hail-and-ride) bus wouldn't need.
-            </p>
+            <div class="tp-data-note" id="tpDataNote">
+              <button type="button" class="tp-data-note-dismiss" id="tpDataNoteDismiss"
+                title="Dismiss this notice" aria-label="Dismiss this notice">✕</button>
+              ⚠ The 2016 routes are derived from incomplete KML data — some
+              routes are missing stops. Where stops are missing near your start
+              or end, the planner routes around the gap, so journeys may show
+              extra transfers or detours.
+            </div>
+            <button type="button" class="tp-data-note-show" id="tpDataNoteShow">
+              ⚠ Show data-coverage notice
+            </button>
           </div>
           <div class="tp-section">
             <div class="tp-point-row">


### PR DESCRIPTION
## What

- **Dismissable notice** — the 2016 data-coverage caveat on the trip planner now has a ✕ to dismiss it. When dismissed it collapses to a small "⚠ Show data-coverage notice" link so it can be brought back.
- **Persistent** — the dismissed/shown choice is stored in `localStorage` (`tp-data-note-dismissed`) and survives reloads. The notice (and the show-link) only ever appear for the **2016** source; persistence/restore logic is centralized in `setDataNoteDismissed()` / `updateDataNote()` and kept in sync across init, the source toggle, and `loadTrip`.
- **Trimmed copy** — the notice is roughly half the length and drops the unsupported "(often hail-and-ride)" claim, which had no backing in the 2016 KML data. The actionable point (incomplete data → missing stops → possible detours/extra transfers) is retained.

## Why

The caveat was long and permanently visible, and asserted a hail-and-ride characteristic that the dataset can't support. This lets users hide it once read (and recover it later) and makes the message accurate and concise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)