### PR TITLE
Admin-editable per-route bounty figures

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,10 @@ bounty basis and takes applications through a built-in form.
   [Editor & admin login](#editor--admin-login)). Admins can set each
   applicant's review status (New → Reviewing → Contacted → Accepted / Rejected),
   add an internal note, delete entries, and export everything as CSV.
-- The per-route bounty figures on `/join` are placeholders (`BND XX` in
-  `templates/join.html`) — set real amounts before publishing.
+- The **per-route bounty** figures shown on `/join` (currency, per-route amount,
+  timing-board bonus, payment note) are edited from the `/applications` admin
+  page and stored in the DB (`settings` table). Leave an amount blank to show
+  "rate confirmed on onboarding" instead of a figure.
 
 ## Technologies Used
 

--- a/app.py
+++ b/app.py
@@ -809,6 +809,42 @@ APPLICATION_TRANSPORT = ("Own vehicle", "Motorcycle", "Public transport", "Other
 # Admin review workflow stages for a submitted application.
 APPLICATION_STATUSES = ("New", "Reviewing", "Contacted", "Accepted", "Rejected")
 
+# Hiring-page per-route bounty, editable by admins (stored in the settings table
+# under key "bounty"). Amounts are free text (e.g. "15" or "10–20") so ranges are
+# allowed; blank amounts render as "confirmed on onboarding" on /join.
+BOUNTY_FIELDS = {
+    "currency": 8,
+    "per_route": 40,
+    "timing_bonus": 40,
+    "payment_note": 500,
+}
+BOUNTY_DEFAULTS = {
+    "currency": "BND",
+    "per_route": "",
+    "timing_bonus": "",
+    "payment_note": (
+        "Paid after a route passes quality review. We agree the exact rate and "
+        "payment method with you when you're onboarded."
+    ),
+}
+
+
+def _get_bounty():
+    """Current bounty settings merged over the defaults (always a full dict)."""
+    out = dict(BOUNTY_DEFAULTS)
+    raw = db.get_setting("bounty")
+    if raw:
+        try:
+            data = json.loads(raw)
+        except ValueError:
+            data = {}
+        if isinstance(data, dict):
+            for k in BOUNTY_FIELDS:
+                v = data.get(k)
+                if isinstance(v, str) and v.strip():
+                    out[k] = v.strip()
+    return out
+
 
 def _validate_application(form):
     """Validate a /join application. `form` has name, contact, districts (list),
@@ -850,6 +886,7 @@ def join_page():
     return render_template(
         "join.html", submitted=False, error=None, form={},
         districts=APPLICATION_DISTRICTS, transport_options=APPLICATION_TRANSPORT,
+        bounty=_get_bounty(),
     )
 
 
@@ -872,11 +909,13 @@ def join_apply():
         return render_template(
             "join.html", submitted=False, error=err, form=form,
             districts=APPLICATION_DISTRICTS, transport_options=APPLICATION_TRANSPORT,
+            bounty=_get_bounty(),
         ), 400
     db.add_application(fields)
     return render_template(
         "join.html", submitted=True, error=None, form={},
         districts=APPLICATION_DISTRICTS, transport_options=APPLICATION_TRANSPORT,
+        bounty=_get_bounty(),
     )
 
 
@@ -888,6 +927,7 @@ def applications_page():
         "applications.html",
         applications=db.list_applications(),
         statuses=APPLICATION_STATUSES,
+        bounty=_get_bounty(),
     )
 
 
@@ -942,6 +982,22 @@ def applications_csv():
         mimetype="text/csv",
         headers={"Content-Disposition": 'attachment; filename="applications.csv"'},
     )
+
+
+@app.route("/applications/bounty", methods=["POST"])
+@auth.admin_required(api=True)
+@ratelimit.rate_limited()
+def save_bounty():
+    # Admin-set per-route bounty rates shown on /join.
+    payload = request.get_json(silent=True) or {}
+    data = {}
+    for field, cap in BOUNTY_FIELDS.items():
+        v = payload.get(field, "")
+        if not isinstance(v, str):
+            return jsonify({"error": f"{field} must be a string"}), 400
+        data[field] = v.strip()[:cap]
+    db.set_setting("bounty", json.dumps(data, ensure_ascii=False))
+    return jsonify({"ok": True, "bounty": _get_bounty()})
 
 
 @app.route("/data/gtfs-meta")

--- a/db.py
+++ b/db.py
@@ -201,6 +201,15 @@ def _schema():
             created_at   TEXT NOT NULL DEFAULT {now}
         )
         """,
+        # App-wide key/value settings (JSON values), e.g. the hiring-page bounty
+        # rates editable from the admin area. Upsert-only.
+        f"""
+        CREATE TABLE IF NOT EXISTS settings (
+            key        TEXT NOT NULL PRIMARY KEY,
+            value      TEXT NOT NULL DEFAULT '',
+            updated_at TEXT NOT NULL DEFAULT {now}
+        )
+        """,
     ]
 
 
@@ -421,6 +430,32 @@ def delete_application(app_id):
             _q("DELETE FROM applications WHERE id=?"), (app_id,)
         )
         return cur.rowcount > 0
+
+
+def get_setting(key, default=None):
+    """Value string for an app setting, or `default` if unset."""
+    with _connect() as conn:
+        row = conn.execute(
+            _q("SELECT value FROM settings WHERE key=?"), (key,)
+        ).fetchone()
+    return row["value"] if row else default
+
+
+def set_setting(key, value):
+    """Upsert an app setting. Returns the saved value."""
+    with _connect() as conn:
+        conn.execute(
+            _q(
+                """
+                INSERT INTO settings (key, value, updated_at)
+                VALUES (?, ?, datetime('now'))
+                ON CONFLICT (key) DO UPDATE SET
+                    value = excluded.value, updated_at = excluded.updated_at
+                """
+            ),
+            (key, value),
+        )
+    return value
 
 
 def get_gtfs_meta(year, key):

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1913,6 +1913,53 @@ tr[data-status="Reviewing"] .apps-status {
   color: #c0392b;
 }
 
+/* Admin bounty editor (/applications). */
+.bounty-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 12px;
+  margin: 8px 0 12px;
+}
+.bounty-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  font-weight: normal;
+}
+.bounty-field > span {
+  font-family: var(--gtfs-display);
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.03em;
+}
+.bounty-narrow {
+  width: 120px;
+}
+.bounty-wide {
+  flex: 1 1 260px;
+}
+.bounty-field input,
+.bounty-field textarea {
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--gtfs-ink);
+  background: var(--gtfs-card);
+  border: 1px solid var(--gtfs-line);
+  border-radius: 4px;
+}
+.bounty-field textarea {
+  resize: vertical;
+}
+.bounty-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 /* Success / error banners. */
 .join-banner {
   padding: 12px 14px;

--- a/static/js/applications-page.js
+++ b/static/js/applications-page.js
@@ -56,6 +56,45 @@
     }
   });
 
+  // Save the per-route bounty rates shown on /join.
+  var bSave = document.getElementById("bSave");
+  if (bSave) {
+    bSave.addEventListener("click", function () {
+      var saved = document.getElementById("bSaved");
+      var body = {
+        currency: (document.getElementById("bCurrency") || {}).value || "",
+        per_route: (document.getElementById("bPerRoute") || {}).value || "",
+        timing_bonus: (document.getElementById("bTimingBonus") || {}).value || "",
+        payment_note: (document.getElementById("bPaymentNote") || {}).value || "",
+      };
+      fetch("/applications/bounty", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+        .then(function (r) {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.json();
+        })
+        .then(function () {
+          if (saved) {
+            saved.textContent = "Saved ✓";
+            saved.className = "apps-saved is-ok";
+            window.setTimeout(function () {
+              saved.textContent = "";
+              saved.className = "apps-saved";
+            }, 1500);
+          }
+        })
+        .catch(function () {
+          if (saved) {
+            saved.textContent = "Failed";
+            saved.className = "apps-saved is-error";
+          }
+        });
+    });
+  }
+
   document.addEventListener("click", function (e) {
     var btn = e.target.closest(".js-delete");
     if (!btn) return;

--- a/templates/applications.html
+++ b/templates/applications.html
@@ -30,6 +30,38 @@
       </header>
 
       <section>
+        <h2>Per-route bounty (shown on /join)</h2>
+        <div class="bounty-form" id="bountyForm">
+          <label class="bounty-field bounty-narrow">
+            <span>Currency</span>
+            <input type="text" id="bCurrency" maxlength="8" value="{{ bounty.currency }}" />
+          </label>
+          <label class="bounty-field bounty-narrow">
+            <span>Per route</span>
+            <input type="text" id="bPerRoute" maxlength="40" placeholder="e.g. 15"
+              value="{{ bounty.per_route }}" />
+          </label>
+          <label class="bounty-field bounty-narrow">
+            <span>Timing-board bonus</span>
+            <input type="text" id="bTimingBonus" maxlength="40" placeholder="e.g. 5"
+              value="{{ bounty.timing_bonus }}" />
+          </label>
+          <label class="bounty-field bounty-wide">
+            <span>Payment note</span>
+            <textarea id="bPaymentNote" rows="2" maxlength="500">{{ bounty.payment_note }}</textarea>
+          </label>
+          <div class="bounty-actions">
+            <button type="button" class="btn btn-primary" id="bSave">Save bounty</button>
+            <span class="apps-saved" id="bSaved" aria-live="polite"></span>
+          </div>
+        </div>
+        <p class="guide-note">
+          Leave an amount blank to show "rate confirmed on onboarding" instead of
+          a figure. Free text is allowed (e.g. a range like <code>10–20</code>).
+        </p>
+      </section>
+
+      <section>
         {% if applications %}
         <table class="guide-table apps-table">
           <thead>

--- a/templates/join.html
+++ b/templates/join.html
@@ -89,35 +89,35 @@
 
       <section>
         <h2>Per-route bounty</h2>
-        <!-- TODO(owner): replace the BND XX placeholders with real rates before
-             publishing this page. -->
         <table class="guide-table">
           <tr>
             <th scope="row">Route fully captured</th>
             <td>
-              <strong>BND XX</strong> per route — GPS track + ordered stops with
-              names/codes + stop signboard photos, accepted after review.
+              {% if bounty.per_route %}<strong>{{ bounty.currency }} {{ bounty.per_route }}</strong> per route —
+              {% endif %}GPS track + ordered stops with names/codes + stop
+              signboard photos, accepted after review.{% if not bounty.per_route %}
+              <strong>Rate confirmed on onboarding.</strong>{% endif %}
             </td>
           </tr>
+          {% if bounty.timing_bonus %}
           <tr>
             <th scope="row">Timing board bonus</th>
             <td>
-              <strong>+BND XX</strong> when you also capture a clear photo of the
-              route's official departure-time signboard.
+              <strong>+{{ bounty.currency }} {{ bounty.timing_bonus }}</strong>
+              when you also capture a clear photo of the route's official
+              departure-time signboard.
             </td>
           </tr>
+          {% endif %}
           <tr>
             <th scope="row">Payment</th>
-            <td>
-              Paid after a route passes quality review. We agree the exact rate
-              and payment method with you when you're onboarded.
-            </td>
+            <td>{{ bounty.payment_note }}</td>
           </tr>
         </table>
         <p class="guide-note">
-          Rates above are indicative — final amounts are confirmed on
-          onboarding. Quality and accuracy beat speed: a route that needs redoing
-          isn't accepted.
+          Rates are indicative — final amounts are confirmed on onboarding.
+          Quality and accuracy beat speed: a route that needs redoing isn't
+          accepted.
         </p>
       </section>
 


### PR DESCRIPTION
## What

The `/join` per-route bounty figures are no longer hardcoded `BND XX` placeholders — admins set them from the `/applications` page and they render live on the public hiring page.

- **Admin bounty form** at the top of `/applications`: currency, per-route amount, timing-board bonus, and payment note. Saved to the DB and shown on `/join`.
- **Blank-amount fallback**: leave an amount empty and `/join` shows "rate confirmed on onboarding" instead of a figure; the timing-bonus row hides entirely when unset.
- Free text allowed for amounts (e.g. a range like `10–20`).
- Admin-only: the editor password gets 401 on the save endpoint.

## Implementation
- `db.py` — `settings` key/value table + `get_setting`/`set_setting`.
- `app.py` — `_get_bounty()` (defaults merged with stored values); passed to `/join` and `/applications`; admin-gated `POST /applications/bounty`.
- `templates/join.html` — renders live values with fallback.
- `templates/applications.html` + `static/js/applications-page.js` + CSS — the bounty form.
- `README.md` — documents the bounty as admin-editable.

## Verified
- Default (no setting) → `/join` shows "rate confirmed on onboarding".
- Admin saves figures → persisted; `/join` shows `BND 15` per route, `+BND 5` bonus, custom payment note.
- Editor password blocked from saving (401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)