### PR TITLE
Hiring: guide-page nav, admin logout/awareness, and join form cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,9 +336,9 @@ bounty basis and takes applications through a built-in form.
   applicant's review status (New → Reviewing → Contacted → Accepted / Rejected),
   add an internal note, delete entries, and export everything as CSV.
 - The **per-route bounty** figures shown on `/join` (currency, per-route amount,
-  timing-board bonus, payment note) are edited from the `/applications` admin
-  page and stored in the DB (`settings` table). Leave an amount blank to show
-  "rate confirmed on onboarding" instead of a figure.
+  payment note) are edited from the `/applications` admin page and stored in the
+  DB (`settings` table). Leave the amount blank to show "rate confirmed on
+  onboarding" instead of a figure.
 
 ## Technologies Used
 

--- a/app.py
+++ b/app.py
@@ -815,13 +815,11 @@ APPLICATION_STATUSES = ("New", "Reviewing", "Contacted", "Accepted", "Rejected")
 BOUNTY_FIELDS = {
     "currency": 8,
     "per_route": 40,
-    "timing_bonus": 40,
     "payment_note": 500,
 }
 BOUNTY_DEFAULTS = {
     "currency": "BND",
     "per_route": "",
-    "timing_bonus": "",
     "payment_note": (
         "Paid after a route passes quality review. We agree the exact rate and "
         "payment method with you when you're onboarded."
@@ -847,15 +845,18 @@ def _get_bounty():
 
 
 def _validate_application(form):
-    """Validate a /join application. `form` has name, contact, districts (list),
-    transport, availability, experience, message. Returns (fields, error) where
-    fields is ready for db.add_application (districts joined to a string)."""
+    """Validate a /join application. `form` has name, email, phone, districts
+    (list), transport, availability, experience, message. Returns (fields, error)
+    where fields is ready for db.add_application (districts joined to a string)."""
     name = (form.get("name") or "").strip()
     if not name:
         return None, "Please enter your name."
-    contact = (form.get("contact") or "").strip()
-    if not contact:
-        return None, "Please enter an email or phone number so we can reach you."
+    email = (form.get("email") or "").strip()
+    phone = (form.get("phone") or "").strip()
+    if not email and not phone:
+        return None, "Please give an email or a phone number so we can reach you."
+    if email and "@" not in email:
+        return None, "That email doesn't look right — check it, or leave it blank."
 
     districts_in = form.get("districts") or []
     if isinstance(districts_in, str):
@@ -868,9 +869,14 @@ def _validate_application(form):
     if transport and transport not in APPLICATION_TRANSPORT:
         return None, "Unknown transport option."
 
+    email = email[:200]
+    phone = phone[:60]
     fields = {
         "name": name[:120],
-        "contact": contact[:200],
+        "email": email,
+        "phone": phone,
+        # Combined contact kept for the legacy column / quick display.
+        "contact": " · ".join(c for c in (email, phone) if c),
         "districts": ", ".join(districts),
         "transport": transport[:40],
         "availability": (form.get("availability") or "").strip()[:300],
@@ -897,7 +903,8 @@ def join_apply():
     # session action, so the editor's JSON/CSRF baseline doesn't apply here).
     form = {
         "name": request.form.get("name", ""),
-        "contact": request.form.get("contact", ""),
+        "email": request.form.get("email", ""),
+        "phone": request.form.get("phone", ""),
         "districts": request.form.getlist("districts"),
         "transport": request.form.get("transport", ""),
         "availability": request.form.get("availability", ""),
@@ -928,6 +935,7 @@ def applications_page():
         applications=db.list_applications(),
         statuses=APPLICATION_STATUSES,
         bounty=_get_bounty(),
+        is_editor=auth.is_authed(),
     )
 
 
@@ -970,8 +978,8 @@ def remove_application(app_id):
 @auth.admin_required()
 def applications_csv():
     # Download all applications as CSV (authed page download).
-    cols = ("id", "created_at", "name", "contact", "districts", "transport",
-            "availability", "experience", "message", "status", "admin_note")
+    cols = ("id", "created_at", "name", "email", "phone", "districts",
+            "transport", "availability", "experience", "message", "status", "admin_note")
     buf = io.StringIO()
     writer = csv.writer(buf)
     writer.writerow(cols)
@@ -1365,10 +1373,17 @@ def plan_trip():
 
 @app.route("/login")
 def login_page():
-    # One login form for both gates (editor + admin). Already in? Skip through.
-    if auth.is_authed() or auth.is_admin():
-        return redirect(auth.safe_next(request.args.get("next")) or url_for("gtfs_page"))
-    return render_template("login.html", next=request.args.get("next", ""), error=False)
+    # One login form for both gates (editor + admin). A direct visit while
+    # signed in skips to that role's home. When redirected here with ?next= (a
+    # gate bounced the visitor), always render the form — never redirect back, or
+    # an admin-only session sent to /gtfs would bounce in a loop. The form shows
+    # an account banner so a partly-signed-in visitor knows their state.
+    next_url = request.args.get("next", "")
+    authed, admin = auth.is_authed(), auth.is_admin()
+    if not next_url and (authed or admin):
+        return redirect(url_for("gtfs_page") if authed else url_for("applications_page"))
+    return render_template("login.html", next=next_url, error=False,
+                           authed=authed, admin=admin)
 
 
 @app.route("/login", methods=["POST"])
@@ -1392,7 +1407,8 @@ def login_submit():
             else url_for("gtfs_page")
         return redirect(auth.safe_next(request.form.get("next")) or default)
     return render_template(
-        "login.html", next=request.form.get("next", ""), error=True
+        "login.html", next=request.form.get("next", ""), error=True,
+        authed=auth.is_authed(), admin=auth.is_admin(),
     ), 401
 
 
@@ -1426,7 +1442,9 @@ def map_page():
 @auth.login_required()
 def gtfs_page():
     # Dedicated GTFS workbench: route list + geometry editor + schedule forms.
-    return render_template("gtfs.html")
+    # Pass admin state so an editor who is also an admin sees a link across to
+    # the hiring applications area.
+    return render_template("gtfs.html", is_admin=auth.is_admin())
 
 
 @app.route("/gtfs/guide")

--- a/db.py
+++ b/db.py
@@ -190,7 +190,9 @@ def _schema():
         CREATE TABLE IF NOT EXISTS applications (
             id           {idpk},
             name         TEXT NOT NULL,
-            contact      TEXT NOT NULL,
+            contact      TEXT NOT NULL DEFAULT '',
+            email        TEXT NOT NULL DEFAULT '',
+            phone        TEXT NOT NULL DEFAULT '',
             districts    TEXT NOT NULL DEFAULT '',
             transport    TEXT NOT NULL DEFAULT '',
             availability TEXT NOT NULL DEFAULT '',
@@ -221,6 +223,8 @@ def _migrations():
     return [
         "ALTER TABLE applications ADD COLUMN status TEXT NOT NULL DEFAULT 'New'",
         "ALTER TABLE applications ADD COLUMN admin_note TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE applications ADD COLUMN email TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE applications ADD COLUMN phone TEXT NOT NULL DEFAULT ''",
     ]
 
 
@@ -370,9 +374,9 @@ def set_note(year, route, note):
 
 def add_application(fields):
     """Insert a field-collection application and return its new id. `fields` is a
-    dict with name, contact, districts, transport, availability, experience,
-    message (the optional ones default to '')."""
-    cols = ("name", "contact", "districts", "transport",
+    dict with name, email, phone, contact, districts, transport, availability,
+    experience, message (the optional ones default to '')."""
+    cols = ("name", "email", "phone", "contact", "districts", "transport",
             "availability", "experience", "message")
     values = tuple(fields.get(c, "") or "" for c in cols)
     sql = _q(
@@ -393,7 +397,7 @@ def list_applications(limit=500):
         rows = conn.execute(
             _q(
                 """
-                SELECT id, name, contact, districts, transport,
+                SELECT id, name, email, phone, contact, districts, transport,
                        availability, experience, message, status,
                        admin_note, created_at
                 FROM applications

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1715,6 +1715,72 @@ body.guide-page {
 
 
 /* --- Join / hiring page (/join) — builds on the .guide-* system above --- */
+/* Top nav for the guide-style pages (no Bootstrap here) — a clear way back to
+   the rest of the app, since the footer links are easy to miss. */
+.guide-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  padding: 10px 24px;
+  background: var(--gtfs-ink);
+  border-bottom: 3px solid var(--gtfs-accent);
+}
+.guide-nav-brand {
+  font-family: var(--gtfs-display);
+  font-weight: 700;
+  font-size: 17px;
+  letter-spacing: 0.03em;
+  color: var(--gtfs-accent);
+  text-decoration: none;
+}
+.guide-nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 18px;
+}
+.guide-nav-links a {
+  color: #f3f4f2;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+}
+.guide-nav-links a:hover {
+  color: var(--gtfs-accent);
+  background: none;
+}
+.guide-nav-who {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--gtfs-accent);
+  border: 1px solid var(--gtfs-accent);
+  border-radius: 3px;
+  padding: 2px 8px;
+}
+.guide-nav-logout {
+  display: inline;
+  margin: 0;
+}
+.guide-nav-logout button {
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  color: #f3f4f2;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+}
+.guide-nav-logout button:hover {
+  color: var(--gtfs-accent);
+}
+
 /* Accent call-to-action button, shared by the hero CTA and the submit button. */
 .join-cta,
 .join-submit {
@@ -1810,6 +1876,11 @@ body.guide-page {
 }
 .join-field textarea {
   resize: vertical;
+}
+.join-field-hint {
+  margin: -6px 0 0;
+  font-size: 12px;
+  color: var(--gtfs-ink-soft);
 }
 .join-field input:focus,
 .join-field select:focus,

--- a/static/js/applications-page.js
+++ b/static/js/applications-page.js
@@ -64,7 +64,6 @@
       var body = {
         currency: (document.getElementById("bCurrency") || {}).value || "",
         per_route: (document.getElementById("bPerRoute") || {}).value || "",
-        timing_bonus: (document.getElementById("bTimingBonus") || {}).value || "",
         payment_note: (document.getElementById("bPaymentNote") || {}).value || "",
       };
       fetch("/applications/bounty", {

--- a/templates/applications.html
+++ b/templates/applications.html
@@ -18,6 +18,18 @@
     />
   </head>
   <body class="guide-page">
+    <nav class="guide-nav">
+      <a class="guide-nav-brand" href="/">Brunei Bus Routes</a>
+      <div class="guide-nav-links">
+        <span class="guide-nav-who">Signed in as Admin</span>
+        <a href="/join">✋ Hiring page</a>
+        {% if is_editor %}<a href="/gtfs">🕐 Workbench</a>{% endif %}
+        <a href="/">🧭 Planner</a>
+        <form method="POST" action="{{ url_for('logout') }}" class="guide-nav-logout">
+          <button type="submit">Log out</button>
+        </form>
+      </div>
+    </nav>
     <div class="guide guide-wide">
       <header class="guide-masthead">
         <div class="guide-kicker">Brunei Bus Routes · Admin</div>
@@ -40,11 +52,6 @@
             <span>Per route</span>
             <input type="text" id="bPerRoute" maxlength="40" placeholder="e.g. 15"
               value="{{ bounty.per_route }}" />
-          </label>
-          <label class="bounty-field bounty-narrow">
-            <span>Timing-board bonus</span>
-            <input type="text" id="bTimingBonus" maxlength="40" placeholder="e.g. 5"
-              value="{{ bounty.timing_bonus }}" />
           </label>
           <label class="bounty-field bounty-wide">
             <span>Payment note</span>
@@ -81,7 +88,9 @@
               <td class="apps-when">{{ a.created_at }}</td>
               <td>
                 <strong>{{ a.name }}</strong><br />
-                <span class="apps-contact">{{ a.contact }}</span>
+                {% if a.email %}<span class="apps-contact">✉ {{ a.email }}</span><br />{% endif %}
+                {% if a.phone %}<span class="apps-contact">☎ {{ a.phone }}</span>
+                {% elif not a.email %}<span class="apps-contact">{{ a.contact }}</span>{% endif %}
               </td>
               <td>
                 {{ a.districts }}{% if a.districts and a.transport %}<br />{% endif %}

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -46,8 +46,13 @@
             </select>
           </li>
         </ul>
+        {% if is_admin %}
+        <a href="{{ url_for('applications_page') }}"
+          class="btn btn-default btn-sm navbar-btn"
+          title="You're also signed in as admin — manage hiring applications">✋ Applications</a>
+        {% endif %}
         <form method="POST" action="{{ url_for('logout') }}" style="display:inline; margin:0">
-          <button type="submit" class="btn btn-default btn-sm navbar-btn" title="Log out of the editor">Log out</button>
+          <button type="submit" class="btn btn-default btn-sm navbar-btn" title="Log out">Log out</button>
         </form>
         <button
           type="button"

--- a/templates/join.html
+++ b/templates/join.html
@@ -21,6 +21,14 @@
     />
   </head>
   <body class="guide-page join-page">
+    <nav class="guide-nav">
+      <a class="guide-nav-brand" href="/">Brunei Bus Routes</a>
+      <div class="guide-nav-links">
+        <a href="/">🧭 Planner</a>
+        <a href="/map">🗺 Map</a>
+        <a href="/gtfs/guide">📋 Data guide</a>
+      </div>
+    </nav>
     <div class="guide">
       <header class="guide-masthead join-hero">
         <div class="guide-kicker">Brunei Bus Routes · Field data collection</div>
@@ -72,8 +80,8 @@
             <div class="join-card-icon">📷</div>
             <h3>Photograph signboards</h3>
             <p>
-              Photograph each stop's signboard and the route's timing board, so
-              names and departure times can be transcribed accurately.
+              Photograph each stop's signboard so stop names and codes can be
+              transcribed accurately.
             </p>
           </div>
           <div class="join-card">
@@ -99,16 +107,6 @@
               <strong>Rate confirmed on onboarding.</strong>{% endif %}
             </td>
           </tr>
-          {% if bounty.timing_bonus %}
-          <tr>
-            <th scope="row">Timing board bonus</th>
-            <td>
-              <strong>+{{ bounty.currency }} {{ bounty.timing_bonus }}</strong>
-              when you also capture a clear photo of the route's official
-              departure-time signboard.
-            </td>
-          </tr>
-          {% endif %}
           <tr>
             <th scope="row">Payment</th>
             <td>{{ bounty.payment_note }}</td>
@@ -164,11 +162,20 @@
           </label>
 
           <label class="join-field">
-            <span>Email or phone (WhatsApp) <em>*</em></span>
-            <input type="text" name="contact" maxlength="200" required
-              placeholder="you@example.com or +673 …"
-              value="{{ form.get('contact', '') }}" />
+            <span>Email</span>
+            <input type="email" name="email" maxlength="200"
+              placeholder="you@example.com"
+              value="{{ form.get('email', '') }}" />
           </label>
+
+          <label class="join-field">
+            <span>Phone / WhatsApp</span>
+            <input type="tel" name="phone" maxlength="60"
+              placeholder="+673 …"
+              value="{{ form.get('phone', '') }}" />
+          </label>
+
+          <p class="join-field-hint">Give at least one — an email or a phone number — so we can reach you.</p>
 
           <fieldset class="join-field">
             <span>Districts you can cover</span>
@@ -205,11 +212,6 @@
             <span>Relevant experience (optional)</span>
             <textarea name="experience" rows="3" maxlength="1000"
               placeholder="Anything that helps — local knowledge, field/survey work, etc.">{{ form.get('experience', '') }}</textarea>
-          </label>
-
-          <label class="join-field">
-            <span>Anything else (optional)</span>
-            <textarea name="message" rows="3" maxlength="2000">{{ form.get('message', '') }}</textarea>
           </label>
 
           <button type="submit" class="btn btn-primary join-submit">Send application</button>

--- a/templates/login.html
+++ b/templates/login.html
@@ -23,6 +23,25 @@
     <div class="login-wrap">
       <h1>🔑 Log in</h1>
       <p class="muted">Enter your editor or admin password. Viewing the map and planner needs no login.</p>
+      {% if authed or admin %}
+      <div class="alert alert-info" role="status">
+        You're signed in as
+        <strong>{% if authed and admin %}Editor &amp; Admin{% elif admin %}Admin{% else %}Editor{% endif %}</strong>.
+        <div style="margin-top: 8px">
+          {% if admin %}<a href="{{ url_for('applications_page') }}" class="btn btn-default btn-sm">✋ Applications</a>{% endif %}
+          {% if authed %}<a href="{{ url_for('gtfs_page') }}" class="btn btn-default btn-sm">🕐 Workbench</a>{% endif %}
+          <form method="POST" action="{{ url_for('logout') }}" style="display:inline; margin:0">
+            <button type="submit" class="btn btn-default btn-sm">Log out</button>
+          </form>
+        </div>
+        {% if not (authed and admin) %}
+        <p class="muted" style="margin: 10px 0 0">
+          Need the {% if admin %}editor workbench{% else %}admin area{% endif %} too?
+          Enter that password below.
+        </p>
+        {% endif %}
+      </div>
+      {% endif %}
       {% if error %}
       <div class="alert alert-danger" role="alert">Incorrect password.</div>
       {% endif %}


### PR DESCRIPTION
## What

Navigation, account, and form improvements across the hiring/admin pages.

**Navigation**
- Top nav bar on `/join` (Planner / Map / Data guide) so the way home isn't only in the footer.
- `/applications` gets a nav with a **"Signed in as Admin"** badge, a **Log out** button, and cross-links.

**Admin awareness + logout (fixes a redirect loop)**
- An **admin-only** session visiting `/gtfs` previously bounced between `/gtfs` and `/login` forever. Now `/login` renders an account banner (your role, links to Applications / Workbench, and Log out) instead of redirecting back.
- Editors who are also admins see a **✋ Applications** link on the workbench navbar.
- The single login form accepts either the editor or admin password.

**Join form cleanup**
- Split the one "Email or phone" field into **separate Email and Phone fields** (at least one required; basic email sanity check). Added `email`/`phone` columns via migration; admin view + CSV show them separately.
- Removed the **timing-board bounty** (the `/join` row, the admin field, and the backend) and all timing-board mentions.
- Removed the redundant **"Anything else"** message field.

## Files
- `app.py` — login/account routing + banner state; email/phone validation; bounty/profile fields trimmed; CSV columns.
- `db.py` — `email`/`phone` columns + migration; updated accessors.
- `templates/` — `join.html`, `applications.html`, `gtfs.html`, `login.html`.
- `static/css/styles.css` — guide-nav, account badge/logout, two-field form.

## Verified
- Admin→`/gtfs` no longer loops; lands on login with banner + Applications link + logout.
- Editor opens only `/gtfs`; admin opens only `/applications`; editor+admin sees cross-links.
- Email-only and phone-only both submit; neither/bad-email rejected; admin + CSV show email/phone.
- No timing-board references remain; "Anything else" field gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)