### PR TITLE
Per-stop photo upload, gallery lightbox, and credits cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ brunei-gtfs-*.zip
 
 # Local Claude Code config (personal slash commands, plans, etc.)
 .claude/
+
+# Local Claude Code project guidance (personal, not shared)
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ full flow is draw → schedule → download. The GTFS pane covers:
   names and coordinates, reorder/remove, and click-to-locate on the map;
   edits save as new geometry versions (official routes become editable via
   the ✎ copy flow)
+- **Stop photos** — each stop row has a 📷 button to upload field photos of the
+  stop (JPEG/PNG/WEBP, ≤5 MB), with a count badge and a thumbnail panel to view
+  or delete them. Images are stored **in the database** (not the filesystem,
+  which is ephemeral on Replit) and keyed to the stop's rounded coordinates, so
+  they survive reordering/renaming. Editor-only
+  (`/data/stop-photo*` endpoints, magic-byte validated)
 - **Feed settings** — the operator list (multiple companies supported; the
   first is the default for unassigned routes), holiday exceptions ("no
   service" or "Sunday timetable" per date → weekday-aware

--- a/app.py
+++ b/app.py
@@ -51,6 +51,9 @@ app.config.update(
     SESSION_COOKIE_SAMESITE="Lax",
     SESSION_COOKIE_SECURE=bool(os.environ.get("SECRET_KEY")),
     PERMANENT_SESSION_LIFETIME=datetime.timedelta(days=14),
+    # Cap request bodies so an oversized stop-photo upload is rejected (413) before
+    # it reaches our code. Every other endpoint takes small JSON, so this is safe.
+    MAX_CONTENT_LENGTH=6 * 1024 * 1024,
 )
 
 # The route data is segregated by year so new datasets live alongside the repo
@@ -1638,6 +1641,113 @@ def stop_image(year, filename):
     if not path:
         return "Stop image not found", 404
     return send_from_directory(os.path.dirname(path), os.path.basename(path))
+
+
+# --- Editor-uploaded stop photos (bytes stored in the DB) --------------------
+STOP_PHOTO_MAX_BYTES = 5 * 1024 * 1024
+# Accept only real images; the type is decided by sniffing magic bytes, not the
+# client-declared content-type, so a renamed non-image can't slip through.
+_IMAGE_SNIFFERS = {
+    "image/jpeg": lambda b: b[:3] == b"\xff\xd8\xff",
+    "image/png": lambda b: b[:8] == b"\x89PNG\r\n\x1a\n",
+    "image/webp": lambda b: b[:4] == b"RIFF" and b[8:12] == b"WEBP",
+}
+# stop_key is the stop's rounded "lon,lat" (computed identically client- and
+# server-side); validated to a strict shape before it touches the DB.
+_STOP_KEY_RE = re.compile(r"-?\d{1,3}\.\d{1,6},-?\d{1,3}\.\d{1,6}")
+
+
+def _validate_image(file_storage):
+    """Validate an uploaded image. Returns (mimetype, data, error)."""
+    if file_storage is None or not file_storage.filename:
+        return None, None, "no file uploaded"
+    data = file_storage.read()
+    if not data:
+        return None, None, "empty file"
+    if len(data) > STOP_PHOTO_MAX_BYTES:
+        return None, None, "image too large (max 5 MB)"
+    for mimetype, sniff in _IMAGE_SNIFFERS.items():
+        if sniff(data):
+            return mimetype, data, None
+    return None, None, "unsupported image type (use JPEG, PNG, or WEBP)"
+
+
+@app.route("/data/stop-photo", methods=["POST"])
+@auth.login_required(api=True)
+@ratelimit.rate_limited()
+def upload_stop_photo():
+    year = _resolve_year(request.form.get("year"))
+    route = (request.form.get("route") or "").strip()[:200]
+    stop_key = (request.form.get("stop_key") or "").strip()[:40]
+    stop_name = (request.form.get("stop_name") or "").strip()[:200]
+    if not route:
+        return jsonify({"error": "route required"}), 400
+    if not _STOP_KEY_RE.fullmatch(stop_key):
+        return jsonify({"error": "bad stop_key"}), 400
+    mimetype, data, err = _validate_image(request.files.get("photo"))
+    if err:
+        return jsonify({"error": err}), 400
+    photo_id = db.add_stop_photo(year, route, stop_key, stop_name, mimetype, data)
+    return jsonify({"ok": True, "id": photo_id}), 201
+
+
+# Listing + serving photos is public (read-only) so the map's stop info panel can
+# show them; uploading and deleting stay editor-gated below.
+@app.route("/data/stop-photos")
+def list_stop_photos():
+    year = _resolve_year(request.args.get("year"))
+    route = (request.args.get("route") or "").strip()[:200]
+    stop_key = (request.args.get("stop") or "").strip()[:40]
+    if not route or not stop_key:
+        return jsonify({"error": "route and stop required"}), 400
+    return jsonify({"photos": db.list_stop_photos(year, route, stop_key)})
+
+
+@app.route("/data/stop-photo-counts")
+@auth.login_required(api=True)
+def stop_photo_counts():
+    year = _resolve_year(request.args.get("year"))
+    route = (request.args.get("route") or "").strip()[:200]
+    if not route:
+        return jsonify({"error": "route required"}), 400
+    return jsonify({"counts": db.stop_photo_counts(year, route)})
+
+
+@app.route("/data/stop-photo/<int:photo_id>")
+def serve_stop_photo(photo_id):
+    photo = db.get_stop_photo(photo_id)
+    if not photo:
+        return "Stop photo not found", 404
+    return Response(
+        photo["image"],
+        mimetype=photo["mimetype"],
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
+@app.route("/data/stop-photo/<int:photo_id>", methods=["DELETE"])
+@auth.login_required(api=True)
+@ratelimit.rate_limited()
+def delete_stop_photo(photo_id):
+    if not db.delete_stop_photo(photo_id):
+        return jsonify({"error": "stop photo not found"}), 404
+    return jsonify({"ok": True})
+
+
+@app.route("/data/stop-photo-order", methods=["POST"])
+@auth.login_required(api=True)
+@ratelimit.rate_limited()
+def order_stop_photos():
+    # Set the display order of a stop's photos from an ordered list of ids.
+    payload = request.get_json(silent=True) or {}
+    ids = payload.get("ids")
+    if not isinstance(ids, list) or not ids or len(ids) > 200:
+        return jsonify({"error": "ids must be a non-empty list"}), 400
+    for x in ids:
+        if not isinstance(x, int) or isinstance(x, bool):
+            return jsonify({"error": "ids must be integers"}), 400
+    db.set_stop_photo_order(ids)
+    return jsonify({"ok": True})
 
 
 @app.route("/data/route-note")

--- a/db.py
+++ b/db.py
@@ -118,9 +118,11 @@ def _schema():
     if _BACKEND == "postgres":
         idpk = "BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY"
         now = "((now())::text)"
+        blob = "BYTEA"
     else:
         idpk = "INTEGER PRIMARY KEY AUTOINCREMENT"
         now = "(datetime('now'))"
+        blob = "BLOB"
     return [
         f"""
         CREATE TABLE IF NOT EXISTS route_versions (
@@ -212,6 +214,26 @@ def _schema():
             updated_at TEXT NOT NULL DEFAULT {now}
         )
         """,
+        # Editor-uploaded photos of a bus stop. Bytes live in the DB (the
+        # filesystem is ephemeral on Replit). A stop has no stable id, so photos
+        # are keyed by the stop's rounded "lon,lat" (stable across reorder/rename).
+        f"""
+        CREATE TABLE IF NOT EXISTS stop_photos (
+            id         {idpk},
+            year       TEXT NOT NULL,
+            filename   TEXT NOT NULL,
+            stop_key   TEXT NOT NULL,
+            stop_name  TEXT NOT NULL DEFAULT '',
+            mimetype   TEXT NOT NULL,
+            image      {blob} NOT NULL,
+            sort_order INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL DEFAULT {now}
+        )
+        """,
+        """
+        CREATE INDEX IF NOT EXISTS idx_stop_photos_stop
+        ON stop_photos (year, filename, stop_key)
+        """,
     ]
 
 
@@ -225,6 +247,7 @@ def _migrations():
         "ALTER TABLE applications ADD COLUMN admin_note TEXT NOT NULL DEFAULT ''",
         "ALTER TABLE applications ADD COLUMN email TEXT NOT NULL DEFAULT ''",
         "ALTER TABLE applications ADD COLUMN phone TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE stop_photos ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0",
     ]
 
 
@@ -460,6 +483,90 @@ def set_setting(key, value):
             (key, value),
         )
     return value
+
+
+def add_stop_photo(year, filename, stop_key, stop_name, mimetype, data):
+    """Store one stop photo (bytes) and return its new id. New photos append to
+    the end of the stop's existing order."""
+    sql = _q(
+        "INSERT INTO stop_photos "
+        "(year, filename, stop_key, stop_name, mimetype, image, sort_order) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)"
+    )
+    with _connect() as conn:
+        nxt = conn.execute(
+            _q(
+                "SELECT COALESCE(MAX(sort_order), -1) + 1 AS n FROM stop_photos "
+                "WHERE year=? AND filename=? AND stop_key=?"
+            ),
+            (year, filename, stop_key),
+        ).fetchone()["n"]
+        values = (year, filename, stop_key, stop_name, mimetype, data, nxt)
+        if _BACKEND == "postgres":
+            return conn.execute(sql + " RETURNING id", values).fetchone()["id"]
+        return conn.execute(sql, values).lastrowid
+
+
+def list_stop_photos(year, filename, stop_key):
+    """Photo metadata (no bytes) for one stop, in display order."""
+    with _connect() as conn:
+        rows = conn.execute(
+            _q(
+                """
+                SELECT id, created_at FROM stop_photos
+                WHERE year=? AND filename=? AND stop_key=?
+                ORDER BY sort_order ASC, id ASC
+                """
+            ),
+            (year, filename, stop_key),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def set_stop_photo_order(ids):
+    """Set each photo's sort_order to its position in `ids`."""
+    with _connect() as conn:
+        for i, pid in enumerate(ids):
+            conn.execute(
+                _q("UPDATE stop_photos SET sort_order=? WHERE id=?"), (i, pid)
+            )
+    return True
+
+
+def stop_photo_counts(year, filename):
+    """{stop_key: count} for a route, for per-stop badges."""
+    with _connect() as conn:
+        rows = conn.execute(
+            _q(
+                """
+                SELECT stop_key, COUNT(*) AS n FROM stop_photos
+                WHERE year=? AND filename=? GROUP BY stop_key
+                """
+            ),
+            (year, filename),
+        ).fetchall()
+    return {r["stop_key"]: r["n"] for r in rows}
+
+
+def get_stop_photo(photo_id):
+    """{mimetype, image bytes} for one photo, or None."""
+    with _connect() as conn:
+        row = conn.execute(
+            _q("SELECT mimetype, image FROM stop_photos WHERE id=?"), (photo_id,)
+        ).fetchone()
+    if not row:
+        return None
+    # psycopg returns a memoryview for BYTEA; normalise to bytes for both backends.
+    return {"mimetype": row["mimetype"], "image": bytes(row["image"])}
+
+
+def delete_stop_photo(photo_id):
+    """Delete one stop photo. Returns True if a row was removed."""
+    with _connect() as conn:
+        cur = conn.execute(
+            _q("DELETE FROM stop_photos WHERE id=?"), (photo_id,)
+        )
+        return cur.rowcount > 0
 
 
 def get_gtfs_meta(year, key):

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -116,6 +116,8 @@ body {
   padding: 10px 14px;
   top: auto;
   bottom: 0;
+  /* Sit above the routes sidebar (z-index 1000) so it's never hidden. */
+  z-index: 1200;
 }
 #info .name {
   font-family: var(--gtfs-display);
@@ -135,6 +137,95 @@ body {
 
 #info .dismiss {
   float: right;
+}
+#info .info-photos {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 8px;
+}
+#info .info-photos img {
+  height: 90px;
+  width: auto;
+  max-width: 140px;
+  object-fit: cover;
+  border: 1px solid var(--gtfs-line);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+/* Shared image lightbox (lightbox.js). */
+.lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 30px;
+  background: rgba(0, 0, 0, 0.85);
+  /* Rapid open/close clicks would otherwise select the image (blue highlight). */
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+.lightbox-overlay.is-open {
+  display: flex;
+}
+.lightbox-img {
+  max-width: 95%;
+  max-height: 95%;
+  object-fit: contain;
+  box-shadow: 0 6px 40px rgba(0, 0, 0, 0.6);
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-user-drag: none;
+}
+.lightbox-close {
+  position: absolute;
+  top: 14px;
+  right: 22px;
+  border: 0;
+  background: none;
+  color: #fff;
+  font-size: 36px;
+  line-height: 1;
+  cursor: pointer;
+}
+.lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  border: 0;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  font-size: 40px;
+  line-height: 1;
+  width: 52px;
+  height: 72px;
+  cursor: pointer;
+  border-radius: 6px;
+}
+.lightbox-nav:hover {
+  background: rgba(0, 0, 0, 0.7);
+}
+.lightbox-prev {
+  left: 16px;
+}
+.lightbox-next {
+  right: 16px;
+}
+.lightbox-counter {
+  position: absolute;
+  bottom: 18px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: #fff;
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
 }
 
 #map {
@@ -302,6 +393,11 @@ textarea:focus-visible {
 body.editing #sidebar {
   top: 108px;
 }
+/* While a stop's info banner is open (docked bottom-centre), lift the sidebar's
+   bottom so the two don't overlap. Toggled by InfoManager. */
+body.stop-selected #sidebar {
+  bottom: 230px;
+}
 .sidebar-title {
   font-family: var(--gtfs-display);
   font-weight: 600;
@@ -335,6 +431,34 @@ body.editing #sidebar {
 }
 .route-group:first-child {
   margin-top: 0;
+}
+/* ⓘ toggle next to a shipped (official) group header — clicking it shows the
+   source-credit callout below. */
+.route-credit-info {
+  margin-left: 6px;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--gtfs-accent);
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+}
+.route-credit-info:hover,
+.route-credit-info:focus,
+.route-credit-info.is-open {
+  color: var(--gtfs-ink);
+  outline: none;
+}
+.route-credit {
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--gtfs-ink);
+  background: rgba(255, 209, 102, 0.16);
+  border-left: 3px solid var(--gtfs-accent);
+  border-radius: 0 4px 4px 0;
+  padding: 6px 9px;
+  margin: 4px 0 8px;
 }
 
 /* --- Route editor --- */
@@ -987,12 +1111,12 @@ body.editing #gtfsEditBtn {
      minmax, so no cell's content (header labels, input intrinsic widths) can
      change a track — columns cannot drift the way two independently-resolved
      flex containers did. */
-  --gep-stop-cols: 26px 40px minmax(60px, 1fr) minmax(56px, 72px) minmax(56px, 72px);
+  --gep-stop-cols: 26px 40px minmax(60px, 1fr) minmax(56px, 72px) minmax(56px, 72px) 30px;
 }
 /* Edit mode (JS toggles the class): one extra ↑↓✕ tools track, sized by the
    rows' identical tool spans; the head simply leaves that cell empty. */
 #gepStopsList.gep-has-tools {
-  --gep-stop-cols: 26px 40px minmax(60px, 1fr) minmax(56px, 72px) minmax(56px, 72px) max-content;
+  --gep-stop-cols: 26px 40px minmax(60px, 1fr) minmax(56px, 72px) minmax(56px, 72px) 30px max-content;
 }
 /* Head and data rows share the same grid, hence identical column edges by
    construction. (JS keeps .gep-stops-head distinct from .gep-stop-row.) */
@@ -1097,6 +1221,107 @@ body.editing #gtfsEditBtn {
 }
 .gep-stop-tools .gep-stop-del {
   color: var(--gtfs-danger);
+}
+
+/* Per-stop photo button + count badge. */
+.gep-stop-photo-col {
+  text-align: center;
+}
+.gep-stop-photo {
+  position: relative;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+  font-size: 14px;
+  line-height: 1;
+  opacity: 0.7;
+}
+.gep-stop-photo:hover {
+  opacity: 1;
+}
+.gep-photo-badge {
+  position: absolute;
+  top: -6px;
+  right: -8px;
+  min-width: 14px;
+  padding: 0 3px;
+  font-size: 9px;
+  line-height: 14px;
+  text-align: center;
+  color: #fff;
+  background: var(--gtfs-danger, #c0392b);
+  border-radius: 8px;
+}
+/* Stop-photo modal: thumbnail grid + upload row. */
+.gep-photo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.gep-photo-cell {
+  position: relative;
+}
+.gep-photo-cell img {
+  width: 100%;
+  height: 110px;
+  object-fit: cover;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  display: block;
+  cursor: pointer;
+}
+.gep-photo-del {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 22px;
+  height: 22px;
+  border: 0;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 22px;
+  padding: 0;
+}
+.gep-photo-del:hover {
+  background: var(--gtfs-danger, #c0392b);
+}
+/* Reorder controls, bottom-left of each thumbnail (shown when >1 photo). */
+.gep-photo-order {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  display: flex;
+  gap: 3px;
+}
+.gep-photo-order button {
+  width: 22px;
+  height: 22px;
+  border: 0;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 22px;
+  padding: 0;
+}
+.gep-photo-order button:hover:not(:disabled) {
+  background: rgba(0, 0, 0, 0.85);
+}
+.gep-photo-order button:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.gep-photo-upload {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 #gtfsTimingBody {

--- a/static/js/gtfs-editor-manager.js
+++ b/static/js/gtfs-editor-manager.js
@@ -17,6 +17,7 @@ APP.GtfsEditorManager = class {
     this._stopsTimer = null;
     this._populating = false; // suppress autosave while filling the form
     this._timingDismissed = false; // user closed the timing panel this session
+    this._photoCounts = {}; // {stop_key: count} for the current route's stop photos
   }
 
   init() {
@@ -269,6 +270,7 @@ APP.GtfsEditorManager = class {
         };
         this.stopsStatus.textContent = "";
         this._renderStops();
+        this._loadPhotoCounts();
       })
       .catch((err) => {
         this.stopsStatus.textContent = "Load failed";
@@ -337,6 +339,7 @@ APP.GtfsEditorManager = class {
     head.append($('<span class="gep-stop-name">Name</span>'));
     head.append($('<span class="gep-stop-coord">Lat</span>'));
     head.append($('<span class="gep-stop-coord">Lon</span>'));
+    head.append($('<span class="gep-stop-photo-col">📷</span>'));
     list.append(head);
     stops.forEach((s, i) => {
       const row = $('<div class="gep-stop-row"></div>').attr("data-i", i);
@@ -363,6 +366,16 @@ APP.GtfsEditorManager = class {
           .val(s.lon.toFixed(6))
           .prop("disabled", !editable)
       );
+      // Per-stop photo button (keyed by rounded lon,lat — see the upload flow);
+      // a badge shows how many photos this stop already has.
+      const pkey = `${s.lon.toFixed(6)},${s.lat.toFixed(6)}`;
+      const pn = this._photoCounts[pkey] || 0;
+      const photo = $('<button type="button" class="gep-stop-photo" title="Stop photos"></button>')
+        .attr("data-key", pkey)
+        .attr("data-name", s.name || "")
+        .text("📷");
+      if (pn) photo.append($('<span class="gep-photo-badge"></span>').text(pn));
+      row.append(photo);
       if (showTools) {
         const tools = $('<span class="gep-stop-tools"></span>');
         tools.append($('<a class="gep-stop-up" title="Move earlier">↑</a>'));
@@ -372,6 +385,159 @@ APP.GtfsEditorManager = class {
       }
       list.append(row);
     });
+  }
+
+  // --- Stop photos ---------------------------------------------------------------
+
+  /** Fetch the current route's per-stop photo counts and refresh the badges. */
+  _loadPhotoCounts() {
+    const ctx = this.current;
+    if (!ctx) return;
+    const q = `?year=${encodeURIComponent(ctx.year)}&route=${encodeURIComponent(ctx.file)}`;
+    fetch(`/data/stop-photo-counts${q}`)
+      .then((r) => (r.ok ? r.json() : { counts: {} }))
+      .then((d) => {
+        if (!this.current || this.current.file !== ctx.file) return; // stale
+        this._photoCounts = d.counts || {};
+        this._renderPhotoBadges();
+      })
+      .catch(() => {});
+  }
+
+  /** Update the photo-count badges in place without rebuilding the rows. */
+  _renderPhotoBadges() {
+    $("#gepStopsList .gep-stop-photo").each((_, btn) => {
+      const n = this._photoCounts[$(btn).attr("data-key")] || 0;
+      $(btn).find(".gep-photo-badge").remove();
+      if (n) $(btn).append($('<span class="gep-photo-badge"></span>').text(n));
+    });
+  }
+
+  /** Open the photo panel for one stop (keyed by its rounded lon,lat). */
+  _openStopPhotos(stopKey, stopName) {
+    if (!this.current) return;
+    this._photoStop = { key: stopKey, name: stopName };
+    document.getElementById("stopPhotoName").textContent = stopName || "(unnamed stop)";
+    const file = document.getElementById("stopPhotoFile");
+    if (file) file.value = "";
+    document.getElementById("stopPhotoStatus").textContent = "";
+    this._loadStopPhotoGrid();
+    $("#stopPhotoModal").modal("show");
+  }
+
+  _loadStopPhotoGrid() {
+    const ctx = this.current;
+    const stop = this._photoStop;
+    if (!ctx || !stop) return;
+    const grid = $("#stopPhotoGrid").html('<span class="gep-status">Loading…</span>');
+    const q = `?year=${encodeURIComponent(ctx.year)}&route=${encodeURIComponent(ctx.file)}`
+      + `&stop=${encodeURIComponent(stop.key)}`;
+    fetch(`/data/stop-photos${q}`)
+      .then((r) => r.json())
+      .then((d) => {
+        const photos = d.photos || [];
+        this._photos = photos; // current display order, for reordering
+        grid.empty();
+        if (!photos.length) {
+          grid.html('<span class="gep-status">No photos yet.</span>');
+          return;
+        }
+        const srcs = photos.map((p) => `/data/stop-photo/${p.id}`);
+        const multi = photos.length > 1;
+        photos.forEach((p, i) => {
+          const cell = $('<div class="gep-photo-cell"></div>').attr("data-id", p.id);
+          cell.append(
+            $('<img alt="stop photo" title="Click to enlarge" />')
+              .attr("src", srcs[i])
+              .on("click", () => APP.lightbox(srcs, i))
+          );
+          cell.append(
+            $('<button type="button" class="gep-photo-del" title="Delete photo">✕</button>')
+              .attr("data-id", p.id)
+          );
+          if (multi) {
+            // Reorder controls — disabled at the ends.
+            const tools = $('<div class="gep-photo-order"></div>');
+            tools.append(
+              $('<button type="button" class="gep-photo-up" title="Move earlier">↑</button>')
+                .attr("data-id", p.id)
+                .prop("disabled", i === 0)
+            );
+            tools.append(
+              $('<button type="button" class="gep-photo-down" title="Move later">↓</button>')
+                .attr("data-id", p.id)
+                .prop("disabled", i === photos.length - 1)
+            );
+            cell.append(tools);
+          }
+          grid.append(cell);
+        });
+      })
+      .catch(() => grid.html('<span class="gep-status">Failed to load.</span>'));
+  }
+
+  _uploadStopPhoto() {
+    const ctx = this.current;
+    const stop = this._photoStop;
+    const input = document.getElementById("stopPhotoFile");
+    const statusEl = document.getElementById("stopPhotoStatus");
+    if (!ctx || !stop || !input || !input.files.length) {
+      statusEl.textContent = "Choose an image first.";
+      return;
+    }
+    const fd = new FormData();
+    fd.append("year", ctx.year);
+    fd.append("route", ctx.file);
+    fd.append("stop_key", stop.key);
+    fd.append("stop_name", stop.name || "");
+    fd.append("photo", input.files[0]);
+    statusEl.textContent = "Uploading…";
+    fetch("/data/stop-photo", { method: "POST", body: fd })
+      .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
+      .then(({ ok, d }) => {
+        if (!ok) {
+          statusEl.textContent = d.error || "Upload failed.";
+          return;
+        }
+        statusEl.textContent = "Saved ✓";
+        input.value = "";
+        this._loadStopPhotoGrid();
+        this._loadPhotoCounts();
+      })
+      .catch(() => { statusEl.textContent = "Upload failed."; });
+  }
+
+  _deleteStopPhoto(id) {
+    fetch(`/data/stop-photo/${id}`, { method: "DELETE" })
+      .then((r) => {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        this._loadStopPhotoGrid();
+        this._loadPhotoCounts();
+      })
+      .catch(() => {
+        document.getElementById("stopPhotoStatus").textContent = "Delete failed.";
+      });
+  }
+
+  /** Move a photo earlier/later in the stop's order and persist the new order. */
+  _reorderStopPhoto(id, delta) {
+    const ids = (this._photos || []).map((p) => p.id);
+    const i = ids.indexOf(id);
+    const j = i + delta;
+    if (i < 0 || j < 0 || j >= ids.length) return;
+    [ids[i], ids[j]] = [ids[j], ids[i]];
+    fetch("/data/stop-photo-order", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ids }),
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error("HTTP " + r.status);
+        this._loadStopPhotoGrid();
+      })
+      .catch(() => {
+        document.getElementById("stopPhotoStatus").textContent = "Reorder failed.";
+      });
   }
 
   _stopAt(el) {
@@ -1253,6 +1419,20 @@ APP.GtfsEditorManager = class {
       if (i == null || !this.page) return;
       const s = this._stopsData()[i];
       if (s) this.page.focusStop(s.lon, s.lat);
+    });
+    stopsList.on("click", ".gep-stop-photo", (e) => {
+      const btn = e.currentTarget;
+      this._openStopPhotos(btn.getAttribute("data-key"), btn.getAttribute("data-name"));
+    });
+    // Stop-photo modal: upload, and delete (delegated — thumbnails are rebuilt).
+    $("#stopPhotoUpload").on("click", () => this._uploadStopPhoto());
+    $("#stopPhotoGrid").on("click", ".gep-photo-del", (e) => {
+      this._deleteStopPhoto(parseInt(e.currentTarget.getAttribute("data-id"), 10));
+    });
+    $("#stopPhotoGrid").on("click", ".gep-photo-up, .gep-photo-down", (e) => {
+      const id = parseInt(e.currentTarget.getAttribute("data-id"), 10);
+      const delta = $(e.currentTarget).hasClass("gep-photo-up") ? -1 : 1;
+      this._reorderStopPhoto(id, delta);
     });
     stopsList.on("input", ".gep-stop-name", (e) => {
       const i = this._stopAt(e.currentTarget);

--- a/static/js/gtfs-page.js
+++ b/static/js/gtfs-page.js
@@ -306,6 +306,12 @@ APP.GtfsPage = class {
     });
     source.on("change", () => {
       if (source.getState() === "ready" && source.getFeatures().length) {
+        // Tag features with the route context so the stop info popup can look up
+        // this stop's photos (same as the public map's route-manager does).
+        source.getFeatures().forEach((f) => {
+          f.set("routeYear", year, true);
+          f.set("routeFile", file, true);
+        });
         const ext = source.getExtent();
         if (ext && isFinite(ext[0])) {
           // Keep the fitted route clear of the timing panel docked on the

--- a/static/js/info-manager.js
+++ b/static/js/info-manager.js
@@ -24,8 +24,11 @@ APP.InfoManager = class {
   showInfo(feature) {
     if (!feature) {
       $("#info").hide();
+      document.body.classList.remove("stop-selected");
       return;
     }
+    // Lets the CSS shorten the routes sidebar so it doesn't cover the banner.
+    document.body.classList.add("stop-selected");
 
     const name = feature.get("name");
     $("#info .name").text(name);
@@ -39,7 +42,46 @@ APP.InfoManager = class {
         .show();
     }
 
+    this.showStopPhotos(feature, coord);
     $("#info").show();
+  }
+
+  /**
+   * Show field photos for a clicked stop, if any exist. Only point features
+   * tagged with a route (year + file) can be matched; the stop is keyed by its
+   * rounded coordinates, the same key the workbench uploads under.
+   * @param {ol.Feature} feature
+   * @param {number[]} coord - [lon, lat] of the feature
+   */
+  showStopPhotos(feature, coord) {
+    const wrap = $("#info .info-photos").empty().hide();
+    const geom = feature.getGeometry();
+    const year = feature.get("routeYear");
+    const file = feature.get("routeFile");
+    if (!geom || geom.getType() !== "Point" || !year || !file || isNaN(coord[0])) {
+      return; // not a locatable stop on a known route
+    }
+    const stopKey = `${coord[0].toFixed(6)},${coord[1].toFixed(6)}`;
+    const token = (this._photoToken = (this._photoToken || 0) + 1);
+    const q = `?year=${encodeURIComponent(year)}&route=${encodeURIComponent(file)}`
+      + `&stop=${encodeURIComponent(stopKey)}`;
+    fetch(`/data/stop-photos${q}`)
+      .then((r) => (r.ok ? r.json() : { photos: [] }))
+      .then((d) => {
+        if (token !== this._photoToken) return; // a newer stop was clicked
+        const photos = d.photos || [];
+        if (!photos.length) return;
+        const srcs = photos.map((p) => `/data/stop-photo/${p.id}`);
+        photos.forEach((p, i) => {
+          wrap.append(
+            $('<img alt="stop photo" title="Click to enlarge" />')
+              .attr("src", srcs[i])
+              .on("click", () => APP.lightbox(srcs, i))
+          );
+        });
+        wrap.show();
+      })
+      .catch(() => {});
   }
 
   /**
@@ -48,6 +90,7 @@ APP.InfoManager = class {
   hideInfo() {
     this.select.getFeatures().clear();
     $("#info").hide();
+    document.body.classList.remove("stop-selected");
   }
 
   /**

--- a/static/js/lightbox.js
+++ b/static/js/lightbox.js
@@ -1,0 +1,86 @@
+// Minimal shared image lightbox with prev/next. Call APP.lightbox(srcs, index)
+// with an array of image URLs (or a single URL) to open a full-size view; click
+// the backdrop / ✕ or press Esc to close, ‹ › or arrow keys to navigate.
+// Vanilla JS, no dependency — the overlay is created lazily on first use.
+window.APP = window.APP || {};
+
+APP.lightbox = (function () {
+  let overlay = null;
+  let imgEl = null;
+  let prevBtn = null;
+  let nextBtn = null;
+  let counter = null;
+  let items = [];
+  let idx = 0;
+
+  function render() {
+    imgEl.src = items[idx] || "";
+    const multi = items.length > 1;
+    prevBtn.style.display = multi ? "" : "none";
+    nextBtn.style.display = multi ? "" : "none";
+    counter.style.display = multi ? "" : "none";
+    counter.textContent = multi ? `${idx + 1} / ${items.length}` : "";
+  }
+
+  function step(delta) {
+    if (items.length < 2) return;
+    idx = (idx + delta + items.length) % items.length;
+    render();
+  }
+
+  function close() {
+    if (!overlay) return;
+    overlay.classList.remove("is-open");
+    imgEl.src = "";
+    items = [];
+  }
+
+  function ensure() {
+    if (overlay) return;
+    overlay = document.createElement("div");
+    overlay.className = "lightbox-overlay";
+    overlay.setAttribute("role", "dialog");
+    overlay.setAttribute("aria-modal", "true");
+    overlay.innerHTML =
+      '<button type="button" class="lightbox-close" aria-label="Close">&times;</button>'
+      + '<button type="button" class="lightbox-nav lightbox-prev" aria-label="Previous">&#8249;</button>'
+      + '<img class="lightbox-img" alt="" />'
+      + '<button type="button" class="lightbox-nav lightbox-next" aria-label="Next">&#8250;</button>'
+      + '<div class="lightbox-counter"></div>';
+    imgEl = overlay.querySelector(".lightbox-img");
+    prevBtn = overlay.querySelector(".lightbox-prev");
+    nextBtn = overlay.querySelector(".lightbox-next");
+    counter = overlay.querySelector(".lightbox-counter");
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay || e.target.classList.contains("lightbox-close")) {
+        close();
+      }
+    });
+    prevBtn.addEventListener("click", (e) => { e.stopPropagation(); step(-1); });
+    nextBtn.addEventListener("click", (e) => { e.stopPropagation(); step(1); });
+    document.addEventListener("keydown", (e) => {
+      if (!overlay.classList.contains("is-open")) return;
+      if (e.key === "Escape") close();
+      else if (e.key === "ArrowLeft") step(-1);
+      else if (e.key === "ArrowRight") step(1);
+    });
+    document.body.appendChild(overlay);
+  }
+
+  function open(srcs, index) {
+    const list = Array.isArray(srcs) ? srcs.slice() : [srcs];
+    if (!list.length || !list[0]) return;
+    ensure();
+    // Drop any text/image selection so the enlarged image isn't shown
+    // highlighted (a stray range from rapid thumbnail clicks).
+    const sel = window.getSelection && window.getSelection();
+    if (sel && sel.removeAllRanges) sel.removeAllRanges();
+    items = list;
+    idx = Math.min(Math.max(index || 0, 0), items.length - 1);
+    render();
+    overlay.classList.add("is-open");
+  }
+
+  open.close = close;
+  return open;
+})();

--- a/static/js/route-manager.js
+++ b/static/js/route-manager.js
@@ -117,6 +117,12 @@ APP.RouteManager = class {
     });
     source.on("change", () => {
       if (source.getState() === "ready") {
+        // Tag each feature with its route context so the stop info panel can
+        // look up photos for the clicked stop (year + route file + coords).
+        source.getFeatures().forEach((f) => {
+          f.set("routeYear", m.year, true);
+          f.set("routeFile", m.file, true);
+        });
         if (source.getFeatures().length > 0 && layer.getVisible()) {
           this.maybeZoomTo(layer);
         }
@@ -236,8 +242,11 @@ APP.RouteManager = class {
           (cat.years || []).indexOf(APP.USER_ROUTE_YEAR) >= 0;
         const palette = APP.ROUTE_COLORS;
         let i = 0;
-        const header = (text) =>
-          out.append($('<div class="route-group"></div>').text(text));
+        const header = (text) => {
+          const el = $('<div class="route-group"></div>').text(text);
+          out.append(el);
+          return el;
+        };
         const addRow = (year, file, kind, isUser, names) => {
           const id = this._id(year, file);
           const color = palette[i++ % palette.length];
@@ -256,16 +265,39 @@ APP.RouteManager = class {
             d.user.forEach((f) => addRow(year, f, "kml", true, d.names || {}));
           }
         });
-        // Then shipped routes + geojson paths, per year.
+        // Then shipped routes + geojson paths, per year. Each shipped (official)
+        // year shows its source credit right under its first group header, so
+        // it's not implied for user routes and isn't buried below the list.
         (cat.years || []).forEach((year) => {
           const d = cat[year] || {};
           const names = d.names || {};
+          const official = year !== APP.USER_ROUTE_YEAR;
+          // Add an ⓘ toggle to each official group header; clicking it shows/hides
+          // a source-credit callout under that header.
+          const maybeCredit = (headerEl, what) => {
+            if (!official) return;
+            const note = $('<div class="route-credit" style="display:none"></div>').text(
+              `${year} ${what}: data from Land Transport Department docs `
+              + "provided for the EOI for the Provision of Public Bus Services."
+            );
+            const icon = $(
+              '<button type="button" class="route-credit-info" aria-expanded="false"'
+              + ' title="Data source"></button>'
+            ).text("ⓘ");
+            icon.on("click", () => {
+              const show = !note.is(":visible");
+              note.toggle(show);
+              icon.attr("aria-expanded", String(show)).toggleClass("is-open", show);
+            });
+            headerEl.append(icon);
+            headerEl.after(note);
+          };
           if (d.routes && d.routes.length) {
-            header(`${year} · Routes (kml)`);
+            maybeCredit(header(`${year} · Routes & Stops`), "routes & stops");
             d.routes.forEach((f) => addRow(year, f, "kml", false, names));
           }
           if (d.geojson && d.geojson.length) {
-            header(`${year} · GeoJSON paths`);
+            maybeCredit(header(`${year} · GeoJSON paths`), "paths");
             d.geojson.forEach((f) => addRow(year, f, "geojson", false, names));
           }
         });

--- a/templates/gtfs.html
+++ b/templates/gtfs.html
@@ -219,6 +219,7 @@
           <a class="btn btn-danger dismiss">X</a>
           <h3 class="name"></h3>
           <h5 class="location"></h5>
+          <div class="info-photos" style="display: none"></div>
         </div>
         <div id="editorToolbar" style="display: none">
           <span class="ed-title">✎ <span id="edRouteName"></span></span>
@@ -442,9 +443,33 @@
       </div>
     </div>
 
+    <!-- Per-stop photos -->
+    <div class="modal fade" id="stopPhotoModal" tabindex="-1" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal">&times;</button>
+            <h4 class="modal-title">📷 Stop photos — <span id="stopPhotoName"></span></h4>
+          </div>
+          <div class="modal-body">
+            <div id="stopPhotoGrid" class="gep-photo-grid"></div>
+            <div class="gep-photo-upload">
+              <input type="file" id="stopPhotoFile"
+                accept="image/jpeg,image/png,image/webp" />
+              <button type="button" class="btn btn-primary btn-sm" id="stopPhotoUpload">Upload</button>
+              <span id="stopPhotoStatus" class="gep-status"></span>
+            </div>
+            <p class="gep-hint">JPEG, PNG or WEBP, up to 5 MB. Photos are stored
+              with the route data and shown to editors.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/config.js') }}"></script>
     <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/lightbox.js') }}"></script>
     <script src="{{ url_for('static', filename='js/info-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/editor-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/stop-image-manager.js') }}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -99,6 +99,7 @@
             <a class="btn btn-danger dismiss">X</a>
             <h3 class="name"></h3>
             <h5 class="location"></h5>
+            <div class="info-photos" style="display: none"></div>
           </div>
           <div id="editorToolbar" style="display: none">
             <span class="ed-title">✎ <span id="edRouteName"></span></span>
@@ -149,10 +150,6 @@
         <div class="list-group" id="routes"></div>
       </div>
       <div id="loading">Loading... <a class="btn btn-danger">X</a></div>
-      <footer>
-        Data via Land Transport Department docs provided for EOI for the
-        Provision of Public Bus Services
-      </footer>
     </div>
 
     <!-- Per-route ride engine chooser -->
@@ -201,6 +198,7 @@
     <script src="{{ url_for('static', filename='js/offcanvas.js') }}"></script>
     <script src="{{ url_for('static', filename='js/config.js') }}"></script>
     <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/lightbox.js') }}"></script>
     <script src="{{ url_for('static', filename='js/route-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/info-manager.js') }}"></script>
     <!-- Editor controls are revealed only for a logged-in editor; the server


### PR DESCRIPTION
## What

Adds field photos for bus stops, plus map/workbench display and some sidebar polish.

**Stop photos**
- Editors upload photos per stop from the workbench (📷 on each Stops-list row; count badge + panel to upload/delete/reorder).
- Stored **in the DB** (`stop_photos`, BYTEA/BLOB) — the Replit filesystem is ephemeral — keyed to the stop's rounded `lon,lat` (stable across reorder/rename).
- Endpoints: `POST /data/stop-photo`, `GET /data/stop-photos`, `GET /data/stop-photo-counts`, `GET /data/stop-photo/<id>`, `DELETE /data/stop-photo/<id>`, `POST /data/stop-photo-order`. Upload/delete/reorder are editor-gated + rate-limited and magic-byte validated (JPEG/PNG/WEBP, ≤5 MB, 6 MB request cap); **list + serve are public** so the public map can display them.

**Display**
- Clicking a stop on the map (`/map`) or in the workbench shows its photos in the info popup.
- Thumbnails open a shared **lightbox with prev/next** (‹ ›, arrow keys, "n / m" counter) instead of new tabs; selection-highlight bug fixed.

**Sidebar / credits**
- Moved the "Land Transport Department EOI" credit out of the global footer (which implied it applied to user routes) into a per-shipped-year **ⓘ toggle** on the sidebar group headers; renamed "2016 · Routes (kml)" → "2016 · Routes & Stops".
- The routes sidebar shortens while a stop banner is open so it isn't covered.

## Files
- `db.py` — `stop_photos` table (+ `sort_order`) and accessors; migrations.
- `app.py` — image validation + the photo endpoints; `MAX_CONTENT_LENGTH`.
- `templates/` — `gtfs.html` (panel + `#info` photos), `index.html` (`#info` photos, footer removed).
- `static/js/` — `lightbox.js` (new), `info-manager.js`, `route-manager.js`, `gtfs-page.js`, `gtfs-editor-manager.js`.
- `static/css/styles.css` — photo UI, lightbox, sidebar/credit styling.

## Verified
Upload/list/serve/delete/reorder (incl. append-after-reorder), public read + key matching to a real stop, auth (401) and validation (400/413) negatives, lightbox prev/next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)